### PR TITLE
Avoid using "ParseArgs" for new syntax package manager commands.

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1108,10 +1108,7 @@ func mvnCmd(c *cli.Context) error {
 		if c.NArg() < 1 {
 			return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 		}
-		args, err := utils.ParseArgs(extractCommand(c))
-		if err != nil {
-			return errorutils.CheckError(err)
-		}
+		args := extractCommand(c)
 		// Validates the mvn command. If a config file is found, the only flags that can be used are build-name, build-number and module.
 		// Otherwise, throw an error.
 		if err := validateCommand(args, cliutils.GetBasicBuildToolsFlags()); err != nil {
@@ -1149,10 +1146,7 @@ func gradleCmd(c *cli.Context) error {
 		if c.NArg() < 1 {
 			return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 		}
-		args, err := utils.ParseArgs(extractCommand(c))
-		if err != nil {
-			return errorutils.CheckError(err)
-		}
+		args := extractCommand(c)
 		// Validates the gradle command. If a config file is found, the only flags that can be used are build-name, build-number and module.
 		// Otherwise, throw an error.
 		if err := validateCommand(args, cliutils.GetBasicBuildToolsFlags()); err != nil {
@@ -1283,10 +1277,8 @@ func nugetCmd(c *cli.Context) error {
 			return err
 		}
 
-		args, err := utils.ParseArgs(extractCommand(c))
-		if err != nil {
-			return errorutils.CheckError(err)
-		}
+		args := extractCommand(c)
+
 		// Validates the nuget command. If a config file is found, the only flags that can be used are build-name, build-number and module.
 		// Otherwise, throw an error.
 		if err := validateCommand(args, cliutils.GetLegacyNugetFlags()); err != nil {
@@ -1364,10 +1356,7 @@ func dotnetCmd(c *cli.Context) error {
 		return err
 	}
 
-	args, err := utils.ParseArgs(extractCommand(c))
-	if err != nil {
-		return errorutils.CheckError(err)
-	}
+	args := extractCommand(c)
 
 	filteredDotnetArgs, buildConfiguration, err := utils.ExtractBuildDetailsFromArgs(args)
 	if err != nil {
@@ -1424,10 +1413,7 @@ func npmInstallOrCiCmd(c *cli.Context, npmCmd *npm.NpmInstallOrCiCommand, npmLeg
 
 	if exists {
 		// Found a config file. Continue as native command.
-		args, err := utils.ParseArgs(extractCommand(c))
-		if err != nil {
-			return errorutils.CheckError(err)
-		}
+		args := extractCommand(c)
 		// Validates the npm command. If a config file is found, the only flags that can be used are threads, build-name, build-number and module.
 		// Otherwise, throw an error.
 		if err := validateCommand(args, cliutils.GetLegacyNpmFlags()); err != nil {
@@ -1473,10 +1459,7 @@ func npmPublishCmd(c *cli.Context) error {
 	}
 	if exists {
 		// Found a config file. Continue as native command.
-		args, err := utils.ParseArgs(extractCommand(c))
-		if err != nil {
-			return errorutils.CheckError(err)
-		}
+		args := extractCommand(c)
 		// Validates the npm command. If a config file is found, the only flags that can be used are build-name, build-number and module.
 		// Otherwise, throw an error.
 		if err := validateCommand(args, cliutils.GetLegacyNpmFlags()); err != nil {

--- a/npm_test.go
+++ b/npm_test.go
@@ -238,8 +238,8 @@ func validateNpmInstall(t *testing.T, npmTestParams npmTestParams) {
 	buildInfo := publishedBuildInfo.BuildInfo
 	if buildInfo.Modules == nil || len(buildInfo.Modules) == 0 {
 		// Case no module was created
-		assert.Fail(t, "npm install test with the arguments: \n%v \nexpected to have module with the following dependencies: \n%v \nbut has no modules: \n%v",
-			npmTestParams, expectedDependencies, buildInfo)
+		t.Error(fmt.Sprintf("npm install test with command '%s' and repo '%s' failed", npmTestParams.command, npmTestParams.repo))
+		return
 	}
 	// The checksums are ignored when comparing the actual and the expected
 	assert.Equal(t, len(expectedDependencies), len(buildInfo.Modules[0].Dependencies), "npm install test with the arguments: \n%v \nexpected to have the following dependencies: \n%v \nbut has: \n%v",

--- a/plugins/utils/signatureutils.go
+++ b/plugins/utils/signatureutils.go
@@ -108,7 +108,7 @@ func signaturesToCommands(signatures []*components.PluginSignature) []cli.Comman
 			Name:            sig.Name,
 			Usage:           sig.Usage,
 			SkipFlagParsing: true,
-			Action: getAction(*sig),
+			Action:          getAction(*sig),
 		})
 	}
 	return commands


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR is aimed at fixing https://github.com/jfrog/jfrog-cli/issues/888.
It appears that for package managers commands, such as **jfrog rt mvn**, which use the new, non-deprecated syntax (a.k.a native syntax), the *ParseArgs* function is not needed. More than that, it causes white-spaces to be removed from the command arguments. For the deprecated syntax though, this utility command is still needed.
This PR also includes the replacement of ```assert.Fail``` with ```t.Error``` in the npm tests. I noticed the old API causes a panic. This issue reviewed itself while finding an issue with my code.
