### PR TITLE
Add Chocolatey package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ artifactory/utils/pip/dependencies/deptreescript.go
 
 # JFrog executable
 jfrog
+jfrog.exe
 
 # Vim
 *~
@@ -21,3 +22,7 @@ jfrog
 
 # IOS
 *.DS_Store
+
+# Chocolatey build files
+build/chocolatey/tools/
+*.nupkg

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,5 @@ jfrog.exe
 *.DS_Store
 
 # Chocolatey build files
-build/chocolatey/tools/
+build/chocolatey/tools/LICENSE
 *.nupkg

--- a/build/chocolatey/README.md
+++ b/build/chocolatey/README.md
@@ -1,0 +1,38 @@
+# Building the Chocolatey package
+
+Since the build is run in Jenkins in a Linux environment, the Chocolatey package
+is built using the unofficial Docker image [linuturk/mono-choco][mono-choco]. The
+official [Dockerfile][choco-dockerfile] was [contributed][choco-dockerfile-pr] by the
+maintainer of the unofficial image and is pending a [PR][choco-image-pr] to become
+the official Docker image.
+
+To generate a package locally, either first compile or download the Windows executable
+and place it in _build/chocolatey/tools_ directory.
+
+With Docker:
+
+```bash
+cd build/chocolatey
+docker run --rm -it -v $(pwd):/work -w /work linuturk/mono-choco pack version=<version>
+```
+
+With `choco` on Windows
+
+```powershell
+cd build\chocolatey
+choco pack version=<version>
+```
+
+This will create the file _build/chocolatey/jfrog-cli.\<version\>.nupkg which can be
+installed with Chcolatey
+
+```powershell
+choco install jfrog-cli.<version>.nupkg
+```
+
+See Chocolatey's official documenattion [here](https://chocolatey.org/docs/create-packages)
+
+[choco-dockerfile-pr]: https://github.com/chocolatey/choco/pull/1153
+[choco-dockerfile]: https://github.com/chocolatey/choco/tree/master/docker
+[choco-image-pr]: https://github.com/chocolatey/choco/issues/1718
+[mono-choco]: https://github.com/Linuturk/mono-choco/

--- a/build/chocolatey/jfrog-cli.nuspec
+++ b/build/chocolatey/jfrog-cli.nuspec
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>jfrog-cli</id>
+    <version>$version$</version>
+    <packageSourceUrl>https://github.com/jfrog/jfrog-cli</packageSourceUrl>
+    <title>JFrog CLI</title>
+    <authors>JFrog Ltd</authors>
+    <owners>JFrog Ltd</owners>
+    <projectUrl>https://www.jfrog.com/confluence/display/CLI/JFrog+CLI</projectUrl>
+    <licenseUrl>https://github.com/jfrog/jfrog-cli-go/blob/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <bugTrackerUrl>https://github.com/jfrog/jfrog-cli/issues</bugTrackerUrl>
+    <tags>JFrog CLI admin</tags>
+    <summary>JFrog CLI provides a simple interface that automates access to JFrog products: JFrog Artifactory, JFrog Mission Control, JFrog Bintray and JFrog Xray.</summary>
+    <description><![CDATA[
+JFrog CLI is a compact and smart client that provides a simple interface that automates access to Artifactory, Bintray and Mission Control through their respective REST APIs. By using the JFrog CLI, you can greatly simplify your automation scripts making them more readable and easier to maintain. Several features of the JFrog CLI makes your scripts more efficient and reliable:
+
+* Multi-threaded upload and download of artifacts make builds run faster
+* Checksum optimization reduces redundant file transfers
+* Wildcards and regular expressions give you an easy way to collect all the artifacts you wish to upload or download.
+* "Dry run" gives you a preview of file transfer operations before you actually run them
+]]></description>
+    <releaseNotes>https://github.com/jfrog/jfrog-cli/commits/master</releaseNotes>
+    <copyright> Copyright 2018 JFrog Ltd.</copyright>
+  </metadata>
+  <files>
+    <file src="tools/**" target="tools" />
+  </files>
+</package>

--- a/build/chocolatey/tools/VERIFICATION.txt
+++ b/build/chocolatey/tools/VERIFICATION.txt
@@ -1,0 +1,23 @@
+VERIFICATION
+
+This is the official package published by JFrog, the application vendor.
+
+https://github.com/jfrog/jfrog-cli/tree/master/build/chocolatey
+
+The executable is signed by JFrog Ltd., with the following certificate chain
+
+Signing Certificate Chain:
+    Issued to: VeriSign Class 3 Public Primary Certification Authority - G5
+    Issued by: VeriSign Class 3 Public Primary Certification Authority - G5
+    Expires:   Wed Jul 16 18:59:59 2036
+    SHA1 hash: 4EB6D578499B1CCF5F581EAD56BE3D9B6744A5E5
+
+        Issued to: Symantec Class 3 SHA256 Code Signing CA
+        Issued by: VeriSign Class 3 Public Primary Certification Authority - G5
+        Expires:   Sat Dec 09 18:59:59 2023
+        SHA1 hash: 007790F6561DAD89B0BCD85585762495E358F8A5
+
+            Issued to: JFrog Ltd.
+            Issued by: Symantec Class 3 SHA256 Code Signing CA
+            Expires:   Sat Nov 27 18:59:59 2021
+            SHA1 hash: 2B0BF2BE8D00DE2BF0E123AAAA4A6BCA7DED1287


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----

This PR is for #70. Since there are no changes to the application code, I didn't run/write any tests or need to run `gofmt`. I have verified that the Chocolatey package built via the Docker method being added in Jenkinsfile can be installed with `choco install`.

There is a README added in _build/chocolatey_ with the commands to package locally on either Linux/Docker or Windows/Powershell.

The new `publishChocoPackage` function in _Jenkinsfile_ requires a Chocolatey developer API key to be saved as a Credential in Jenkins, named **choco-api-key**. The process to take over as the package maintainer is documented [here](https://chocolatey.org/docs/package-triage-process#i-want-to-take-overhelp-with-package-maintenance-for-my-software). I will also sending a message to the site admins there that we're working on transferring the package to you.