### PR TITLE
Update plexus-classworlds jar detection

### DIFF
--- a/artifactory/commands/mvn/mvn.go
+++ b/artifactory/commands/mvn/mvn.go
@@ -151,7 +151,7 @@ func (mc *MvnCommand) createMvnRunConfig(dependenciesPath string) (*mvnRunConfig
 	}
 
 	mavenHome := os.Getenv("M2_HOME")
-	plexusClassworlds, err := filepath.Glob(filepath.Join(mavenHome, "boot", "plexus-classworlds*"))
+	plexusClassworlds, err := filepath.Glob(filepath.Join(mavenHome, "boot", "plexus-classworlds*.jar"))
 	if err != nil {
 		return nil, errorutils.CheckError(err)
 	}


### PR DESCRIPTION
Updated plexus-classworlds jar detection to not detect license file which then fails the length != 1 check

Haven't tested (and haven't touched go in my life, if it does not work/is not supposed to work fell free to propose changes)