### PR TITLE
Make username optional in access-token-create

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -2708,7 +2708,7 @@ func accessTokenCreateCmd(c *cli.Context) error {
 		return err
 	}
 
-	if c.NArg() != 1 {
+	if c.NArg() > 1 {
 		return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 	}
 
@@ -2716,12 +2716,18 @@ func accessTokenCreateCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	var userName string
+	if c.NArg() > 0 {
+		userName = c.Args().Get(0)
+	} else {
+		userName = rtDetails.GetUrl()
+	}
 	expiry, err := cliutils.GetIntFlagValue(c, "expiry", cliutils.TokenExpiry)
 	if err != nil {
 		return err
 	}
 	accessTokenCreateCmd := generic.NewAccessTokenCreateCommand()
-	accessTokenCreateCmd.SetUserName(c.Args().Get(0)).SetRtDetails(rtDetails).SetRefreshable(c.Bool("refreshable")).SetExpiry(expiry).SetGroups(c.String("groups")).SetAudience(c.String("audience")).SetGrantAdmin(c.Bool("grant-admin"))
+	accessTokenCreateCmd.SetUserName(userName).SetRtDetails(rtDetails).SetRefreshable(c.Bool("refreshable")).SetExpiry(expiry).SetGroups(c.String("groups")).SetAudience(c.String("audience")).SetGrantAdmin(c.Bool("grant-admin"))
 	err = commands.Exec(accessTokenCreateCmd)
 	if err != nil {
 		return err

--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -2716,6 +2716,8 @@ func accessTokenCreateCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	// If the username is provided as an argument, then it is used when creating the token. 
+	// If not, then the configured username (or the the value of the --user option) is used.
 	var userName string
 	if c.NArg() > 0 {
 		userName = c.Args().Get(0)

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -4093,10 +4093,25 @@ func TestAccessTokenCreate(t *testing.T) {
 	// Restore previous logger when the function returns
 	defer log.SetLogger(previousLog)
 
-	// Create access token for current user
-	err := artifactoryCli.Exec("atc", *tests.RtUser)
+	// Create access token for current user, implicitly
+	err := artifactoryCli.Exec("atc")
 	assert.NoError(t, err)
 
+	// Check access token
+	checkAccessToken(t, buffer)
+
+	// Create access token for current user, explicitly
+	err = artifactoryCli.Exec("atc", *tests.RtUser)
+	assert.NoError(t, err)
+
+	// Check access token
+	checkAccessToken(t, buffer)
+
+	// Cleanup
+	cleanArtifactoryTest()
+}
+
+func checkAccessToken(t *testing.T, buffer *bytes.Buffer) {
 	// Write the command output to the origin
 	content := buffer.Bytes()
 	buffer.Reset()
@@ -4108,9 +4123,6 @@ func TestAccessTokenCreate(t *testing.T) {
 	// Try ping with the new token
 	err = tests.NewJfrogCli(execMain, "jfrog rt", "--url="+*tests.RtUrl+" --access-token="+token).Exec("ping")
 	assert.NoError(t, err)
-
-	// Cleanup
-	cleanArtifactoryTest()
 }
 
 func TestRefreshableTokens(t *testing.T) {

--- a/docs/artifactory/accesstokencreate/help.go
+++ b/docs/artifactory/accesstokencreate/help.go
@@ -2,7 +2,7 @@ package accesstokencreate
 
 const Description = "Creates an access token. By default an user-scoped token will be created, unless the --groups and/or --grant-admin options are specified."
 
-var Usage = []string{`jfrog rt atc <user name>`}
+var Usage = []string{"jfrog rt atc", "jfrog rt atc <user name>"}
 
 const Arguments string = `	user name
-		The user name for which this token is created.`
+		The user name for which this token is created. If not specified, the token will be created for the current user.`


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

`jfrog rt atc` - If username is not specified, use the current user