### PR TITLE
Maven tests - exclude 'maven-metadata.xml'

### DIFF
--- a/testsdata/specs/search_all_maven.json
+++ b/testsdata/specs/search_all_maven.json
@@ -1,7 +1,8 @@
 {
   "files": [
     {
-      "pattern": "${MAVEN_REPO1}/*"
+      "pattern": "${MAVEN_REPO1}/*",
+      "exclusions": ["${MAVEN_REPO1}/org/jfrog/cli-test/maven-metadata.xml"]
     }
   ]
 }

--- a/utils/tests/artifactoryconsts.go
+++ b/utils/tests/artifactoryconsts.go
@@ -1314,7 +1314,6 @@ func GetSearchResultAfterDeleteByPropsStep3() []generic.SearchResult {
 
 func GetMavenDeployedArtifacts() []string {
 	return []string{
-		MvnRepo1 + "/org/jfrog/cli-test/maven-metadata.xml",
 		MvnRepo1 + "/org/jfrog/cli-test/1.0/cli-test-1.0.jar",
 		MvnRepo1 + "/org/jfrog/cli-test/1.0/cli-test-1.0.pom",
 	}

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -157,7 +158,8 @@ func getPathsFromSearchResults(searchResults []generic.SearchResult) []string {
 }
 
 func CompareExpectedVsActual(expected []string, actual []generic.SearchResult, t *testing.T) {
-	assert.ElementsMatch(t, expected, getPathsFromSearchResults(actual))
+	actualPaths := getPathsFromSearchResults(actual)
+	assert.ElementsMatch(t, expected, actualPaths, fmt.Sprintf("Expected: %v \nActual: %v", expected, actualPaths))
 }
 
 func GetTestResourcesPath() string {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

This fix resolves the following error:
>
    TestMavenBuildWithCredentials: utils.go:162: 
        	Error Trace:	utils.go:162
        	            				artifactory_test.go:3479
        	            				maven_test.go:136
        	            				maven_test.go:82
        	Error:      	lengths don't match: 2 != 3
        	Test:       	TestMavenBuildWithCredentials
        	Messages:   	
        	            	Expected: [cli-tests-mvn1-1594187811/org/jfrog/cli-test/1.0/cli-test-1.0.jar cli-tests-mvn1-1594187811/org/jfrog/cli-test/1.0/cli-test-1.0.pom] 
        	            	Actual: [cli-tests-mvn1-1594187811/org/jfrog/cli-test/1.0/cli-test-1.0.pom cli-tests-mvn1-1594187811/org/jfrog/cli-test/maven-metadata.xml cli-tests-mvn1-1594187811/org/jfrog/cli-test/1.0/cli-test-1.0.jar]

'maven-metadata.xml' is probably created asynchronously and does not related to the Maven tests.
Lets exclude it from the Maven search spec.
