### PR TITLE
Fix spelling mistake in npm/install.go log

### DIFF
--- a/artifactory/commands/npm/install.go
+++ b/artifactory/commands/npm/install.go
@@ -291,7 +291,7 @@ func (nca *NpmCommandArgs) setDependenciesList() (err error) {
 }
 
 func (nca *NpmCommandArgs) collectDependenciesChecksums() error {
-	log.Info("Collecting dependencies information... This may take a few minuets...")
+	log.Info("Collecting dependencies information... This may take a few minutes...")
 	servicesManager, err := utils.CreateServiceManager(nca.rtDetails, false)
 	if err != nil {
 		return err


### PR DESCRIPTION
Noticed while setting up / debugging some Jenkins automation. Must have been overlooked in PR review previously.
- - -
_(OT: from debugging, the jfrog CLI makes too many individual calls when dealing w/ NPM artifacts, resulting in my jenkins server getting banned off the network w/ default IT firewalls ... seems like a really silly overhead to have ... this seems to be by design, so I'm not sure if it's worth opening it's own bug or not)_