### PR TITLE
Allow 'go-generate' of completion scripts

### DIFF
--- a/completion/cli.go
+++ b/completion/cli.go
@@ -2,30 +2,31 @@ package completion
 
 import (
 	"github.com/codegangsta/cli"
-	"github.com/jfrog/jfrog-cli-go/completion/shells"
+	"github.com/jfrog/jfrog-cli-go/completion/shells/bash"
+	"github.com/jfrog/jfrog-cli-go/completion/shells/zsh"
 	"github.com/jfrog/jfrog-cli-go/docs/common"
-	"github.com/jfrog/jfrog-cli-go/docs/completion/bash"
-	"github.com/jfrog/jfrog-cli-go/docs/completion/zsh"
+	bash_docs "github.com/jfrog/jfrog-cli-go/docs/completion/bash"
+	zsh_docs "github.com/jfrog/jfrog-cli-go/docs/completion/zsh"
 )
 
 func GetCommands() []cli.Command {
 	return []cli.Command{
 		{
 			Name:         "bash",
-			Usage:        bash.Description,
-			HelpName:     common.CreateUsage("completion bash", bash.Description, bash.Usage),
+			Usage:        bash_docs.Description,
+			HelpName:     common.CreateUsage("completion bash", bash_docs.Description, bash_docs.Usage),
 			BashComplete: common.CreateBashCompletionFunc(),
 			Action: func(*cli.Context) {
-				shells.WriteBashCompletionScript()
+				bash.WriteBashCompletionScript()
 			},
 		},
 		{
 			Name:         "zsh",
-			Usage:        zsh.Description,
-			HelpName:     common.CreateUsage("completion zsh", zsh.Description, zsh.Usage),
+			Usage:        zsh_docs.Description,
+			HelpName:     common.CreateUsage("completion zsh", zsh_docs.Description, zsh_docs.Usage),
 			BashComplete: common.CreateBashCompletionFunc(),
 			Action: func(*cli.Context) {
-				shells.WriteZshCompletionScript()
+				zsh.WriteZshCompletionScript()
 			},
 		},
 	}

--- a/completion/shells/bash/bash.go
+++ b/completion/shells/bash/bash.go
@@ -1,4 +1,6 @@
-package shells
+package bash
+
+//go:generate go run ../generate_scripts.go
 
 import (
 	"fmt"
@@ -8,7 +10,7 @@ import (
 	"path/filepath"
 )
 
-const bashAutocomplete = `#!/bin/bash
+const BashAutocomplete = `#!/bin/bash
 _jfrog() {
     local cur opts base
     COMPREPLY=()
@@ -27,7 +29,7 @@ func WriteBashCompletionScript() {
 		return
 	}
 	completionPath := filepath.Join(homeDir, "jfrog_bash_completion")
-	if err = ioutil.WriteFile(completionPath, []byte(bashAutocomplete), 0600); err != nil {
+	if err = ioutil.WriteFile(completionPath, []byte(BashAutocomplete), 0600); err != nil {
 		log.Error(err)
 		return
 	}

--- a/completion/shells/generate_scripts.go
+++ b/completion/shells/generate_scripts.go
@@ -1,0 +1,39 @@
+// +build ignore
+
+// This program generates bash and zsh completion scripts.
+// It can be invoked by running 'go generate ./completion/shells/...'
+package main
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/jfrog/jfrog-cli-go/completion/shells/bash"
+	"github.com/jfrog/jfrog-cli-go/completion/shells/zsh"
+	"github.com/jfrog/jfrog-cli-go/utils/cliutils"
+	"github.com/jfrog/jfrog-cli-go/utils/log"
+)
+
+func main() {
+	log.SetDefaultLogger()
+	dir, err := os.Getwd()
+	cliutils.ExitOnErr(err)
+	if strings.HasSuffix(dir, "bash") {
+		writeScript(bash.BashAutocomplete)
+	} else if strings.HasSuffix(dir, "zsh") {
+		writeScript(zsh.ZshAutocomplete)
+	} else {
+		cliutils.ExitOnErr(errors.New("Unexpected script to create"))
+	}
+}
+
+func writeScript(script string) {
+	scriptFile, err := os.Create("jfrog")
+	cliutils.ExitOnErr(err)
+	defer scriptFile.Close()
+	err = scriptFile.Chmod(os.ModePerm)
+	cliutils.ExitOnErr(err)
+	_, err = scriptFile.WriteString(script)
+	cliutils.ExitOnErr(err)
+}

--- a/completion/shells/generate_scripts_test.go
+++ b/completion/shells/generate_scripts_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"github.com/jfrog/jfrog-cli-go/completion/shells/bash"
+	"github.com/jfrog/jfrog-cli-go/completion/shells/zsh"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenrateScripts(t *testing.T) {
+	bashPath := filepath.Join("bash", "jfrog")
+	zshPath := filepath.Join("zsh", "jfrog")
+
+	// Make sure test environment is clean before and after test
+	os.Remove(bashPath)
+	os.Remove(zshPath)
+	defer os.Remove(bashPath)
+	defer os.Remove(zshPath)
+
+	// Run go generate ./...
+	cmd := exec.Command("go", "generate", "./...")
+	err := cmd.Run()
+	assert.NoError(t, err)
+
+	// Check bash completion script
+	file, err := os.Open(bashPath)
+	assert.NoError(t, err)
+	b, err := ioutil.ReadAll(file)
+	file.Close()
+	assert.Equal(t, bash.BashAutocomplete, string(b))
+
+	// Check zsh completion script
+	file, err = os.Open(zshPath)
+	assert.NoError(t, err)
+	b, err = ioutil.ReadAll(file)
+	file.Close()
+	assert.Equal(t, zsh.ZshAutocomplete, string(b))
+}

--- a/completion/shells/generate_scripts_test.go
+++ b/completion/shells/generate_scripts_test.go
@@ -27,16 +27,16 @@ func TestGenrateScripts(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check bash completion script
-	file, err := os.Open(bashPath)
+	bashFile, err := os.Open(bashPath)
+	defer bashFile.Close()
 	assert.NoError(t, err)
-	b, err := ioutil.ReadAll(file)
-	file.Close()
+	b, err := ioutil.ReadAll(bashFile)
 	assert.Equal(t, bash.BashAutocomplete, string(b))
 
 	// Check zsh completion script
-	file, err = os.Open(zshPath)
+	zshFile, err := os.Open(zshPath)
+	defer zshFile.Close()
 	assert.NoError(t, err)
-	b, err = ioutil.ReadAll(file)
-	file.Close()
+	b, err = ioutil.ReadAll(zshFile)
 	assert.Equal(t, zsh.ZshAutocomplete, string(b))
 }

--- a/completion/shells/zsh/zsh.go
+++ b/completion/shells/zsh/zsh.go
@@ -1,4 +1,6 @@
-package shells
+package zsh
+
+//go:generate go run ../generate_scripts.go
 
 import (
 	"fmt"
@@ -8,7 +10,7 @@ import (
 	"path/filepath"
 )
 
-const zshAutocomplete = `_jfrog() {
+const ZshAutocomplete = `_jfrog() {
 	local -a opts
 	opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
 	_describe 'values' opts
@@ -26,7 +28,7 @@ func WriteZshCompletionScript() {
 		return
 	}
 	completionPath := filepath.Join(homeDir, "jfrog_zsh_completion")
-	if err = ioutil.WriteFile(completionPath, []byte(zshAutocomplete), 0600); err != nil {
+	if err = ioutil.WriteFile(completionPath, []byte(ZshAutocomplete), 0600); err != nil {
 		log.Error(err)
 		return
 	}


### PR DESCRIPTION
Allow generation of bash and zsh completion scripts by running `go generate ./completion/shells/...` from the root dir.
This will allow auto installation of autocomplete scripts by Homebrew:

```ruby
system "go", "generate", "./completion/shells/..."
bash_completion.install "completion/shells/bash/jfrog"
zsh_completion.install "completion/shells/zsh/jfrog" => "_jfrog"
```