### PR TITLE
Fix occasional panic on TestInsecureTlsMavenBuild

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -1077,11 +1077,10 @@ func checkIfServerIsUp(port, proxyScheme string, useClientCerts bool) error {
 	}
 	client := &http.Client{Transport: tr}
 
-	for attempt := 0; attempt < 10; attempt++ {
+	for attempt := 0; attempt < 20; attempt++ {
 		log.Info("Checking if proxy server is up and running.", strconv.Itoa(attempt+1), "attempt.", "URL:", proxyScheme+"://localhost:"+port)
 		resp, err := client.Get(proxyScheme + "://localhost:" + port)
 		if err != nil {
-			attempt++
 			time.Sleep(time.Second)
 			continue
 		}
@@ -1089,7 +1088,6 @@ func checkIfServerIsUp(port, proxyScheme string, useClientCerts bool) error {
 		if resp.StatusCode != http.StatusOK {
 			continue
 		}
-
 		return nil
 	}
 	return fmt.Errorf("failed while waiting for the proxy server to be accessible")

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -1086,6 +1086,7 @@ func checkIfServerIsUp(port, proxyScheme string, useClientCerts bool) error {
 		}
 		resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
+			time.Sleep(time.Second)
 			continue
 		}
 		return nil

--- a/utils/tests/proxy/server/server.go
+++ b/utils/tests/proxy/server/server.go
@@ -197,7 +197,7 @@ func GetProxyHttpsPort() string {
 func startHttpsReverseProxy(proxyTarget string, requestClientCerts bool) error {
 	handler, err := getReverseProxyHandler(proxyTarget)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	// Starts a new Go routine
 	httpsMux, absPathCert, absPathKey, err := prepareHTTPSHandling(handler)

--- a/utils/tests/proxy/server/server.go
+++ b/utils/tests/proxy/server/server.go
@@ -2,6 +2,11 @@ package server
 
 import (
 	"crypto/tls"
+	"github.com/jfrog/jfrog-cli/utils/tests"
+	"github.com/jfrog/jfrog-cli/utils/tests/proxy/server/certificate"
+	"github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	clilog "github.com/jfrog/jfrog-client-go/utils/log"
 	"io"
 	"log"
 	"net"
@@ -10,11 +15,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-
-	"github.com/jfrog/jfrog-cli/utils/tests"
-	"github.com/jfrog/jfrog-cli/utils/tests/proxy/server/certificate"
-	"github.com/jfrog/jfrog-client-go/utils"
-	clilog "github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 type httpResponse func(rw http.ResponseWriter, req *http.Request)
@@ -156,22 +156,34 @@ func GetProxyHttpPort() string {
 	return port
 }
 
-func prepareHTTPSHandling(handler *httputil.ReverseProxy) (*http.ServeMux, string, string) {
+func prepareHTTPSHandling(handler *httputil.ReverseProxy) (httpsMux *http.ServeMux, absPathCert, absPathKey string, err error) {
 	// We can use the same handler for both HTTP and HTTPS
-	httpsMux := http.NewServeMux()
+	httpsMux = http.NewServeMux()
 	httpsMux.HandleFunc("/", handleReverseProxyHttps(handler))
-	absPathCert, absPathKey := CreateNewServerCertificates()
-	return httpsMux, absPathCert, absPathKey
+	absPathCert, absPathKey, err = CreateNewServerCertificates()
+	return
 }
 
-// Create new server certificates and returns the certificates path
-func CreateNewServerCertificates() (string, string) {
-	if _, err := os.Stat(certificate.CERT_FILE); os.IsNotExist(err) {
-		certificate.CreateNewCert()
+// Creates a server cerf file and cert key file.
+// Returns the absolute path of these two files.
+func CreateNewServerCertificates() (certFilePath, keyCertFilePath string, err error) {
+	certFilePath, err = filepath.Abs(certificate.CERT_FILE)
+	if errorutils.CheckError(err) != nil {
+		return
 	}
-	absPathCert, _ := filepath.Abs(certificate.CERT_FILE)
-	absPathKey, _ := filepath.Abs(certificate.KEY_FILE)
-	return absPathCert, absPathKey
+	keyCertFilePath, err = filepath.Abs(certificate.KEY_FILE)
+	if errorutils.CheckError(err) != nil {
+		return
+	}
+
+	if _, err = os.Stat(certFilePath); os.IsNotExist(err) {
+		err = certificate.CreateNewCert(certFilePath, keyCertFilePath)
+		if err != nil {
+			return
+		}
+	}
+	errorutils.CheckError(err)
+	return
 }
 
 func GetProxyHttpsPort() string {
@@ -182,13 +194,16 @@ func GetProxyHttpsPort() string {
 	return port
 }
 
-func startHttpsReverseProxy(proxyTarget string, requestClientCerts bool) {
+func startHttpsReverseProxy(proxyTarget string, requestClientCerts bool) error {
 	handler, err := getReverseProxyHandler(proxyTarget)
 	if err != nil {
 		panic(err)
 	}
 	// Starts a new Go routine
-	httpsMux, absPathCert, absPathKey := prepareHTTPSHandling(handler)
+	httpsMux, absPathCert, absPathKey, err := prepareHTTPSHandling(handler)
+	if err != nil {
+		return err
+	}
 
 	if requestClientCerts {
 		server := &http.Server{
@@ -198,14 +213,12 @@ func startHttpsReverseProxy(proxyTarget string, requestClientCerts bool) {
 				ClientAuth: tls.RequireAnyClientCert,
 			},
 		}
-
-		server.ListenAndServeTLS(absPathCert, absPathKey)
+		err = server.ListenAndServeTLS(absPathCert, absPathKey)
 	} else {
 		err = http.ListenAndServeTLS(":"+GetProxyHttpsPort(), absPathCert, absPathKey, httpsMux)
-		if err != nil {
-			panic(err)
-		}
 	}
+
+	return err
 }
 
 func StartLocalReverseHttpProxy(artifactoryUrl string, requestClientCerts bool) {
@@ -213,7 +226,10 @@ func StartLocalReverseHttpProxy(artifactoryUrl string, requestClientCerts bool) 
 		artifactoryUrl = "http://localhost:8081/artifactory/"
 	}
 	artifactoryUrl = utils.AddTrailingSlashIfNeeded(artifactoryUrl)
-	startHttpsReverseProxy(artifactoryUrl, requestClientCerts)
+	err := startHttpsReverseProxy(artifactoryUrl, requestClientCerts)
+	// Since this function is always executed in its own go routine,
+	// we panic when an error occurs.
+	panic(err)
 }
 
 func StartHttpProxy() {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR aims to fix the below panic, which is occasionally thrown when running the maven tests.
```
=== RUN   TestInsecureTlsMavenBuild
[Info] Reverse proxy URL: https://ecosysjfrog.jfrog.io/artifactory/
[Info] Checking if proxy server is up and running. 1 attempt. URL: https://localhost:1028
panic: open /Users/eyalb/dev/forks/jfrog-cli/naive_proxy_cert.pem: no such file or directory

goroutine 513 [running]:
github.com/jfrog/jfrog-cli/utils/tests/proxy/server.startHttpsReverseProxy(0x7ffc46508686, 0x29, 0x0)
	/Users/eyalb/dev/forks/jfrog-cli/utils/tests/proxy/server/server.go:206 +0x395
github.com/jfrog/jfrog-cli/utils/tests/proxy/server.StartLocalReverseHttpProxy(0x7ffc46508686, 0x29, 0x0)
	/Users/eyalb/dev/forks/jfrog-cli/utils/tests/proxy/server/server.go:216 +0x8c
created by github.com/jfrog/jfrog-cli.TestInsecureTlsMavenBuild
	/Users/eyalb/dev/forks/jfrog-cli/maven_test.go:104 +0xab
FAIL	github.com/jfrog/jfrog-cli	628.459s
FAIL
```
The issue is inconsistent and doesn't occur always. After implementing the code in this PR, I stopped seeing this error. I think the issue came from the existing implementation of the ```CreateNewCert ```, which I modified. I hope this fixes the issue completely. In case it doesn't, and the issue appears again, we'll keep investigating. In any case, I believe this is an improvement over the existing code.