### PR TITLE
resolves #620 by adding maven sync command

### DIFF
--- a/bintray/commands/mavensync.go
+++ b/bintray/commands/mavensync.go
@@ -1,0 +1,15 @@
+package commands
+
+import (
+	"github.com/jfrog/jfrog-client-go/bintray"
+	"github.com/jfrog/jfrog-client-go/bintray/services/mavensync"
+	"github.com/jfrog/jfrog-client-go/bintray/services/versions"
+)
+
+func MavenCentralSync(config bintray.Config, params *mavensync.Params, path *versions.Path) error {
+	sm, err := bintray.New(config)
+	if err != nil {
+		return err
+	}
+	return sm.MavenCentralContentSync(params, path)
+}

--- a/docs/bintray/mavensync/help.go
+++ b/docs/bintray/mavensync/help.go
@@ -1,0 +1,9 @@
+package mavensync
+
+const Description string = "Sync Version Artifacts to Maven Central"
+
+var Usage = []string{"jfrog bt mcs [command options] <target path>"}
+
+const Arguments string = `	target path
+		The path, in Bintray, to the version that should be synced.
+		Format: subject/repository/package/version.`


### PR DESCRIPTION
- [X] I signed [JFrog's CLA](https://secure.echosign.com/public/hostedForm?formid=5IYKLZ2RXB543N).
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [X] This pull request is on the dev branch.
- [X] I used gofmt for formatting the code before submitting the pull request.
-----

This adds maven sync command to the cli, which was added in the https://github.com/jfrog/jfrog-client-go/pull/154 

invocation: `jfrog-cli bt ms subject/repository/package/version`

help:
```
Name:
  jfrog bt maven-central-sync - Sync Version Artifacts to Maven Central

Usage:
  jfrog bt mcs [command options] <target path>

Arguments:
  target path
    The path, in Bintray, to the version that should be synced.
    Format: subject/repository/package/version.

Options:
  --user                 [Optional] Bintray username. If not set, the subject sent as part of the command argument is used for authentication.
  --key                  [Mandatory] Bintray API key
  --sonatype-username    [Optional] Sonatype OSS username
  --sonatype-password    [Optional] Sonatype OSS user password
  --dont-close           [Default: false] By default the staging repository is closed and artifacts are released to Maven Central.

```

