### PR TITLE
Bump golang to v1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine as builder
+FROM golang:1.14-alpine as builder
 WORKDIR /jfrog-cli-go
 COPY . /jfrog-cli-go
 RUN apk add --update git && sh build.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node {
     repo = 'jfrog-cli'
     sh 'rm -rf temp'
     sh 'mkdir temp'
-    def goRoot = tool 'go-1.12'
+    def goRoot = tool 'go-1.14'
     env.GOROOT="$goRoot"
     env.PATH+=":${goRoot}/bin"
     env.GO111MODULE="on"
@@ -35,12 +35,12 @@ node {
             jfrogCliRepoDir = "${cliWorkspace}/${repo}/"
             jfrogCliDir = "${jfrogCliRepoDir}jfrog-cli/jfrog"
             sh "echo jfrogCliDir=$jfrogCliDir"
-            
+
             sh 'go version'
             dir("$jfrogCliRepoDir") {
                 sh './build.sh'
             }
-            
+
             sh 'mkdir builder'
             sh "mv $jfrogCliRepoDir/jfrog builder/"
 
@@ -106,7 +106,7 @@ def buildAndUpload(goos, goarch, pkg, fileExtension) {
     dir("${jfrogCliRepoDir}") {
         env.GOOS="$goos"
         env.GOARCH="$goarch"
-        sh "./build.sh $fileName" 
+        sh "./build.sh $fileName"
 
         if (goos == 'windows') {
             dir("${cliWorkspace}/certs-dir") {
@@ -123,7 +123,7 @@ def buildAndUpload(goos, goarch, pkg, fileExtension) {
             }
         }
     }
-    
+
     uploadToBintray(pkg, fileName)
     sh "rm $jfrogCliRepoDir/$fileName"
 }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ JFrog CLI is written in the [Go programming language](https://golang.org/), so t
 ## Install Go
 
 To download and install `Go`, please refer to the [Go documentation](https://golang.org/doc/install).
-Please download `Go 1.12.7` or above.
+Please download `Go 1.14.x` or above.
 
 ## Download and Build the CLI
 
@@ -103,7 +103,7 @@ The types are:
 
 * Running the tests will create two repositories: `jfrog-cli-tests-repo` and `jfrog-cli-tests-repo1`.<br/>
 Once the tests are completed, the content of these repositories will be deleted.
- 
+
 #### Artifactory tests
 In addition to [general optional flags](#Usage) you can use the following optional artifactory flags.
 
@@ -212,7 +212,7 @@ go test -v github.com/jfrog/jfrog-cli-go -test.pip [flags]
 ### Bintray tests
 Bintray tests credentials are taken from the CLI configuration. If non configured or not passed as flags, the tests will fail.
 
-To run Bintray tests execute the following command: 
+To run Bintray tests execute the following command:
 ````
 go test -v github.com/jfrog/jfrog-cli-go -test.bintray
 ````

--- a/artifactory/utils/golang/project/project_test.go
+++ b/artifactory/utils/golang/project/project_test.go
@@ -15,7 +15,7 @@ func TestParseModuleName(t *testing.T) {
 
 module github.com/jfrog/go-example
 
-go 1.12
+go 1.14
 
 require (
         github.com/Sirupsen/logrus v1.0.6

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/jfrog/jfrog-cli-go
 
+go 1.14
+
 require (
 	github.com/buger/jsonparser v0.0.0-20180910192245-6acdf747ae99
 	github.com/codegangsta/cli v1.20.0
@@ -18,9 +20,3 @@ require (
 	gopkg.in/src-d/go-git-fixtures.v3 v3.3.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
-
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go dev
-
-// replace github.com/jfrog/gocmd => github.com/jfrog/gocmd master
-
-go 1.13


### PR DESCRIPTION
- [x] I signed [JFrog's CLA](https://secure.echosign.com/public/hostedForm?formid=5IYKLZ2RXB543N).
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

- Kind of relates to https://github.com/Homebrew/homebrew-core/pull/51031 (homebrew-core ships the formula with the latest golang version, which is v1.14)
- Not quite whether you guys need to setup go-1.14 on your end, but I did bump the Jenkinsfile as well.