### PR TITLE
Add support for client certificates

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -611,6 +611,14 @@ func getBaseFlags() []cli.Flag {
 			Name:  "access-token",
 			Usage: "[Optional] Artifactory access token.` `",
 		},
+		cli.StringFlag{
+			Name:  "client-certificate-path",
+			Usage: "[Optional] CLient certificate.` `",
+		},
+		cli.StringFlag{
+			Name:  "client-certificate-key-path",
+			Usage: "[Optional] Client certificate key.` `",
+		},
 		cli.BoolFlag{
 			Name:  "insecure-tls",
 			Usage: "[Default: false] Set to true to skip TLS certificates verification.` `",
@@ -2394,6 +2402,8 @@ func createArtifactoryDetails(c *cli.Context, includeConfig bool) (details *conf
 	details.SshKeyPath = c.String("ssh-key-path")
 	details.SshPassphrase = c.String("ssh-passphrase")
 	details.AccessToken = c.String("access-token")
+	details.ClientCertificatePath = c.String("client-certificate-path")
+	details.ClientCertificateKeyPath = c.String("client-certificate-key-path")
 	details.ServerId = c.String("server-id")
 	details.InsecureTls = c.Bool("insecure-tls")
 
@@ -2428,6 +2438,12 @@ func createArtifactoryDetails(c *cli.Context, includeConfig bool) (details *conf
 			}
 			if details.AccessToken == "" {
 				details.AccessToken = confDetails.AccessToken
+			}
+			if details.ClientCertificatePath == "" {
+				details.ClientCertificatePath = confDetails.ClientCertificatePath
+			}
+			if details.ClientCertificateKeyPath == "" {
+				details.ClientCertificateKeyPath = confDetails.ClientCertificateKeyPath
 			}
 		}
 	}

--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -522,7 +522,7 @@ func GetCommands() []cli.Command {
 		},
 		{
 			Name:         "ping",
-			Flags:        getServerWithClientCertificatesFlags(),
+			Flags:        getServerWithClientCertsFlags(),
 			Aliases:      []string{"p"},
 			Usage:        ping.Description,
 			HelpName:     common.CreateUsage("rt ping", ping.Description, ping.Usage),
@@ -618,7 +618,7 @@ func getBaseFlags() []cli.Flag {
 		})
 }
 
