### PR TITLE
Removed an invalid regexp escape "\a"

### DIFF
--- a/testsdata/specs/win_simple_download_spec.json
+++ b/testsdata/specs/win_simple_download_spec.json
@@ -4,7 +4,7 @@
       "pattern": "${REPO1}/*",
       "target": "out\\win\\",
       "flat": "true",
-      "excludePatterns": ["*\\a1.in", "*a3.in"]
+      "excludePatterns": ["*a1.in", "*a3.in"]
     }
   ]
 }


### PR DESCRIPTION
The bell character (\a) causes this test to fail when run against Windows artifactory servers.