### PR TITLE
New feature: version command shows if newer version are available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go dev
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v0.2.1

--- a/jfrog-cli/docs/common/help.go
+++ b/jfrog-cli/docs/common/help.go
@@ -16,4 +16,8 @@ const GlobalEnvVars string = `	JFROG_CLI_LOG_LEVEL
 	JFROG_CLI_HOME_DIR
 		[Default: ~/.jfrog]
 		Defines the JFrog CLI home directory path.
+	
+	JFROG_CLI_SHOW_UPDATE
+		[Default: true]
+		If true, JFrog CLI shows whether you're running the latest version.
 		`

--- a/jfrog-cli/docs/common/help.go
+++ b/jfrog-cli/docs/common/help.go
@@ -17,7 +17,7 @@ const GlobalEnvVars string = `	JFROG_CLI_LOG_LEVEL
 		[Default: ~/.jfrog]
 		Defines the JFrog CLI home directory path.
 	
-	JFROG_CLI_SHOW_UPDATE
+	JFROG_CLI_SHOW_VERSION_UPDATE
 		[Default: true]
 		If true, JFrog CLI shows whether you're running the latest version.
 		`

--- a/jfrog-cli/utils/cliutils/utils.go
+++ b/jfrog-cli/utils/cliutils/utils.go
@@ -118,7 +118,7 @@ func confirmAnswer(answer string) bool {
 }
 
 func GetVersion() string {
-	if ok, _ := utils.GetBoolEnvValue("JFROG_CLI_SHOW_UPDATE", true); ok {
+	if ok, _ := utils.GetBoolEnvValue("JFROG_CLI_SHOW_VERSION_UPDATE", true); ok {
 		latestRelease, err := getLatestRelease()
 		if err != nil {
 			return CliVersion


### PR DESCRIPTION
JFrog CLI is awesome, but it doesn't show if there are any new versions available. This PR introduces that behavior:

```bash
$ jfrog-cli
NAME:
   jfrog - See https://github.com/jfrog/jfrog-cli-go for usage instructions.

USAGE:
   main [global options] command [command options] [arguments...]

VERSION:
   1.23.1 (you're running the latest version)

... snip ...
```

When you're running the latest version:

```bash
$ jfrog-cli --version
jfrog version 1.23.1 (you're running the latest version)
```

When there is a newer version available

```bash
$ jfrog-cli --version
jfrog version 1.0.0 (there is a newer version available [v1.23.1])
```

As not everyone is interested in these messages there is also a new environment variable `JFROG_CLI_SHOW_UPDATE`

```
JFROG_CLI_SHOW_UPDATE
[Default: true]
If true, JFrog CLI shows whether you're running the latest version.
```

If this variable is set to `false`, the behavior of the CLI is exactly as it is currently. If this variable is not set, or set to `true`, it will display the new message as above