### PR TITLE
Save Artifactory username as lowercase

### DIFF
--- a/artifactory/commands/config.go
+++ b/artifactory/commands/config.go
@@ -67,10 +67,6 @@ func (cc *ConfigCommand) SetDefaultDetails(defaultDetails *config.ArtifactoryDet
 
 func (cc *ConfigCommand) SetDetails(details *config.ArtifactoryDetails) *ConfigCommand {
 	cc.details = details
-	// Artifactory expects the username to be lower-cased. In case it is not,
-	// Artifactory will silently save it lower-cased, but the token creation
-	// REST API will fail with a non lower-cased username.
-	cc.details.User = strings.ToLower(cc.details.User)
 	return cc
 }
 
@@ -114,6 +110,11 @@ func (cc *ConfigCommand) Config() error {
 			return err
 		}
 	}
+
+	// Artifactory expects the username to be lower-cased. In case it is not,
+	// Artifactory will silently save it lower-cased, but the token creation
+	// REST API will fail with a non lower-cased username.
+	cc.details.User = strings.ToLower(cc.details.User)
 
 	if len(configurations) == 1 {
 		cc.details.IsDefault = true

--- a/artifactory/commands/config.go
+++ b/artifactory/commands/config.go
@@ -3,11 +3,13 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"github.com/jfrog/jfrog-client-go/auth"
 	"io/ioutil"
 	"reflect"
+	"strings"
 	"sync"
 	"syscall"
+
+	"github.com/jfrog/jfrog-client-go/auth"
 
 	"github.com/jfrog/jfrog-cli/artifactory/commands/generic"
 	"github.com/jfrog/jfrog-cli/artifactory/utils"
@@ -65,6 +67,10 @@ func (cc *ConfigCommand) SetDefaultDetails(defaultDetails *config.ArtifactoryDet
 
 func (cc *ConfigCommand) SetDetails(details *config.ArtifactoryDetails) *ConfigCommand {
 	cc.details = details
+	// Artifactory expects the username to be lower-cased. In case it is not,
+	// Artifactory will silently save it lower-cased, but the token creation
+	// REST API will fail with a non lower-cased username.
+	cc.details.User = strings.ToLower(cc.details.User)
 	return cc
 }
 

--- a/artifactory/commands/config_test.go
+++ b/artifactory/commands/config_test.go
@@ -2,12 +2,13 @@ package commands
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+
 	"github.com/jfrog/jfrog-cli/utils/cliutils"
 	"github.com/jfrog/jfrog-cli/utils/config"
 	"github.com/jfrog/jfrog-cli/utils/log"
 	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 func init() {
@@ -22,6 +23,22 @@ func TestBasicAuth(t *testing.T) {
 		ApiKey: "", SshKeyPath: "", AccessToken: "",
 		ServerId:  "test",
 		IsDefault: false}
+	configAndTest(t, &inputDetails)
+}
+
+func TestUsernameSavedLowercase(t *testing.T) {
+	inputDetails := config.ArtifactoryDetails{
+		Url:             "http://localhost:8080/artifactory",
+		DistributionUrl: "http://localhost:8080/distribution",
+		User:            "ADMIN", Password: "password",
+		ApiKey: "", SshKeyPath: "", AccessToken: "",
+		ServerId:  "test",
+		IsDefault: false}
+
+	outputConfig, err := configAndGetTestServer(t, &inputDetails, false)
+	assert.NoError(t, err)
+	outputConfig.User = strings.ToLower(outputConfig.User)
+
 	configAndTest(t, &inputDetails)
 }
 

--- a/artifactory/commands/config_test.go
+++ b/artifactory/commands/config_test.go
@@ -37,9 +37,7 @@ func TestUsernameSavedLowercase(t *testing.T) {
 
 	outputConfig, err := configAndGetTestServer(t, &inputDetails, false)
 	assert.NoError(t, err)
-	outputConfig.User = strings.ToLower(outputConfig.User)
-
-	configAndTest(t, &inputDetails)
+	assert.Equal(t, outputConfig.User, "admin", "The config command is supposed to save username as lowercase")
 }
 
 func TestApiKey(t *testing.T) {

--- a/artifactory/commands/testdata/jfrog-cli.conf
+++ b/artifactory/commands/testdata/jfrog-cli.conf
@@ -4,8 +4,7 @@
       "url": "http://localhost:8081/artifactory/",
       "user": "admin",
       "password": "AP2xjNFZW3iRzycZLQQ8HDGctAH",
-      "serverId": "local",
-      "isDefault": false
+      "serverId": "local"
     },
     {
       "url": "http://localhost:8082/artifactory/",
@@ -15,5 +14,5 @@
       "isDefault": true
     }
   ],
-  "version": "2"
+  "version": "3"
 }

