### PR TITLE
Fix TestArtifactoryReplicationCreate

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -3746,6 +3746,7 @@ func TestArtifactoryReplicationCreate(t *testing.T) {
 	result, err := servicesManager.GetReplication(tests.RtRepo1)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, result, tests.GetReplicationConfig())
+	// The Replicator may encrypt the password internally, therefore we should only check that the password is not empty
 	assert.NotEmpty(t, result[0].Password)
 
 	// Delete replication

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -3745,9 +3745,10 @@ func TestArtifactoryReplicationCreate(t *testing.T) {
 	assert.NoError(t, err)
 	result, err := servicesManager.GetReplication(tests.RtRepo1)
 	assert.NoError(t, err)
-	assert.ElementsMatch(t, result, tests.GetReplicationConfig())
 	// The Replicator may encrypt the password internally, therefore we should only check that the password is not empty
 	assert.NotEmpty(t, result[0].Password)
+	result[0].Password = ""
+	assert.ElementsMatch(t, result, tests.GetReplicationConfig())
 
 	// Delete replication
 	err = artifactoryCli.Exec("rpldel", tests.RtRepo1)

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -3746,6 +3746,7 @@ func TestArtifactoryReplicationCreate(t *testing.T) {
 	result, err := servicesManager.GetReplication(tests.RtRepo1)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, result, tests.GetReplicationConfig())
+	assert.NotEmpty(t, result[0].Password)
 
 	// Delete replication
 	err = artifactoryCli.Exec("rpldel", tests.RtRepo1)

--- a/utils/tests/artifactoryconsts.go
+++ b/utils/tests/artifactoryconsts.go
@@ -1430,7 +1430,6 @@ func GetReplicationConfig() []clientutils.ReplicationParams {
 		{
 			Url:                    *RtUrl,
 			Username:               "admin",
-			Password:               "password",
 			CronExp:                "0 0 12 * * ?",
 			RepoKey:                RtRepo1,
 			EnableEventReplication: false,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

In some Artifactory instances, the replicator encrypts the password internally. We should only check that the password is not empty.