### PR TITLE
Set/Delete props unified errors output

### DIFF
--- a/artifactory/commands/generic/deleteprops.go
+++ b/artifactory/commands/generic/deleteprops.go
@@ -30,9 +30,9 @@ func (deleteProps *DeletePropsCommand) Run() error {
 	if err != nil {
 		return err
 	}
-	reader, searchErr := searchItems(deleteProps.Spec(), servicesManager)
-	if searchErr != nil {
-		return searchErr
+	reader, err := searchItems(deleteProps.Spec(), servicesManager)
+	if err != nil {
+		return err
 	}
 	defer reader.Close()
 	propsParams := GetPropsParams(reader, deleteProps.props)

--- a/artifactory/commands/generic/deleteprops.go
+++ b/artifactory/commands/generic/deleteprops.go
@@ -40,9 +40,9 @@ func (deleteProps *DeletePropsCommand) Run() error {
 	result := deleteProps.Result()
 	result.SetSuccessCount(success)
 	totalLength, totalLengthErr := reader.Length()
+	result.SetFailCount(totalLength - success)
 	if totalLengthErr != nil {
 		return totalLengthErr
 	}
-	result.SetFailCount(totalLength - success)
 	return err
 }

--- a/artifactory/commands/generic/setprops.go
+++ b/artifactory/commands/generic/setprops.go
@@ -32,6 +32,9 @@ func (setProps *SetPropsCommand) Run() error {
 	}
 
 	reader, searchErr := searchItems(setProps.Spec(), servicesManager)
+	if searchErr != nil {
+		return searchErr
+	}
 	defer reader.Close()
 	propsParams := GetPropsParams(reader, setProps.props)
 	success, err := servicesManager.SetProps(propsParams)
@@ -40,9 +43,6 @@ func (setProps *SetPropsCommand) Run() error {
 	result.SetSuccessCount(success)
 	totalLength, totalLengthErr := reader.Length()
 	result.SetFailCount(totalLength - success)
-	if err == nil {
-		return searchErr
-	}
 	if totalLengthErr != nil {
 		return totalLengthErr
 	}

--- a/artifactory/commands/generic/setprops.go
+++ b/artifactory/commands/generic/setprops.go
@@ -31,9 +31,9 @@ func (setProps *SetPropsCommand) Run() error {
 		return err
 	}
 
-	reader, searchErr := searchItems(setProps.Spec(), servicesManager)
-	if searchErr != nil {
-		return searchErr
+	reader, err := searchItems(setProps.Spec(), servicesManager)
+	if err != nil {
+		return err
 	}
 	defer reader.Close()
 	propsParams := GetPropsParams(reader, setProps.props)


### PR DESCRIPTION
Set props command could have returned a none (nill) error instead of the totalLengthErr
that occurred.
The failCount of delete props command was not set in case of returning an error.
For consistency it is now set before the return error statement like in the set props command logic.

- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
