### PR TITLE
Bugfix - delete props command always returns a failure

### DIFF
--- a/artifactory/commands/generic/deleteprops.go
+++ b/artifactory/commands/generic/deleteprops.go
@@ -43,6 +43,6 @@ func (deleteProps *DeletePropsCommand) Run() error {
 	if totalLengthErr != nil {
 		return totalLengthErr
 	}
-	result.SetFailCount(totalLength)
+	result.SetFailCount(totalLength - success)
 	return err
 }


### PR DESCRIPTION
Although the command itself was executed successfully the return status
was always set to "failure" due to missing subtraction
of the success count.

- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
