### PR TITLE
Fix a wrong command-name for mvnc help.

### DIFF
--- a/docs/artifactory/mvnconfig/help.go
+++ b/docs/artifactory/mvnconfig/help.go
@@ -2,4 +2,4 @@ package mvnconfig
 
 const Description = "Generate maven build configuration."
 
-var Usage = []string{"jfrog rt maven-config [command options]"}
+var Usage = []string{"jfrog rt mvn-config [command options]"}


### PR DESCRIPTION
This fixes an error in the help text for mvnc.