### PR TITLE
Bugfix - docker pull fails to collect buildinfo from remote repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The types are:
 | `-test.nuget` | Nuget tests |
 | `-test.plugins` | Plugins tests |
 
-* Running the tests will create builds and repositories with timestamps, 
+* Running the tests will create builds and repositories with timestamps,
 for example: `cli-tests-rt1-1592990748` and `cli-tests-rt2-1592990748`.<br/>
 Once the tests are completed, the content of these repositories will be deleted.
 
@@ -157,7 +157,8 @@ In addition to [general optional flags](#Usage) you *must* use the following doc
 | --- | --- |
 | `-rt.dockerRepoDomain` | Artifactory Docker registry domain. |
 | `-rt.dockerVirtualRepo` | Artifactory Docker virtual repository name. |
-| `-rt.dockerTargetRepo` | Artifactory Docker repository name. |
+| `-rt.dockerRemoteRepo` | Artifactory Docker remote repository name. |
+| `-rt.dockerTargetRepo` | Artifactory Docker local repository name. |
 
 ##### Examples
 To run docker tests execute the following command (fill out the missing parameters as described below).

--- a/docker_test.go
+++ b/docker_test.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	"os"
+	"path"
+	"strings"
+	"testing"
+
 	gofrogcmd "github.com/jfrog/gofrog/io"
 	"github.com/jfrog/jfrog-cli-core/artifactory/commands/generic"
 	"github.com/jfrog/jfrog-cli-core/artifactory/spec"
@@ -9,10 +14,6 @@ import (
 	"github.com/jfrog/jfrog-cli/inttestutils"
 	"github.com/jfrog/jfrog-cli/utils/tests"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"path"
-	"strings"
-	"testing"
 )
 
 func InitDockerTests() {
@@ -137,7 +138,7 @@ func TestDockerFatManifestPull(t *testing.T) {
 	buildNumber := "1"
 
 	// Pull docker image using docker client
-	artifactoryCli.Exec("docker-pull", imageTag, *tests.DockerVirtualRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber)
+	artifactoryCli.Exec("docker-pull", imageTag, *tests.DockerRemoteRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber)
 	artifactoryCli.Exec("build-publish", tests.DockerBuildName, buildNumber)
 
 	// Validate

--- a/docker_test.go
+++ b/docker_test.go
@@ -132,13 +132,13 @@ func TestDockerClientApiVersionCmd(t *testing.T) {
 
 func TestDockerFatManifestPull(t *testing.T) {
 	initDockerTest(t)
-
+	for _, dockerRepo := range [...]string{*tests.DockerRemoteRepo, *tests.DockerVirtualRepo} {
 	imageName := "traefik"
 	imageTag := path.Join(*tests.DockerRepoDomain, imageName+":2.2")
 	buildNumber := "1"
 
 	// Pull docker image using docker client
-	artifactoryCli.Exec("docker-pull", imageTag, *tests.DockerRemoteRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber)
+	artifactoryCli.Exec("docker-pull", imageTag, dockerRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber)
 	artifactoryCli.Exec("build-publish", tests.DockerBuildName, buildNumber)
 
 	// Validate
@@ -147,6 +147,7 @@ func TestDockerFatManifestPull(t *testing.T) {
 
 	inttestutils.DockerTestCleanup(artifactoryDetails, artHttpDetails, imageName, tests.DockerBuildName)
 	inttestutils.DeleteTestDockerImage(imageTag)
+	}
 }
 
 func TestDockerPromote(t *testing.T) {

--- a/gradle_test.go
+++ b/gradle_test.go
@@ -1,12 +1,11 @@
 package main
 
 import (
+	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
 
 	"github.com/stretchr/testify/assert"
 

--- a/gradle_test.go
+++ b/gradle_test.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
 
 	"github.com/stretchr/testify/assert"
 

--- a/pipelines.yml
+++ b/pipelines.yml
@@ -142,7 +142,7 @@ pipelines:
             - cd $res_jfrogCliGit_resourcePath
             - docker version
             - *CREATE_RT_ACCESS_TOKEN
-            - env -i PATH=$PATH M2_HOME=$M2_HOME HOME=$HOME DOCKER_CLI_EXPERIMENTAL=enabled `which go` test -v -timeout 0 -test.docker -rt.url=$int_jfrog_rt_url -rt.accessToken=$(< rtToken) -rt.dockerRepoDomain=ecosysjfrog-docker-virtual.jfrog.io -rt.dockerVirtualRepo=docker-virtual -rt.dockerTargetRepo=docker-local  -rt.dockerRemoteRepo=docker-remote
+            - env -i PATH=$PATH M2_HOME=$M2_HOME HOME=$HOME DOCKER_CLI_EXPERIMENTAL=enabled `which go` test -v -timeout 0 -test.docker -rt.url=$int_jfrog_rt_url -rt.accessToken=$(< rtToken) -rt.dockerRepoDomain=ecosysjfrog-docker-virtual.jfrog.io -rt.dockerVirtualRepo=docker-virtual -rt.dockerTargetRepo=docker-local -rt.dockerRemoteRepo=docker-remote
 
       # Parallel tests
       - name: NuGet

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	corelog "github.com/jfrog/jfrog-cli-core/utils/log"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	corelog "github.com/jfrog/jfrog-cli-core/utils/log"
 
 	"github.com/jfrog/jfrog-cli-core/artifactory/commands/generic"
 	"github.com/jfrog/jfrog-cli-core/artifactory/spec"
@@ -53,6 +54,7 @@ var TestGradle *bool
 var TestMaven *bool
 var DockerRepoDomain *string
 var DockerVirtualRepo *string
+var DockerRemoteRepo *string
 var DockerTargetRepo *string
 var TestNuget *bool
 var HideUnitTestLog *bool
@@ -84,6 +86,7 @@ func init() {
 	TestMaven = flag.Bool("test.maven", false, "Test Maven")
 	DockerRepoDomain = flag.String("rt.dockerRepoDomain", "", "Docker repository domain")
 	DockerVirtualRepo = flag.String("rt.dockerVirtualRepo", "", "Docker virtual repo")
+	DockerRemoteRepo = flag.String("rt.dockerRemoteRepo", "", "Docker remote repo")
 	DockerTargetRepo = flag.String("rt.dockerTargetRepo", "", "Docker local repo")
 	TestNuget = flag.Bool("test.nuget", false, "Test Nuget")
 	HideUnitTestLog = flag.Bool("test.hideUnitTestLog", false, "Hide unit tests logs and print it in a file")


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
