### PR TITLE
Add different exit codes for different errors of "build-scan" command

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -2529,8 +2529,7 @@ func buildScanCmd(c *cli.Context) error {
 	}
 	buildScanCmd := buildinfo.NewBuildScanCommand().SetRtDetails(rtDetails).SetFailBuild(c.BoolT("fail")).SetBuildConfiguration(buildConfiguration)
 	err = commands.Exec(buildScanCmd)
-
-	return cliutils.ExitBuildScan(buildScanCmd.BuildFailed(), err)
+	return err
 }
 
 func buildCleanCmd(c *cli.Context) error {

--- a/artifactory/commands/buildinfo/xrayscan.go
+++ b/artifactory/commands/buildinfo/xrayscan.go
@@ -2,8 +2,8 @@ package buildinfo
 
 import (
 	"encoding/json"
-	"errors"
 	"github.com/jfrog/jfrog-cli-go/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-go/utils/cliutils"
 	"github.com/jfrog/jfrog-cli-go/utils/config"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
@@ -74,7 +74,10 @@ func (bsc *BuildScanCommand) Run() error {
 	// Check if should fail build
 	if bsc.failBuild && scanResults.Summary.FailBuild {
 		bsc.buildFailed = true
-		return errorutils.CheckError(errors.New(scanResults.Summary.Message))
+		if scanResults.Summary.TotalAlerts >= 1 {
+			return cliutils.ExitBuildScanWithAlerts(bsc.failBuild, scanResults.Summary.Message)
+		}
+		return cliutils.ExitBuildScanNotConfigured(bsc.failBuild, scanResults.Summary.Message)
 	}
 
 	return err

--- a/utils/cliutils/utils.go
+++ b/utils/cliutils/utils.go
@@ -49,7 +49,8 @@ type ExitCode struct {
 var ExitCodeNoError = ExitCode{0}
 var ExitCodeError = ExitCode{1}
 var ExitCodeFailNoOp = ExitCode{2}
-var ExitCodeBuildScan = ExitCode{3}
+var ExitCodeBuildScanNotConfigured = ExitCode{3}
+var ExitCodeBuildScanWithAlerts = ExitCode{4}
 
 type CliError struct {
 	ExitCode
@@ -93,14 +94,20 @@ func GetCliError(err error, success, failed int, failNoOp bool) error {
 	}
 }
 
-func ExitBuildScan(failBuild bool, err error) error {
-	if failBuild && err != nil {
-		return CliError{ExitCodeBuildScan, "Build Scan Failed"}
+func ExitBuildScanNotConfigured(failBuild bool, err string) error {
+	if failBuild && len(err) > 0 {
+		return CliError{ExitCodeBuildScanNotConfigured, err}
 	}
 
 	return nil
 }
 
+func ExitBuildScanWithAlerts(failBuild bool, err string) error {
+	if failBuild && len(err) > 0 {
+		return CliError{ExitCodeBuildScanWithAlerts, err}
+	}
+	return nil
+}
 func GetExitCode(err error, success, failed int, failNoOp bool) ExitCode {
 	// Error occurred - Return 1
 	if err != nil || failed > 0 {


### PR DESCRIPTION
Fix of issue #448

When the build is not configured for scanning the exit code will be 3
When the build has been failed since the build job containing vulnerabilities the exit code will be 4