--- a/utils/cliutils/utils.go
+++ b/utils/cliutils/utils.go
@@ -3,14 +3,15 @@ package cliutils
 import (
 	"bytes"
 	"fmt"
-	serviceutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
-	"github.com/jfrog/jfrog-client-go/utils/io/content"
-	"github.com/jfrog/jfrog-client-go/utils/prompt"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	serviceutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
+	"github.com/jfrog/jfrog-client-go/utils/io/content"
+	"github.com/jfrog/jfrog-client-go/utils/prompt"
 
 	"github.com/codegangsta/cli"
 	"github.com/jfrog/jfrog-cli/utils/summary"
@@ -251,7 +252,7 @@ func GetVersion() string {
 }
 
 func GetConfigVersion() string {
-	return "2"
+	return "3"
 }
 
 func GetDocumentationMessage() string {

--- a/utils/config/config_test.go
+++ b/utils/config/config_test.go
@@ -2,16 +2,16 @@ package config
 
 import (
 	"encoding/json"
-	"github.com/jfrog/jfrog-cli/utils/cliutils"
-	"github.com/jfrog/jfrog-cli/utils/log"
-	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
-	"strconv"
 	"testing"
+
+	"github.com/jfrog/jfrog-cli/utils/cliutils"
+	"github.com/jfrog/jfrog-cli/utils/log"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -38,9 +38,9 @@ func TestCovertConfigV0ToV1(t *testing.T) {
 	`
 	content, err := convertConfigV0toV1([]byte(configV0))
 	assert.NoError(t, err)
-	configV1 := new(ConfigV2)
+	configV1 := new(ConfigV3)
 	assert.NoError(t, json.Unmarshal(content, &configV1))
-	assertionHelper(t, configV1, 1, false)
+	assertionHelper(t, configV1, "1", false)
 }
 
 func TestCovertConfigV0ToV1EmptyArtifactory(t *testing.T) {
@@ -55,17 +55,19 @@ func TestCovertConfigV0ToV1EmptyArtifactory(t *testing.T) {
 	`
 	content, err := convertConfigV0toV1([]byte(configV0))
 	assert.NoError(t, err)
-	configV1 := new(ConfigV2)
+	configV1 := new(ConfigV3)
 	assert.NoError(t, json.Unmarshal(content, &configV1))
 }
 
-func TestConvertConfigV1ToV2(t *testing.T) {
+func TestConvertConfigV1ToV3(t *testing.T) {
+	// The Artifactory username is uppercase intentionally,
+	// to test the lowercase conversion to version 3.
 	config := `
 		{
 		  "artifactory": [
 			{
 			  "url": "http://localhost:8080/artifactory/",
-			  "user": "user",
+			  "user": "USER",
 			  "password": "password",
 			  "serverId": "` + DefaultServerId + `",
 			  "isDefault": true
@@ -87,9 +89,12 @@ func TestConvertConfigV1ToV2(t *testing.T) {
 
 	content, err := convertIfNeeded([]byte(config))
 	assert.NoError(t, err)
-	configV2 := new(ConfigV2)
-	assert.NoError(t, json.Unmarshal(content, &configV2))
-	assertionHelper(t, configV2, 2, false)
+	configV3 := new(ConfigV3)
+	assert.NoError(t, json.Unmarshal(content, &configV3))
+	assertionHelper(t, configV3, cliutils.GetConfigVersion(), false)
+
+	// The conversion to version 3, turns the Artifactory usernames to lowercase.
+	assert.Equal(t, configV3.Artifactory[0].User, "user")
 
 	assertCertsMigrationAndBackupCreation(t)
 }
@@ -124,9 +129,9 @@ func TestConvertConfigV0ToV2(t *testing.T) {
 
 	content, err := convertIfNeeded([]byte(configV0))
 	assert.NoError(t, err)
-	configV2 := new(ConfigV2)
-	assert.NoError(t, json.Unmarshal(content, &configV2))
-	assertionHelper(t, configV2, 2, false)
+	ConfigV3 := new(ConfigV3)
+	assert.NoError(t, json.Unmarshal(content, &ConfigV3))
+	assertionHelper(t, ConfigV3, cliutils.GetConfigVersion(), false)
 	assertCertsMigrationAndBackupCreation(t)
 }
 
@@ -157,10 +162,10 @@ func TestConfigEncryption(t *testing.T) {
 	verifyEncryptionStatus(t, originalConfig, readConfig, false)
 }
 
-func readConfFromFile(t *testing.T) *ConfigV2 {
+func readConfFromFile(t *testing.T) *ConfigV3 {
 	confFilePath, err := getConfFilePath()
 	assert.NoError(t, err)
-	config := new(ConfigV2)
+	config := new(ConfigV3)
 	assert.FileExists(t, confFilePath)
 	content, err := fileutils.ReadFile(confFilePath)
 	assert.NoError(t, err)
@@ -205,7 +210,7 @@ func TestGetArtifactoriesFromConfig(t *testing.T) {
 	`
 	content, err := convertIfNeeded([]byte(config))
 	assert.NoError(t, err)
-	configV1 := new(ConfigV2)
+	configV1 := new(ConfigV3)
 	assert.NoError(t, json.Unmarshal(content, &configV1))
 	serverDetails, err := GetDefaultConfiguredArtifactoryConf(configV1.Artifactory)
 	assert.NoError(t, err)
@@ -235,8 +240,8 @@ func TestGetJfrogDependenciesPath(t *testing.T) {
 	assert.Equal(t, expectedDependenciesPath, dependenciesPath)
 }
 
-func assertionHelper(t *testing.T, convertedConfig *ConfigV2, expectedVersion int, expectedEnc bool) {
-	assert.Equal(t, strconv.Itoa(expectedVersion), convertedConfig.Version)
+func assertionHelper(t *testing.T, convertedConfig *ConfigV3, expectedVersion string, expectedEnc bool) {
+	assert.Equal(t, expectedVersion, convertedConfig.Version)
 	assert.Equal(t, expectedEnc, convertedConfig.Enc)
 
 	rtConverted := convertedConfig.Artifactory
@@ -257,7 +262,7 @@ func assertionHelper(t *testing.T, convertedConfig *ConfigV2, expectedVersion in
 func TestHandleSecrets(t *testing.T) {
 	masterKey := "randomkeywithlengthofexactly32!!"
 
-	original := new(ConfigV2)
+	original := new(ConfigV3)
 	original.Artifactory = []*ArtifactoryDetails{{User: "user", Password: "password", Url: "http://localhost:8080/artifactory/", AccessToken: "accessToken",
 		RefreshToken: "refreshToken", ApiKey: "apiKEY", SshPassphrase: "sshPass"}}
 	original.Bintray = &BintrayDetails{ApiUrl: "APIurl", Key: "bintrayKey"}
@@ -274,16 +279,16 @@ func TestHandleSecrets(t *testing.T) {
 	verifyEncryptionStatus(t, original, newConf, false)
 }
 
-func copyConfig(t *testing.T, original *ConfigV2) *ConfigV2 {
+func copyConfig(t *testing.T, original *ConfigV3) *ConfigV3 {
 	b, err := json.Marshal(&original)
 	assert.NoError(t, err)
-	newConf := new(ConfigV2)
+	newConf := new(ConfigV3)
 	err = json.Unmarshal(b, &newConf)
 	assert.NoError(t, err)
 	return newConf
 }
 
-func verifyEncryptionStatus(t *testing.T, original, actual *ConfigV2, encryptionExpected bool) {
+func verifyEncryptionStatus(t *testing.T, original, actual *ConfigV3, encryptionExpected bool) {
 	var equals []bool
 	for i := range actual.Artifactory {
 		if original.Artifactory[i].Password != "" {

--- a/utils/config/config_test.go
+++ b/utils/config/config_test.go
@@ -93,8 +93,7 @@ func TestConvertConfigV1ToV3(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(content, &configV3))
 	assertionHelper(t, configV3, cliutils.GetConfigVersion(), false)
 
-	// The conversion to version 3, turns the Artifactory usernames to lowercase.
-	assert.Equal(t, configV3.Artifactory[0].User, "user")
+	assert.Equal(t, "user", configV3.Artifactory[0].User, "The config conversion to version 3 is supposed to save the username as lowercase")
 
 	assertCertsMigrationAndBackupCreation(t)
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR fixes https://github.com/jfrog/jfrog-cli/issues/780
This fix includes the following twi changes:
1. The **jfrog rt c** command saves the username as lowercase.
2. Converts the stored config, so that the usernames are converted to lowercase.