### PR TITLE
Adding Diagnosis command to cli

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -51,6 +51,7 @@ import (
 	nugetdocs "github.com/jfrog/jfrog-cli-go/docs/artifactory/nuget"
 	nugettree "github.com/jfrog/jfrog-cli-go/docs/artifactory/nugetdepstree"
 	"github.com/jfrog/jfrog-cli-go/docs/artifactory/ping"
+	"github.com/jfrog/jfrog-cli-go/docs/artifactory/diagnosis"
 	"github.com/jfrog/jfrog-cli-go/docs/artifactory/search"
 	"github.com/jfrog/jfrog-cli-go/docs/artifactory/setprops"
 	"github.com/jfrog/jfrog-cli-go/docs/artifactory/upload"
@@ -494,6 +495,18 @@ func GetCommands() []cli.Command {
 			ArgsUsage: common.CreateEnvVars(),
 			Action: func(c *cli.Context) {
 				pingCmd(c)
+			},
+		},
+		{
+			Name:		"diagnosis",
+			Flags:		getServerFlags(),
+			Aliases:	[]string{"diag"},
+			Usage:		diagnosis.Description,
+			HelpName:	common.CreateUsage("rt diagnosis",diagnosis.Description,diagnosis.Usage),
+			UsageText:	diagnosis.Arguments,
+			ArgsUsage:	common.CreateEnvVars(),
+			Action:		func(c *cli.Context) {
+				diagCmd(c)
 			},
 		},
 		{
@@ -1622,6 +1635,18 @@ func pingCmd(c *cli.Context) {
 	log.Output(resString)
 }
 
+func diagCmd(c *cli.Context) {
+	artDetails := createArtifactoryDetailsByFlags(c, true)
+	diagCmd := generic.NewDiagCommand()
+	diagCmd.SetRtDetails(artDetails)
+	diagCmd.SetThread(getThreadsCount(c))
+	err := commands.Exec(diagCmd)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+}
+
 func downloadCmd(c *cli.Context) {
 	if c.NArg() > 0 && c.IsSet("spec") {
 		cliutils.PrintHelpAndExitWithError("No arguments should be sent when the spec option is used.", c)
@@ -2085,7 +2110,7 @@ func getDeleteSpec(c *cli.Context) (deleteSpec *spec.SpecFiles) {
 	err = spec.ValidateSpec(deleteSpec.Files, false, true)
 	cliutils.ExitOnErr(err)
 	return
-}
+}                                                                                                     
 
 func createDefaultSearchSpec(c *cli.Context) *spec.SpecFiles {
 	return spec.NewBuilder().

--- a/artifactory/commands/generic/diagnosis.go
+++ b/artifactory/commands/generic/diagnosis.go
@@ -1,0 +1,196 @@
+package generic
+
+import (
+	"github.com/jfrog/jfrog-client-go/artifactory/services"
+	"regexp"
+	"io/ioutil"
+	"path/filepath"
+	"github.com/jfrog/jfrog-cli-go/utils/config"
+	//"errors"
+	"github.com/jfrog/jfrog-cli-go/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-go/utils/progressbar"
+	ioUtils "github.com/jfrog/jfrog-client-go/utils/io"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	//"github.com/jfrog/jfrog-client-go/utils/log"
+	"text/tabwriter"
+	"os"
+	"time"
+	"strconv"
+	//"bufio"
+	"fmt"
+	"encoding/json"
+)
+
+type DiagCommand struct {
+	GenericCommand
+	logFile       *os.File
+	thread 		 int
+}
+
+func NewDiagCommand() *DiagCommand {
+	return &DiagCommand{GenericCommand: *NewGenericCommand()}
+}
+
+func (dc *DiagCommand) LogFile() *os.File {
+	return dc.logFile
+}
+
+func (dc *DiagCommand) SetThread(thr int) {
+	dc.thread = thr
+}
+
+func (dc *DiagCommand) GetThread() int {
+	return dc.thread
+}
+
+func (dc *DiagCommand) RtDetails() (*config.ArtifactoryDetails, error) {
+	return dc.rtDetails, nil
+}
+
+func (dc *DiagCommand) SetRtDetails(rtDetails *config.ArtifactoryDetails) *DiagCommand {
+	dc.rtDetails = rtDetails
+	return dc
+}
+
+func (dc *DiagCommand) CommandName() string {
+	return "rt_diagnosis"
+}
+
+func (dc *DiagCommand) ExecSystemInfo() (interface{}, error) {
+	return "",nil
+}
+
+func (dc *DiagCommand) Run() error {
+	var err error
+	var progressBar ioUtils.Progress
+	progressBar, dc.logFile, err = progressbar.InitProgressBarIfPossible()
+	if err != nil {
+		return err
+	}
+	if progressBar != nil {
+		defer progressBar.Quit()
+	}
+	servicesManager, err := utils.CreateDiagnosisServiceManager(dc.rtDetails, dc.thread, false, progressBar)  //utils.CreateServiceManager(dc.rtDetails, false)
+	if err != nil {
+		return err
+	}
+	oldResult,err := dc.readOldResults()
+	if err != nil {
+		fmt.Println(err)
+		//return err
+	}
+	result,err := servicesManager.Diagnostics()
+	if err != nil {
+		return err
+	}
+	dc.compareResultsAndDisplay(oldResult,result)
+
+	err = dc.saveCurrentResults(result)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	return nil
+}
+
+func (dc *DiagCommand) readOldResults() (*services.DiagnosisResult,error){
+	logDir,err := config.CreateDirInJfrogHome("logs")
+	if err != nil {
+		return nil,err
+	}
+	jsonFiles,err := ioutil.ReadDir(logDir)
+	if err != nil {
+		return nil,err
+	}
+	var modTime time.Time
+	var jsonFileName string
+
+	for _,fi := range jsonFiles {
+		//if found,err := filepath.Match("perf*json",fi.Name()); err != nil && found  {
+		if ok,_ := regexp.MatchString("perf.*.json",fi.Name()); ok {
+			if fi.Mode().IsRegular() {
+				if !fi.ModTime().Before(modTime) {
+					if fi.ModTime().After(modTime) {
+						modTime = fi.ModTime()
+						jsonFileName = fi.Name()
+					}
+				}
+			}
+		}
+	}
+	jsonFile, err := os.Open(logDir+"/"+jsonFileName)
+	if err != nil {
+		return nil,nil
+	}
+	//defer jsonFile.Close()
+	bytevalue,err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		
+		return nil,err
+	}
+	var data *services.DiagnosisResult
+	json.Unmarshal(bytevalue,&data)
+	return data,nil
+
+}
+
+func (dc *DiagCommand) saveCurrentResults(tasks *services.DiagnosisResult) error {
+	logDir,err := config.CreateDirInJfrogHome("logs")
+	if err != nil {
+		return err
+	}
+	currentTime := time.Now().Format("2006-01-02.15-04-05")
+	pid := os.Getpid()
+	fileName := filepath.Join(logDir, "perf."+currentTime+"."+strconv.Itoa(pid)+".json")
+	jsonFile, err := os.OpenFile(fileName, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	defer jsonFile.Close() 
+	jsonData,err := json.Marshal(tasks)
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	jsonFile.Write(jsonData)
+	return nil
+}
+
+func (dc *DiagCommand) compareResultsAndDisplay(oldResult, newResult *services.DiagnosisResult) {
+	w := new(tabwriter.Writer)
+	w.Init(os.Stdout, 0, 8, 2, '\t', tabwriter.Debug|tabwriter.AlignRight)
+	fmt.Fprintf(w, "Task\tLast Run\tThis Run\tStatus\t\n")
+	oldVersion := "x"
+	oldUrl := "x"
+	if oldResult != nil {
+		oldVersion = oldResult.Version
+		oldUrl = oldResult.Url
+	}
+	newVersion := "x"
+	newUrl := "x"
+	if newResult != nil {
+		newVersion = newResult.Version
+		newUrl = newResult.Url
+	}
+	fmt.Fprintf(w, "Version\t%s\t%s\t✓\t\n",oldVersion,newVersion)
+	fmt.Fprintf(w, "URL\t%s\t%s\t✓\t\n",oldUrl,newUrl)
+	i := 0
+	if newResult != nil {
+		for taskName, taskResult := range newResult.Tasks {
+			status := "✓"
+			if taskResult.Err != nil {
+				status = "x"
+			}
+			if oldResult != nil {
+				if oldTaskResult,ok := oldResult.Tasks[taskName]; ok {
+					fmt.Fprintf(w, "%s\t%v\t%v\t%s\t\n",taskName,oldTaskResult.ElapsedTime,taskResult.ElapsedTime,status)
+				}
+			} else {
+				fmt.Fprintf(w, "%s\tx\t%v\t%s\t\n",taskName,taskResult.ElapsedTime,status)
+			}
+			i++
+		}
+	}
+	fmt.Fprintln(w)
+	w.Flush()
+	fmt.Println("Total: ",i)
+}

--- a/artifactory/utils/diagnosis.go
+++ b/artifactory/utils/diagnosis.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"github.com/jfrog/jfrog-cli-go/utils/config"
+	"github.com/jfrog/jfrog-client-go/artifactory"
+	"github.com/jfrog/jfrog-client-go/utils/io"
+)
+
+func CreateDiagnosisServiceManager(artDetails *config.ArtifactoryDetails, threadCount int, dryRun bool, progressBar io.Progress) (*artifactory.ArtifactoryServicesManager, error) {
+	certPath, err := GetJfrogSecurityDir()
+	if err != nil {
+		return nil, err
+	}
+	artAuth, err := artDetails.CreateArtAuthConfig()
+	if err != nil {
+		return nil, err
+	}
+	servicesConfig, err := artifactory.NewConfigBuilder().
+		SetArtDetails(artAuth).
+		SetDryRun(dryRun).
+		SetCertificatesPath(certPath).
+		SetInsecureTls(artDetails.InsecureTls).
+		SetThreads(threadCount).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+	return artifactory.NewWithProgress(&artAuth, servicesConfig, progressBar)
+}
+

--- a/docs/artifactory/diagnosis/help.go
+++ b/docs/artifactory/diagnosis/help.go
@@ -1,0 +1,7 @@
+package diagnosis
+
+const Description = "Pre and Post updgrade diagnosis of artifactory"
+
+var Usage = []string{`jfrog rt diagnosis [command options]`}
+
+const Arguments string = ""

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,6 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v0.4.0
+replace github.com/jfrog/jfrog-client-go => /Users/bhanud/work/jfrog-client-go
 
 replace github.com/jfrog/gocmd => github.com/jfrog/gocmd v0.1.9

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWs
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/codegangsta/cli v1.20.0 h1:iX1FXEgwzd5+XN6wk5cVHOGQj6Q3Dcp20lUeS4lHNTw=
 github.com/codegangsta/cli v1.20.0/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=
+github.com/dashbhanu/jfrog-client-go v0.4.0 h1:pwzs6c3+YPuvTUVMveZTbmx4OmfIi7J3XbIuqK6C+Ks=
+github.com/dashbhanu/jfrog-client-go v0.4.0/go.mod h1:z0TT7uU1IcpkiEgySOE7UD/0f/Vzg85wEOixa5IQTas=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dsnet/compress v0.0.0-20171208185109-cc9eb1d7ad76 h1:eX+pdPPlD279OWgdx7f6KqIRSONuK7egk+jDx7OM3Ac=
@@ -46,6 +48,7 @@ github.com/jfrog/gocmd v0.1.10-0.20190611063106-dee9f4672ff7 h1:nczBi5k1p99DxFa8
 github.com/jfrog/gocmd v0.1.10-0.20190611063106-dee9f4672ff7/go.mod h1:sshFvZq1d45d4BP8VQV1D4yGatFRqY0hO0bmHI2cN+w=
 github.com/jfrog/gofrog v1.0.4 h1:jtMkCBEsGOC/URxeHXGLZNFjOAMfvDn0UhN+0uXo1GA=
 github.com/jfrog/gofrog v1.0.4/go.mod h1:4Caxvc8B2K1A798G1Ne+SsUICRPPre4GpgcFqj+EXJ8=
+github.com/jfrog/jfrog-cli-go v1.22.0 h1:rD88IgDybo9sBDpNE4fjLHz3Ql1vSA559pcCOIlrxK0=
 github.com/jfrog/jfrog-client-go v0.3.2 h1:vtRy7IbRtbMPObpDLTYMb0c91iNEAsZgPod2DMUrbrA=
 github.com/jfrog/jfrog-client-go v0.3.2/go.mod h1:z0TT7uU1IcpkiEgySOE7UD/0f/Vzg85wEOixa5IQTas=
 github.com/jfrog/jfrog-client-go v0.3.3 h1:rh3pLmgbW4cnkVVksuknpK67KD7+HViLgFFA8iBmrlE=


### PR DESCRIPTION
A new features in CLI to get a diagnosis of Artifactory after each upgrade. This command should run before and after upgrade, so that it will print the performance and stability of artifactory instance. The default command is like
jfrog  rt diagnosis 