### PR TITLE
Support npm-publish

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
 FROM golang:1.12-alpine as builder
+
+# Add NodeJS/NPM to support npm-publish
+#   jfrog rt npm-publish my-local-npm-repo --build-name=my-build-name --build-number=1
+# https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory#CLIforJFrogArtifactory-BuildingNpmPackages
+# https://github.com/jfrog/jfrog-cli/issues/348
+RUN apk add --update nodejs && \
+    rm -rf /var/cache/apk/* && \
+    npm i npm -g
+
 WORKDIR /jfrog-cli-go
 COPY . /jfrog-cli-go
 RUN apk add --update git && sh build.sh


### PR DESCRIPTION
**npm-publisj** requires node and npm client.

It's not present so we get the error:

```bash
docker run -it --rm \
        -v ${PWD}:/directory -w /directory \
        --env JFROG_CLI_OFFER_CONFIG=false \
        662182053957.dkr.ecr.eu-west-1.amazonaws.com/docker-vendored-images/jfrog-cli-go:1.25.0-b1 \
        rt npm-publish @nvm \
                --url https://vonagecc.jfrog.io/vonagecc/npm-local \
                --user $ARTIFACTORY_USER \
                --password $ARTIFACTORY_SECRET \
                --build-number 0 \
                --build-name "ci-sample"
[Info] Running npm Publish
[Error] exec: "npm": executable file not found in $PATH
```
Related with #348