-func getClientCertificatesFlags() []cli.Flag {
+func getClientCertsFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
 			Name:  "client-cert-path",
@@ -644,8 +644,8 @@ func getServerFlags() []cli.Flag {
 	return append(getCommonFlags(), getServerIdFlag())
 }
 
-func getServerWithClientCertificatesFlags() []cli.Flag {
-	return append(getServerFlags(), getClientCertificatesFlags()...)
+func getServerWithClientCertsFlags() []cli.Flag {
+	return append(getServerFlags(), getClientCertsFlags()...)
 }
 
 func getSortLimitFlags() []cli.Flag {
@@ -670,7 +670,7 @@ func getSortLimitFlags() []cli.Flag {
 }
 
 func getUploadFlags() []cli.Flag {
-	uploadFlags := append(getServerWithClientCertificatesFlags(), getSpecFlags()...)
+	uploadFlags := append(getServerWithClientCertsFlags(), getSpecFlags()...)
 	uploadFlags = append(uploadFlags, getBuildToolAndModuleFlags()...)
 	return append(uploadFlags, []cli.Flag{
 		cli.StringFlag{
@@ -716,7 +716,7 @@ func getUploadFlags() []cli.Flag {
 }
 
 func getDownloadFlags() []cli.Flag {
-	downloadFlags := append(getServerWithClientCertificatesFlags(), getSortLimitFlags()...)
+	downloadFlags := append(getServerWithClientCertsFlags(), getSortLimitFlags()...)
 	downloadFlags = append(downloadFlags, getSpecFlags()...)
 	downloadFlags = append(downloadFlags, getBuildToolAndModuleFlags()...)
 	return append(downloadFlags, []cli.Flag{
@@ -939,7 +939,7 @@ func getGoPublishFlags() []cli.Flag {
 }
 
 func getMoveFlags() []cli.Flag {
-	moveFlags := append(getServerWithClientCertificatesFlags(), getSortLimitFlags()...)
+	moveFlags := append(getServerWithClientCertsFlags(), getSortLimitFlags()...)
 	moveFlags = append(moveFlags, getSpecFlags()...)
 	return append(moveFlags, []cli.Flag{
 		cli.BoolTFlag{
@@ -968,7 +968,7 @@ func getMoveFlags() []cli.Flag {
 }
 
 func getCopyFlags() []cli.Flag {
-	copyFlags := append(getServerWithClientCertificatesFlags(), getSortLimitFlags()...)
+	copyFlags := append(getServerWithClientCertsFlags(), getSortLimitFlags()...)
 	copyFlags = append(copyFlags, getSpecFlags()...)
 	return append(copyFlags, []cli.Flag{
 		cli.BoolTFlag{
@@ -996,7 +996,7 @@ func getCopyFlags() []cli.Flag {
 }
 
 func getDeleteFlags() []cli.Flag {
-	deleteFlags := append(getServerWithClientCertificatesFlags(), getSortLimitFlags()...)
+	deleteFlags := append(getServerWithClientCertsFlags(), getSortLimitFlags()...)
 	deleteFlags = append(deleteFlags, getSpecFlags()...)
 	return append(deleteFlags, []cli.Flag{
 		cli.BoolTFlag{
@@ -1021,7 +1021,7 @@ func getDeleteFlags() []cli.Flag {
 }
 
 func getSearchFlags() []cli.Flag {
-	searchFlags := append(getServerWithClientCertificatesFlags(), getSortLimitFlags()...)
+	searchFlags := append(getServerWithClientCertsFlags(), getSortLimitFlags()...)
 	searchFlags = append(searchFlags, getSpecFlags()...)
 	return append(searchFlags, []cli.Flag{
 		cli.BoolTFlag{
@@ -1090,7 +1090,7 @@ func getDeletePropertiesFlags() []cli.Flag {
 }
 
 func getPropertiesFlags() []cli.Flag {
-	propsFlags := append(getServerWithClientCertificatesFlags(), getSortLimitFlags()...)
+	propsFlags := append(getServerWithClientCertsFlags(), getSortLimitFlags()...)
 	return append(propsFlags, []cli.Flag{
 		cli.BoolTFlag{
 			Name:  "recursive",
@@ -2412,8 +2412,8 @@ func createArtifactoryDetails(c *cli.Context, includeConfig bool) (details *conf
 	details.SshKeyPath = c.String("ssh-key-path")
 	details.SshPassphrase = c.String("ssh-passphrase")
 	details.AccessToken = c.String("access-token")
-	details.ClientCertificatePath = c.String("client-cert-path")
-	details.ClientCertificateKeyPath = c.String("client-cert-key-path")
+	details.ClientCertPath = c.String("client-cert-path")
+	details.ClientCertKeyPath = c.String("client-cert-key-path")
 	details.ServerId = c.String("server-id")
 	details.InsecureTls = c.Bool("insecure-tls")
 
@@ -2449,11 +2449,11 @@ func createArtifactoryDetails(c *cli.Context, includeConfig bool) (details *conf
 			if details.AccessToken == "" {
 				details.AccessToken = confDetails.AccessToken
 			}
-			if details.ClientCertificatePath == "" {
-				details.ClientCertificatePath = confDetails.ClientCertificatePath
+			if details.ClientCertPath == "" {
+				details.ClientCertPath = confDetails.ClientCertPath
 			}
-			if details.ClientCertificateKeyPath == "" {
-				details.ClientCertificateKeyPath = confDetails.ClientCertificateKeyPath
+			if details.ClientCertKeyPath == "" {
+				details.ClientCertKeyPath = confDetails.ClientCertKeyPath
 			}
 		}
 	}

--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -621,11 +621,11 @@ func getBaseFlags() []cli.Flag {
 func getClientCertificatesFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name:  "client-certificate-path",
+			Name:  "client-cert-path",
 			Usage: "[Optional] Client certificate file in PEM format.` `",
 		},
 		cli.StringFlag{
-			Name:  "client-certificate-key-path",
+			Name:  "client-cert-key-path",
 			Usage: "[Optional] Private key file for the client certificate in PEM format.` `",
 		},
 	}
@@ -2412,8 +2412,8 @@ func createArtifactoryDetails(c *cli.Context, includeConfig bool) (details *conf
 	details.SshKeyPath = c.String("ssh-key-path")
 	details.SshPassphrase = c.String("ssh-passphrase")
 	details.AccessToken = c.String("access-token")
-	details.ClientCertificatePath = c.String("client-certificate-path")
-	details.ClientCertificateKeyPath = c.String("client-certificate-key-path")
+	details.ClientCertificatePath = c.String("client-cert-path")
+	details.ClientCertificateKeyPath = c.String("client-cert-key-path")
 	details.ServerId = c.String("server-id")
 	details.InsecureTls = c.Bool("insecure-tls")
 

--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -613,11 +613,11 @@ func getBaseFlags() []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:  "client-certificate-path",
-			Usage: "[Optional] CLient certificate.` `",
+			Usage: "[Optional] Client certificate file in PEM format.` `",
 		},
 		cli.StringFlag{
 			Name:  "client-certificate-key-path",
-			Usage: "[Optional] Client certificate key.` `",
+			Usage: "[Optional] Private key file for the client certificate in PEM format.` `",
 		},
 		cli.BoolFlag{
 			Name:  "insecure-tls",

--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
 	"github.com/codegangsta/cli"
 	"github.com/jfrog/jfrog-cli-go/artifactory/commands"
 	"github.com/jfrog/jfrog-cli-go/artifactory/commands/buildinfo"
@@ -69,9 +73,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/mattn/go-shellwords"
-	"os"
-	"strconv"
-	"strings"
 )
 
 func GetCommands() []cli.Command {
@@ -533,15 +534,14 @@ func GetCommands() []cli.Command {
 			},
 		},
 		{
-			Name:            "curl",
-			Flags:           getCurlFlags(),
-			Aliases:         []string{"cl"},
-			Usage:           curldocs.Description,
-			HelpName:        common.CreateUsage("rt curl", curldocs.Description, curldocs.Usage),
-			UsageText:       curldocs.Arguments,
-			ArgsUsage:       common.CreateEnvVars(),
-			SkipFlagParsing: true,
-			BashComplete:    common.CreateBashCompletionFunc(),
+			Name:         "curl",
+			Flags:        getCurlFlags(),
+			Aliases:      []string{"cl"},
+			Usage:        curldocs.Description,
+			HelpName:     common.CreateUsage("rt curl", curldocs.Description, curldocs.Usage),
+			UsageText:    curldocs.Arguments,
+			ArgsUsage:    common.CreateEnvVars(),
+			BashComplete: common.CreateBashCompletionFunc(),
 			Action: func(c *cli.Context) error {
 				return curlCmd(c)
 			},
@@ -1304,7 +1304,7 @@ func getBuildAddGitFlags() []cli.Flag {
 }
 
 func getCurlFlags() []cli.Flag {
-	return []cli.Flag{getServerIdFlag()}
+	return getServerFlags()
 }
 
 func getPipInstallFlags() []cli.Flag {
@@ -2297,7 +2297,7 @@ func curlCmd(c *cli.Context) error {
 		return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 	}
 	curlCommand := curl.NewCurlCommand().SetArguments(extractCommand(c))
-	rtDetails, err := curlCommand.GetArtifactoryDetails()
+	rtDetails, err := createArtifactoryDetailsByFlags(c, true)
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/config.go
+++ b/artifactory/commands/config.go
@@ -195,14 +195,14 @@ func (cc *ConfigCommand) getConfigurationFromUser() error {
 		return getSshKeyPath(cc.details)
 	} else {
 		answer := "no"
-		if cc.defaultDetails.ClientCertificatePath != "" {
+		if cc.defaultDetails.ClientCertPath != "" {
 			answer = "yes"
 		}
 		ioutils.ScanFromConsole("Is the Artifactory HTTP proxy configured to accept a client certificate?", &answer, answer)
 
 		if strings.ToLower(answer) == "y" || strings.ToLower(answer) == "yes" {
-			ioutils.ScanFromConsole("Client certificate file path", &cc.details.ClientCertificatePath, cc.defaultDetails.ClientCertificatePath)
-			ioutils.ScanFromConsole("Client certificate key path", &cc.details.ClientCertificateKeyPath, cc.defaultDetails.ClientCertificateKeyPath)
+			ioutils.ScanFromConsole("Client certificate file path", &cc.details.ClientCertPath, cc.defaultDetails.ClientCertPath)
+			ioutils.ScanFromConsole("Client certificate key path", &cc.details.ClientCertKeyPath, cc.defaultDetails.ClientCertKeyPath)
 		}
 	}
 	cc.details.Url = clientutils.AddTrailingSlashIfNeeded(cc.details.Url)
@@ -341,11 +341,11 @@ func printConfigs(configuration []*config.ArtifactoryDetails) {
 		if details.SshKeyPath != "" {
 			log.Output("SSH key file path: " + details.SshKeyPath)
 		}
-		if details.ClientCertificatePath != "" {
-			log.Output("Client certificate file path: " + details.ClientCertificatePath)
+		if details.ClientCertPath != "" {
+			log.Output("Client certificate file path: " + details.ClientCertPath)
 		}
-		if details.ClientCertificateKeyPath != "" {
-			log.Output("Client certificate key path: " + details.ClientCertificateKeyPath)
+		if details.ClientCertKeyPath != "" {
+			log.Output("Client certificate key path: " + details.ClientCertKeyPath)
 		}
 		log.Output("Default: ", details.IsDefault)
 		log.Output()

--- a/artifactory/commands/config.go
+++ b/artifactory/commands/config.go
@@ -3,6 +3,12 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"sync"
+	"syscall"
+
 	"github.com/jfrog/jfrog-cli-go/artifactory/commands/generic"
 	"github.com/jfrog/jfrog-cli-go/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-go/utils/cliutils"
@@ -15,10 +21,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"golang.org/x/crypto/ssh/terminal"
-	"io/ioutil"
-	"reflect"
-	"sync"
-	"syscall"
 )
 
 // Internal golang locking for the same process.
@@ -191,6 +193,17 @@ func (cc *ConfigCommand) getConfigurationFromUser() error {
 	// Ssh-Key
 	if fileutils.IsSshUrl(cc.details.Url) {
 		return getSshKeyPath(cc.details)
+	} else {
+		answer := "no"
+		if cc.defaultDetails.ClientCertificatePath != "" {
+			answer = "yes"
+		}
+		ioutils.ScanFromConsole("Is the Artifactory HTTP proxy configured to accept a client certificate?", &answer, answer)
+
+		if strings.ToLower(answer) == "y" || strings.ToLower(answer) == "yes" {
+			ioutils.ScanFromConsole("Client certificate file path", &cc.details.ClientCertificatePath, cc.defaultDetails.ClientCertificatePath)
+			ioutils.ScanFromConsole("Client certificate key path", &cc.details.ClientCertificateKeyPath, cc.defaultDetails.ClientCertificateKeyPath)
+		}
 	}
 	cc.details.Url = clientutils.AddTrailingSlashIfNeeded(cc.details.Url)
 	// Api-Key/Password/Access-Token
@@ -327,6 +340,12 @@ func printConfigs(configuration []*config.ArtifactoryDetails) {
 		}
 		if details.SshKeyPath != "" {
 			log.Output("SSH key file path: " + details.SshKeyPath)
+		}
+		if details.ClientCertificatePath != "" {
+			log.Output("Client certificate file path: " + details.ClientCertificatePath)
+		}
+		if details.ClientCertificateKeyPath != "" {
+			log.Output("Client certificate key path: " + details.ClientCertificateKeyPath)
 		}
 		log.Output("Default: ", details.IsDefault)
 		log.Output()

--- a/artifactory/commands/curl/curl.go
+++ b/artifactory/commands/curl/curl.go
@@ -53,7 +53,7 @@ func (curlCmd *CurlCommand) Run() error {
 	}
 
 	// If the command already includes certificates flag, return an error.
-	if curlCmd.rtDetails.ClientCertificatePath != "" && curlCmd.isCertificateFlagExists() {
+	if curlCmd.rtDetails.ClientCertPath != "" && curlCmd.isCertificateFlagExists() {
 		return errorutils.CheckError(errors.New("Curl command must not include certificate flag (--cert or --key)."))
 	}
 
@@ -78,10 +78,10 @@ func (curlCmd *CurlCommand) Run() error {
 func (curlCmd *CurlCommand) addCommandCredentials() (string, error) {
 	certificateHelpPrefix := ""
 
-	if curlCmd.rtDetails.ClientCertificatePath != "" {
+	if curlCmd.rtDetails.ClientCertPath != "" {
 		curlCmd.arguments = append(curlCmd.arguments,
-			"--cert", curlCmd.rtDetails.ClientCertificatePath,
-			"--key", curlCmd.rtDetails.ClientCertificateKeyPath)
+			"--cert", curlCmd.rtDetails.ClientCertPath,
+			"--key", curlCmd.rtDetails.ClientCertKeyPath)
 		certificateHelpPrefix = "--cert *** --key *** "
 	}
 

--- a/artifactory/commands/curl/curl.go
+++ b/artifactory/commands/curl/curl.go
@@ -85,13 +85,7 @@ func (curlCmd *CurlCommand) addCommandCredentials() (string, error) {
 		certificateHelpPrefix = "--cert *** --key *** "
 	}
 
-	if curlCmd.rtDetails.ApiKey != "" {
-		// Add access token header.
-		tokenHeader := fmt.Sprintf("X-JFrog-Art-Api: %s", curlCmd.rtDetails.ApiKey)
-		curlCmd.arguments = append(curlCmd.arguments, "-H", tokenHeader)
-
-		return certificateHelpPrefix + "-H \"X-JFrog-Art-Api: ***\"", nil
-	} else if curlCmd.rtDetails.AccessToken != "" {
+	if curlCmd.rtDetails.AccessToken != "" {
 		// Add access token header.
 		tokenHeader := fmt.Sprintf("Authorization: Bearer %s", curlCmd.rtDetails.AccessToken)
 		curlCmd.arguments = append(curlCmd.arguments, "-H", tokenHeader)

--- a/artifactory/utils/utils.go
+++ b/artifactory/utils/utils.go
@@ -59,6 +59,8 @@ func GetEncryptedPasswordFromArtifactory(artifactoryAuth auth.ArtifactoryDetails
 	client, err := httpclient.ClientBuilder().
 		SetCertificatesPath(securityDir).
 		SetInsecureTls(insecureTls).
+		SetClientCertificatePath(artifactoryAuth.GetClientCertificatePath()).
+		SetClientCertificateKeyPath(artifactoryAuth.GetClientCertificateKeyPath()).
 		Build()
 	if err != nil {
 		return "", err

--- a/artifactory/utils/utils.go
+++ b/artifactory/utils/utils.go
@@ -59,8 +59,8 @@ func GetEncryptedPasswordFromArtifactory(artifactoryAuth auth.ArtifactoryDetails
 	client, err := httpclient.ClientBuilder().
 		SetCertificatesPath(securityDir).
 		SetInsecureTls(insecureTls).
-		SetClientCertificatePath(artifactoryAuth.GetClientCertificatePath()).
-		SetClientCertificateKeyPath(artifactoryAuth.GetClientCertificateKeyPath()).
+		SetClientCertPath(artifactoryAuth.GetClientCertPath()).
+		SetClientCertKeyPath(artifactoryAuth.GetClientCertKeyPath()).
 		Build()
 	if err != nil {
 		return "", err

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -777,7 +777,7 @@ func TestArtifactoryClientCert(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDirPath)
 	os.Setenv(cliutils.JfrogHomeDirEnv, tempDirPath)
-	os.Setenv(tests.HttpsProxyEnvVar, "1024")
+	os.Setenv(tests.HttpsProxyEnvVar, "1025")
 	go cliproxy.StartLocalReverseHttpProxy(artifactoryDetails.Url, true)
 
 	// The two certificate files are created by the reverse proxy on startup in the current directory.

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -807,8 +807,8 @@ func TestArtifactoryClientCert(t *testing.T) {
 	}
 
 	// Inject client certificates, we expect the search to succeed
-	artifactoryDetails.ClientCertificatePath = certificate.CERT_FILE
-	artifactoryDetails.ClientCertificateKeyPath = certificate.KEY_FILE
+	artifactoryDetails.ClientCertPath = certificate.CERT_FILE
+	artifactoryDetails.ClientCertKeyPath = certificate.KEY_FILE
 
 	searchCmd = generic.NewSearchCommand()
 	searchCmd.SetRtDetails(artifactoryDetails).SetSpec(fileSpec)
@@ -819,8 +819,8 @@ func TestArtifactoryClientCert(t *testing.T) {
 
 	artifactoryDetails.Url = artAuth.GetUrl()
 	artifactoryDetails.InsecureTls = false
-	artifactoryDetails.ClientCertificatePath = ""
-	artifactoryDetails.ClientCertificateKeyPath = ""
+	artifactoryDetails.ClientCertPath = ""
+	artifactoryDetails.ClientCertKeyPath = ""
 	cleanArtifactoryTest()
 }
 
@@ -974,12 +974,12 @@ func checkForErrDueToMissingProxy(spec *spec.SpecFiles, t *testing.T) {
 	}
 }
 
-func checkIfServerIsUp(port, proxyScheme string, useClientCertificates bool) error {
+func checkIfServerIsUp(port, proxyScheme string, useClientCerts bool) error {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 
-	if useClientCertificates {
+	if useClientCerts {
 		for attempt := 0; attempt < 10; attempt++ {
 			if _, err := os.Stat(certificate.CERT_FILE); os.IsNotExist(err) {
 				log.Info("Waiting for certificate to appear...")

--- a/utils/config/config.go
+++ b/utils/config/config.go
@@ -338,17 +338,19 @@ func (o *ConfigV0) Convert() *ConfigV1 {
 }
 
 type ArtifactoryDetails struct {
-	Url            string            `json:"url,omitempty"`
-	SshUrl         string            `json:"-"`
-	User           string            `json:"user,omitempty"`
-	Password       string            `json:"password,omitempty"`
-	SshKeyPath     string            `json:"sshKeyPath,omitempty"`
-	SshPassphrase  string            `json:"SshPassphrase,omitempty"`
-	SshAuthHeaders map[string]string `json:"SshAuthHeaders,omitempty"`
-	AccessToken    string            `json:"accessToken,omitempty"`
-	ServerId       string            `json:"serverId,omitempty"`
-	IsDefault      bool              `json:"isDefault,omitempty"`
-	InsecureTls    bool              `json:"-"`
+	Url                      string            `json:"url,omitempty"`
+	SshUrl                   string            `json:"-"`
+	User                     string            `json:"user,omitempty"`
+	Password                 string            `json:"password,omitempty"`
+	SshKeyPath               string            `json:"sshKeyPath,omitempty"`
+	SshPassphrase            string            `json:"SshPassphrase,omitempty"`
+	SshAuthHeaders           map[string]string `json:"SshAuthHeaders,omitempty"`
+	AccessToken              string            `json:"accessToken,omitempty"`
+	ClientCertificatePath    string            `json:"clientCertificatePath,omitempty"`
+	ClientCertificateKeyPath string            `json:"clientCertificateKeyPath,omitempty"`
+	ServerId                 string            `json:"serverId,omitempty"`
+	IsDefault                bool              `json:"isDefault,omitempty"`
+	InsecureTls              bool              `json:"-"`
 	// Deprecated, use password option instead.
 	ApiKey string `json:"apiKey,omitempty"`
 }
@@ -387,6 +389,14 @@ func (artifactoryDetails *ArtifactoryDetails) SetAccessToken(accessToken string)
 	artifactoryDetails.AccessToken = accessToken
 }
 
+func (artifactoryDetails *ArtifactoryDetails) SetClientCertificatePath(certificatePath string) {
+	artifactoryDetails.ClientCertificatePath = certificatePath
+}
+
+func (artifactoryDetails *ArtifactoryDetails) SetClientCertificateKeyPath(certificatePath string) {
+	artifactoryDetails.ClientCertificateKeyPath = certificatePath
+}
+
 func (artifactoryDetails *ArtifactoryDetails) GetApiKey() string {
 	return artifactoryDetails.ApiKey
 }
@@ -407,6 +417,14 @@ func (artifactoryDetails *ArtifactoryDetails) GetAccessToken() string {
 	return artifactoryDetails.AccessToken
 }
 
+func (artifactoryDetails *ArtifactoryDetails) GetClientCertificatePath() string {
+	return artifactoryDetails.ClientCertificatePath
+}
+
+func (artifactoryDetails *ArtifactoryDetails) GetClientCertificateKeyPath() string {
+	return artifactoryDetails.ClientCertificateKeyPath
+}
+
 func (artifactoryDetails *ArtifactoryDetails) SshAuthHeaderSet() bool {
 	return len(artifactoryDetails.SshAuthHeaders) > 0
 }
@@ -420,6 +438,8 @@ func (artifactoryDetails *ArtifactoryDetails) CreateArtAuthConfig() (auth.Artifa
 	artAuth.SetUser(artifactoryDetails.User)
 	artAuth.SetPassword(artifactoryDetails.Password)
 	artAuth.SetAccessToken(artifactoryDetails.AccessToken)
+	artAuth.SetClientCertificatePath(artifactoryDetails.ClientCertificatePath)
+	artAuth.SetClientCertificateKeyPath(artifactoryDetails.ClientCertificateKeyPath)
 	artAuth.SetSshKeyPath(artifactoryDetails.SshKeyPath)
 	artAuth.SetSshPassphrase(artifactoryDetails.SshPassphrase)
 	if artAuth.IsSshAuthentication() && !artAuth.IsSshAuthHeaderSet() {

--- a/utils/config/config.go
+++ b/utils/config/config.go
@@ -5,6 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+
 	"github.com/buger/jsonparser"
 	"github.com/jfrog/jfrog-cli-go/utils/cliutils"
 	"github.com/jfrog/jfrog-client-go/artifactory/auth"
@@ -12,10 +17,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"io/ioutil"
-	"os"
-	"path"
-	"path/filepath"
 )
 
 // This is the default server id. It is used when adding a server config without providing a server ID
@@ -338,19 +339,19 @@ func (o *ConfigV0) Convert() *ConfigV1 {
 }
 
 type ArtifactoryDetails struct {
-	Url                      string            `json:"url,omitempty"`
-	SshUrl                   string            `json:"-"`
-	User                     string            `json:"user,omitempty"`
-	Password                 string            `json:"password,omitempty"`
-	SshKeyPath               string            `json:"sshKeyPath,omitempty"`
-	SshPassphrase            string            `json:"SshPassphrase,omitempty"`
-	SshAuthHeaders           map[string]string `json:"SshAuthHeaders,omitempty"`
-	AccessToken              string            `json:"accessToken,omitempty"`
-	ClientCertificatePath    string            `json:"clientCertificatePath,omitempty"`
-	ClientCertificateKeyPath string            `json:"clientCertificateKeyPath,omitempty"`
-	ServerId                 string            `json:"serverId,omitempty"`
-	IsDefault                bool              `json:"isDefault,omitempty"`
-	InsecureTls              bool              `json:"-"`
+	Url               string            `json:"url,omitempty"`
+	SshUrl            string            `json:"-"`
+	User              string            `json:"user,omitempty"`
+	Password          string            `json:"password,omitempty"`
+	SshKeyPath        string            `json:"sshKeyPath,omitempty"`
+	SshPassphrase     string            `json:"SshPassphrase,omitempty"`
+	SshAuthHeaders    map[string]string `json:"SshAuthHeaders,omitempty"`
+	AccessToken       string            `json:"accessToken,omitempty"`
+	ClientCertPath    string            `json:"clientCertPath,omitempty"`
+	ClientCertKeyPath string            `json:"clientCertKeyPath,omitempty"`
+	ServerId          string            `json:"serverId,omitempty"`
+	IsDefault         bool              `json:"isDefault,omitempty"`
+	InsecureTls       bool              `json:"-"`
 	// Deprecated, use password option instead.
 	ApiKey string `json:"apiKey,omitempty"`
 }
@@ -389,12 +390,12 @@ func (artifactoryDetails *ArtifactoryDetails) SetAccessToken(accessToken string)
 	artifactoryDetails.AccessToken = accessToken
 }
 
-func (artifactoryDetails *ArtifactoryDetails) SetClientCertificatePath(certificatePath string) {
-	artifactoryDetails.ClientCertificatePath = certificatePath
+func (artifactoryDetails *ArtifactoryDetails) SetClientCertPath(certificatePath string) {
+	artifactoryDetails.ClientCertPath = certificatePath
 }
 
-func (artifactoryDetails *ArtifactoryDetails) SetClientCertificateKeyPath(certificatePath string) {
-	artifactoryDetails.ClientCertificateKeyPath = certificatePath
+func (artifactoryDetails *ArtifactoryDetails) SetClientCertKeyPath(certificatePath string) {
+	artifactoryDetails.ClientCertKeyPath = certificatePath
 }
 
 func (artifactoryDetails *ArtifactoryDetails) GetApiKey() string {
@@ -417,12 +418,12 @@ func (artifactoryDetails *ArtifactoryDetails) GetAccessToken() string {
 	return artifactoryDetails.AccessToken
 }
 
-func (artifactoryDetails *ArtifactoryDetails) GetClientCertificatePath() string {
-	return artifactoryDetails.ClientCertificatePath
+func (artifactoryDetails *ArtifactoryDetails) GetClientCertPath() string {
+	return artifactoryDetails.ClientCertPath
 }
 
-func (artifactoryDetails *ArtifactoryDetails) GetClientCertificateKeyPath() string {
-	return artifactoryDetails.ClientCertificateKeyPath
+func (artifactoryDetails *ArtifactoryDetails) GetClientCertKeyPath() string {
+	return artifactoryDetails.ClientCertKeyPath
 }
 
 func (artifactoryDetails *ArtifactoryDetails) SshAuthHeaderSet() bool {
@@ -438,8 +439,8 @@ func (artifactoryDetails *ArtifactoryDetails) CreateArtAuthConfig() (auth.Artifa
 	artAuth.SetUser(artifactoryDetails.User)
 	artAuth.SetPassword(artifactoryDetails.Password)
 	artAuth.SetAccessToken(artifactoryDetails.AccessToken)
-	artAuth.SetClientCertificatePath(artifactoryDetails.ClientCertificatePath)
-	artAuth.SetClientCertificateKeyPath(artifactoryDetails.ClientCertificateKeyPath)
+	artAuth.SetClientCertPath(artifactoryDetails.ClientCertPath)
+	artAuth.SetClientCertKeyPath(artifactoryDetails.ClientCertKeyPath)
 	artAuth.SetSshKeyPath(artifactoryDetails.SshKeyPath)
 	artAuth.SetSshPassphrase(artifactoryDetails.SshPassphrase)
 	if artAuth.IsSshAuthentication() && !artAuth.IsSshAuthHeaderSet() {

--- a/utils/config/configtoken.go
+++ b/utils/config/configtoken.go
@@ -8,41 +8,47 @@ import (
 const tokenVersion = 1
 
 type configToken struct {
-	Version       int    `json:"version,omitempty"`
-	Url           string `json:"url,omitempty"`
-	User          string `json:"user,omitempty"`
-	Password      string `json:"password,omitempty"`
-	SshKeyPath    string `json:"sshKeyPath,omitempty"`
-	SshPassphrase string `json:"sshPassphrase,omitempty"`
-	AccessToken   string `json:"accessToken,omitempty"`
-	ServerId      string `json:"serverId,omitempty"`
-	ApiKey        string `json:"apiKey,omitempty"`
+	Version                  int    `json:"version,omitempty"`
+	Url                      string `json:"url,omitempty"`
+	User                     string `json:"user,omitempty"`
+	Password                 string `json:"password,omitempty"`
+	SshKeyPath               string `json:"sshKeyPath,omitempty"`
+	SshPassphrase            string `json:"sshPassphrase,omitempty"`
+	AccessToken              string `json:"accessToken,omitempty"`
+	ClientCertificatePath    string `json:"clientCertificatePath,omitempty"`
+	ClientCertificateKeyPath string `json:"clientCertificateKeyPath,omitempty"`
+	ServerId                 string `json:"serverId,omitempty"`
+	ApiKey                   string `json:"apiKey,omitempty"`
 }
 
 func fromArtifactoryDetails(details *ArtifactoryDetails) *configToken {
 	return &configToken{
-		Version:       tokenVersion,
-		Url:           details.Url,
-		User:          details.User,
-		Password:      details.Password,
-		SshKeyPath:    details.SshKeyPath,
-		SshPassphrase: details.SshPassphrase,
-		AccessToken:   details.AccessToken,
-		ServerId:      details.ServerId,
-		ApiKey:        details.ApiKey,
+		Version:                  tokenVersion,
+		Url:                      details.Url,
+		User:                     details.User,
+		Password:                 details.Password,
+		SshKeyPath:               details.SshKeyPath,
+		SshPassphrase:            details.SshPassphrase,
+		AccessToken:              details.AccessToken,
+		ClientCertificatePath:    details.ClientCertificatePath,
+		ClientCertificateKeyPath: details.ClientCertificateKeyPath,
+		ServerId:                 details.ServerId,
+		ApiKey:                   details.ApiKey,
 	}
 }
 
 func toArtifactoryDetails(detailsSerialization *configToken) *ArtifactoryDetails {
 	return &ArtifactoryDetails{
-		Url:           detailsSerialization.Url,
-		User:          detailsSerialization.User,
-		Password:      detailsSerialization.Password,
-		SshKeyPath:    detailsSerialization.SshKeyPath,
-		SshPassphrase: detailsSerialization.SshPassphrase,
-		AccessToken:   detailsSerialization.AccessToken,
-		ServerId:      detailsSerialization.ServerId,
-		ApiKey:        detailsSerialization.ApiKey,
+		Url:                      detailsSerialization.Url,
+		User:                     detailsSerialization.User,
+		Password:                 detailsSerialization.Password,
+		SshKeyPath:               detailsSerialization.SshKeyPath,
+		SshPassphrase:            detailsSerialization.SshPassphrase,
+		AccessToken:              detailsSerialization.AccessToken,
+		ClientCertificatePath:    detailsSerialization.ClientCertificatePath,
+		ClientCertificateKeyPath: detailsSerialization.ClientCertificateKeyPath,
+		ServerId:                 detailsSerialization.ServerId,
+		ApiKey:                   detailsSerialization.ApiKey,
 	}
 }
 

--- a/utils/config/configtoken.go
+++ b/utils/config/configtoken.go
@@ -8,47 +8,47 @@ import (
 const tokenVersion = 1
 
 type configToken struct {
-	Version                  int    `json:"version,omitempty"`
-	Url                      string `json:"url,omitempty"`
-	User                     string `json:"user,omitempty"`
-	Password                 string `json:"password,omitempty"`
-	SshKeyPath               string `json:"sshKeyPath,omitempty"`
-	SshPassphrase            string `json:"sshPassphrase,omitempty"`
-	AccessToken              string `json:"accessToken,omitempty"`
-	ClientCertificatePath    string `json:"clientCertificatePath,omitempty"`
-	ClientCertificateKeyPath string `json:"clientCertificateKeyPath,omitempty"`
-	ServerId                 string `json:"serverId,omitempty"`
-	ApiKey                   string `json:"apiKey,omitempty"`
+	Version           int    `json:"version,omitempty"`
+	Url               string `json:"url,omitempty"`
+	User              string `json:"user,omitempty"`
+	Password          string `json:"password,omitempty"`
+	SshKeyPath        string `json:"sshKeyPath,omitempty"`
+	SshPassphrase     string `json:"sshPassphrase,omitempty"`
+	AccessToken       string `json:"accessToken,omitempty"`
+	ClientCertPath    string `json:"clientCertPath,omitempty"`
+	ClientCertKeyPath string `json:"clientCertKeyPath,omitempty"`
+	ServerId          string `json:"serverId,omitempty"`
+	ApiKey            string `json:"apiKey,omitempty"`
 }
 
 func fromArtifactoryDetails(details *ArtifactoryDetails) *configToken {
 	return &configToken{
-		Version:                  tokenVersion,
-		Url:                      details.Url,
-		User:                     details.User,
-		Password:                 details.Password,
-		SshKeyPath:               details.SshKeyPath,
-		SshPassphrase:            details.SshPassphrase,
-		AccessToken:              details.AccessToken,
-		ClientCertificatePath:    details.ClientCertificatePath,
-		ClientCertificateKeyPath: details.ClientCertificateKeyPath,
-		ServerId:                 details.ServerId,
-		ApiKey:                   details.ApiKey,
+		Version:           tokenVersion,
+		Url:               details.Url,
+		User:              details.User,
+		Password:          details.Password,
+		SshKeyPath:        details.SshKeyPath,
+		SshPassphrase:     details.SshPassphrase,
+		AccessToken:       details.AccessToken,
+		ClientCertPath:    details.ClientCertPath,
+		ClientCertKeyPath: details.ClientCertKeyPath,
+		ServerId:          details.ServerId,
+		ApiKey:            details.ApiKey,
 	}
 }
 
 func toArtifactoryDetails(detailsSerialization *configToken) *ArtifactoryDetails {
 	return &ArtifactoryDetails{
-		Url:                      detailsSerialization.Url,
-		User:                     detailsSerialization.User,
-		Password:                 detailsSerialization.Password,
-		SshKeyPath:               detailsSerialization.SshKeyPath,
-		SshPassphrase:            detailsSerialization.SshPassphrase,
-		AccessToken:              detailsSerialization.AccessToken,
-		ClientCertificatePath:    detailsSerialization.ClientCertificatePath,
-		ClientCertificateKeyPath: detailsSerialization.ClientCertificateKeyPath,
-		ServerId:                 detailsSerialization.ServerId,
-		ApiKey:                   detailsSerialization.ApiKey,
+		Url:               detailsSerialization.Url,
+		User:              detailsSerialization.User,
+		Password:          detailsSerialization.Password,
+		SshKeyPath:        detailsSerialization.SshKeyPath,
+		SshPassphrase:     detailsSerialization.SshPassphrase,
+		AccessToken:       detailsSerialization.AccessToken,
+		ClientCertPath:    detailsSerialization.ClientCertPath,
+		ClientCertKeyPath: detailsSerialization.ClientCertKeyPath,
+		ServerId:          detailsSerialization.ServerId,
+		ApiKey:            detailsSerialization.ApiKey,
 	}
 }
 

--- a/utils/tests/proxy/server/server.go
+++ b/utils/tests/proxy/server/server.go
@@ -182,7 +182,7 @@ func GetProxyHttpsPort() string {
 	return port
 }
 
-func startHttpsReverseProxy(proxyTarget string, requestClientCertificates bool) {
+func startHttpsReverseProxy(proxyTarget string, requestClientCerts bool) {
 	handler, err := getReverseProxyHandler(proxyTarget)
 	if err != nil {
 		panic(err)
@@ -190,7 +190,7 @@ func startHttpsReverseProxy(proxyTarget string, requestClientCertificates bool) 
 	// Starts a new Go routine
 	httpsMux, absPathCert, absPathKey := prepareHTTPSHandling(handler)
 
-	if requestClientCertificates {
+	if requestClientCerts {
 		server := &http.Server{
 			Addr:    ":" + GetProxyHttpsPort(),
 			Handler: httpsMux,
@@ -208,12 +208,12 @@ func startHttpsReverseProxy(proxyTarget string, requestClientCertificates bool) 
 	}
 }
 
-func StartLocalReverseHttpProxy(artifactoryUrl string, requestClientCertificates bool) {
+func StartLocalReverseHttpProxy(artifactoryUrl string, requestClientCerts bool) {
 	if artifactoryUrl == "" {
 		artifactoryUrl = "http://localhost:8081/artifactory/"
 	}
 	artifactoryUrl = utils.AddTrailingSlashIfNeeded(artifactoryUrl)
-	startHttpsReverseProxy(artifactoryUrl, requestClientCertificates)
+	startHttpsReverseProxy(artifactoryUrl, requestClientCerts)
 }
 
 func StartHttpProxy() {


### PR DESCRIPTION
This PR adds the support for client certificate authentication to the CLI. It requires https://github.com/jfrog/jfrog-client-go/issues/82 to be merged to jfrog-client-go.

Fixes #100 and #113