### PR TITLE
Use maven-2-default layout instead of gradle-default

### DIFF
--- a/artifactory/commands/repository/template.go
+++ b/artifactory/commands/repository/template.go
@@ -162,7 +162,7 @@ const (
 	ComposerDefaultRepoLayout = "composer-default"
 	ConanDefaultRepoLayout    = "conan-default"
 	GoDefaultRepoLayout       = "go-default"
-	GradleDefaultRepoLayout   = "gradle-default"
+	GradleDefaultRepoLayout   = "maven-2-default"
 	IvyDefaultRepoLayout      = "ivy-default"
 	Maven1DefaultRepoLayout   = "maven-1-default"
 	Maven2DefaultRepoLayout   = "maven-2-default"

--- a/testdata/gradle_repository_config.json
+++ b/testdata/gradle_repository_config.json
@@ -1,7 +1,7 @@
 {
   "key": "${GRADLE_REPO}",
   "packageType": "gradle",
-  "repoLayoutRef": "gradle-default",
+  "repoLayoutRef": "maven-2-default",
   "enableNpmSupport": true,
   "rclass": "local"
 }


### PR DESCRIPTION
Replacing gradle-default repository layout with maven-2-default due to gradle-default deprecation.