### PR TITLE
Fix Control+C in the repo-template

### DIFF
--- a/artifactory/commands/utils/questionnaire.go
+++ b/artifactory/commands/utils/questionnaire.go
@@ -1,14 +1,12 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/c-bata/go-prompt"
-	"github.com/jfrog/jfrog-cli-go/utils/cliutils"
 )
 
 // The interactive questionnaire works as follows:
@@ -77,7 +75,7 @@ func interruptKeyBind() prompt.Option {
 	interrupt := prompt.KeyBind{
 		Key: prompt.ControlC,
 		Fn: func(buf *prompt.Buffer) {
-			cliutils.ExitOnErr(errors.New("Interrupted"))
+			panic("Interrupted")
 		},
 	}
 	return prompt.OptionAddKeyBind(interrupt)


### PR DESCRIPTION
**Issue:**
On Bash: After Control+C inside the repo-template, you cannot run shell commands in the terminal.

**Why does it happen:**
The key binding does not being canceled when interrupting with os.Exit(...).

**Solution:**
Use panic instead of os.Exit(...)