### PR TITLE
TestSignReleaseBundle - accept STORED status

### DIFF
--- a/distribution_test.go
+++ b/distribution_test.go
@@ -293,15 +293,12 @@ func TestSignReleaseBundle(t *testing.T) {
 	// Create a release bundle without --sign and make sure it is not signed
 	runRb(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/b1.in")
 	distributableResponse := inttestutils.GetLocalBundle(t, tests.BundleName, bundleVersion, distHttpDetails)
-	assert.NotNil(t, distributableResponse)
-	assert.Equal(t, inttestutils.Open, distributableResponse.State)
+	inttestutils.AssertReleaseBundleOpen(t, distributableResponse)
 
 	// Sign the release bundle and make sure it is signed
 	runRb(t, "rbs", tests.BundleName, bundleVersion)
 	distributableResponse = inttestutils.GetLocalBundle(t, tests.BundleName, bundleVersion, distHttpDetails)
-	assert.NotNil(t, distributableResponse)
-
-	assert.True(t, distributableResponse.State == inttestutils.Signed || distributableResponse.State == inttestutils.ReadyForDistribution)
+	inttestutils.AssertReleaseBundleSigned(t, distributableResponse)
 
 	// Cleanup
 	cleanDistributionTest(t)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

TestSignReleaseBundle - accept STORED status, that is the status of a release bundle before Xray scanning.