### PR TITLE
Check docker API version instead of version

### DIFF
--- a/artifactory/commands/docker/pull.go
+++ b/artifactory/commands/docker/pull.go
@@ -19,7 +19,7 @@ func NewDockerPullCommand() *DockerPullCommand {
 
 // Pull docker image and create build info if needed
 func (dpc *DockerPullCommand) Run() error {
-	err := docker.ValidateVersion()
+	err := docker.ValidateClientApiVersion()
 	if err != nil {
 		return err
 	}

--- a/artifactory/commands/docker/push.go
+++ b/artifactory/commands/docker/push.go
@@ -29,7 +29,7 @@ func (dpc *DockerPushCommand) SetThreads(threads int) *DockerPushCommand {
 
 // Push docker image and create build info if needed
 func (dpc *DockerPushCommand) Run() error {
-	err := docker.ValidateVersion()
+	err := docker.ValidateClientApiVersion()
 	if err != nil {
 		return err
 	}

--- a/artifactory/utils/docker/docker.go
+++ b/artifactory/utils/docker/docker.go
@@ -352,7 +352,7 @@ func ValidateClientApiVersion() error {
 	// 'docker version' may return 1 in case of errors from daemon. We should ignore this kind of errors.
 	content, err := gofrogcmd.RunCmdOutput(cmd)
 	content = strings.TrimSpace(content)
-	if (!ClientApiVersionRegex.Match([]byte(content))) {
+	if !ClientApiVersionRegex.Match([]byte(content)) {
 		// The Api version is expected to be 'x.x'. Anything else should return an error.
 		return errorutils.CheckError(err)
 	}

--- a/artifactory/utils/docker/docker_test.go
+++ b/artifactory/utils/docker/docker_test.go
@@ -72,22 +72,24 @@ func TestResolveRegistryFromTag(t *testing.T) {
 	}
 }
 
-func TestCheckDockerMinVersion(t *testing.T) {
-	// Supported
-	have := "Docker version 19.03.5, build 633a0ea"
-	want := true
-	got := checkDockerMinVersion(have)
-
-	if got != want {
-		t.Errorf("checkDockerMinVersion(%s) == %t, want %t", have, got, want)
+func TestDockerClientApiVersionRegex(t *testing.T) {
+	var versionStrings = []struct {
+		in       string
+		expected bool
+	}{
+		{"1", false},
+		{"1.1", true},
+		{"1.11", true},
+		{"12.12", true},
+		{"1.1.11", false},
+		{"1.illegal", false},
+		{"1 11", false},
 	}
 
-	// Not supported
-	have = "Docker version 17.03.5, build 633a0ea"
-	want = false
-	got = checkDockerMinVersion(have)
-
-	if got != want {
-		t.Errorf("checkDockerMinVersion(%s) == %t, want %t", have, got, want)
+	for _, v := range versionStrings {
+		result := ClientApiVersionRegex.Match([]byte(v.in))
+		if result != v.expected {
+			t.Errorf("Version(\"%s\") => '%v', want '%v'", v.in, result, v.expected)
+		}
 	}
 }

--- a/artifactory/utils/docker/docker_test.go
+++ b/artifactory/utils/docker/docker_test.go
@@ -87,7 +87,7 @@ func TestDockerClientApiVersionRegex(t *testing.T) {
 	}
 
 	for _, v := range versionStrings {
-		result := ClientApiVersionRegex.Match([]byte(v.in))
+		result := ApiVersionRegex.Match([]byte(v.in))
 		if result != v.expected {
 			t.Errorf("Version(\"%s\") => '%v', want '%v'", v.in, result, v.expected)
 		}

--- a/docker_test.go
+++ b/docker_test.go
@@ -171,13 +171,20 @@ func dockerTestCleanup(imageName, buildName string) {
 	tests.DeleteFiles(deleteSpec, artifactoryDetails)
 }
 
-func TestDockerVersionScript(t *testing.T) {
+func TestDockerClientApiVersionCmd(t *testing.T) {
 	if !*tests.TestDocker {
 		t.Skip("Skipping docker test. To run docker test add the '-test.docker=true' option.")
 	}
-	cmd := &docker.VersionCmd{}
+	
+	// Run docker version command and expect no errors
+	cmd := &docker.ClientApiVersionCmd{}
 	content, err := gofrogcmd.RunCmdOutput(cmd)
-	if err != nil || strings.Index(content, "Docker version") == -1 {
-		t.Errorf("Could not get docker version, error: %s", err.Error())
-	}
+	assert.NoError(t, err)
+
+	// Expect VersionRegex to match the output API version
+	content = strings.TrimSpace(content)
+	assert.True(t, docker.ClientApiVersionRegex.Match([]byte(content)))
+
+	// Assert docker min API version
+	assert.True(t, docker.CheckDockerMinVersion(content))
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -175,7 +175,7 @@ func TestDockerClientApiVersionCmd(t *testing.T) {
 	if !*tests.TestDocker {
 		t.Skip("Skipping docker test. To run docker test add the '-test.docker=true' option.")
 	}
-	
+
 	// Run docker version command and expect no errors
 	cmd := &docker.ClientApiVersionCmd{}
 	content, err := gofrogcmd.RunCmdOutput(cmd)

--- a/docker_test.go
+++ b/docker_test.go
@@ -177,14 +177,14 @@ func TestDockerClientApiVersionCmd(t *testing.T) {
 	}
 
 	// Run docker version command and expect no errors
-	cmd := &docker.ClientApiVersionCmd{}
+	cmd := &docker.VersionCmd{}
 	content, err := gofrogcmd.RunCmdOutput(cmd)
 	assert.NoError(t, err)
 
 	// Expect VersionRegex to match the output API version
 	content = strings.TrimSpace(content)
-	assert.True(t, docker.ClientApiVersionRegex.Match([]byte(content)))
+	assert.True(t, docker.ApiVersionRegex.Match([]byte(content)))
 
 	// Assert docker min API version
-	assert.True(t, docker.CheckDockerMinVersion(content))
+	assert.True(t, docker.IsCompatibleApiVersion(content))
 }


### PR DESCRIPTION
- [x] I signed [JFrog's CLA](https://secure.echosign.com/public/hostedForm?formid=5IYKLZ2RXB543N).
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

This PR is targeting: https://github.com/jfrog/setup-jfrog-cli/issues/8

In this PR, I rely on the API version structure of `Major.Minor` provided in the [docker official documentation](https://docs.docker.com/engine/api/#api-version-matrix).
