### PR TITLE
Bug fix - User prompts in plugins are invisible

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1108,7 +1108,7 @@ func mvnCmd(c *cli.Context) error {
 		if c.NArg() < 1 {
 			return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 		}
-		args := extractCommand(c)
+		args := cliutils.ExtractCommand(c)
 		// Validates the mvn command. If a config file is found, the only flags that can be used are build-name, build-number and module.
 		// Otherwise, throw an error.
 		if err := validateCommand(args, cliutils.GetBasicBuildToolsFlags()); err != nil {
@@ -1146,7 +1146,7 @@ func gradleCmd(c *cli.Context) error {
 		if c.NArg() < 1 {
 			return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 		}
-		args := extractCommand(c)
+		args := cliutils.ExtractCommand(c)
 		// Validates the gradle command. If a config file is found, the only flags that can be used are build-name, build-number and module.
 		// Otherwise, throw an error.
 		if err := validateCommand(args, cliutils.GetBasicBuildToolsFlags()); err != nil {
@@ -1277,7 +1277,7 @@ func nugetCmd(c *cli.Context) error {
 			return err
 		}
 
-		args := extractCommand(c)
+		args := cliutils.ExtractCommand(c)
 
 		// Validates the nuget command. If a config file is found, the only flags that can be used are build-name, build-number and module.
 		// Otherwise, throw an error.
@@ -1356,7 +1356,7 @@ func dotnetCmd(c *cli.Context) error {
 		return err
 	}
 
-	args := extractCommand(c)
+	args := cliutils.ExtractCommand(c)
 
 	filteredDotnetArgs, buildConfiguration, err := utils.ExtractBuildDetailsFromArgs(args)
 	if err != nil {
@@ -1413,7 +1413,7 @@ func npmInstallOrCiCmd(c *cli.Context, npmCmd *npm.NpmInstallOrCiCommand, npmLeg
 
 	if exists {
 		// Found a config file. Continue as native command.
-		args := extractCommand(c)
+		args := cliutils.ExtractCommand(c)
 		// Validates the npm command. If a config file is found, the only flags that can be used are threads, build-name, build-number and module.
 		// Otherwise, throw an error.
 		if err := validateCommand(args, cliutils.GetLegacyNpmFlags()); err != nil {
@@ -1459,7 +1459,7 @@ func npmPublishCmd(c *cli.Context) error {
 	}
 	if exists {
 		// Found a config file. Continue as native command.
-		args := extractCommand(c)
+		args := cliutils.ExtractCommand(c)
 		// Validates the npm command. If a config file is found, the only flags that can be used are build-name, build-number and module.
 		// Otherwise, throw an error.
 		if err := validateCommand(args, cliutils.GetLegacyNpmFlags()); err != nil {
@@ -1671,7 +1671,7 @@ func goNativeCmd(c *cli.Context, configFilePath string) error {
 	if c.NArg() < 1 {
 		return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 	}
-	args := extractCommand(c)
+	args := cliutils.ExtractCommand(c)
 	// Validates the go command. If a config file is found, the only flags that can be used are build-name, build-number and module.
 	// Otherwise, throw an error.
 	if err := validateCommand(args, cliutils.GetLegacyGoFlags()); err != nil {
@@ -2457,7 +2457,7 @@ func curlCmd(c *cli.Context) error {
 	if c.NArg() < 1 {
 		return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 	}
-	curlCommand := curl.NewCurlCommand().SetArguments(extractCommand(c))
+	curlCommand := curl.NewCurlCommand().SetArguments(cliutils.ExtractCommand(c))
 	rtDetails, err := curlCommand.GetArtifactoryDetails()
 	if err != nil {
 		return err
@@ -2490,7 +2490,7 @@ func pipInstallCmd(c *cli.Context) error {
 
 	// Run command.
 	pipCmd := pip.NewPipInstallCommand()
-	pipCmd.SetRtDetails(rtDetails).SetRepo(pipConfig.TargetRepo()).SetArgs(extractCommand(c))
+	pipCmd.SetRtDetails(rtDetails).SetRepo(pipConfig.TargetRepo()).SetArgs(cliutils.ExtractCommand(c))
 	return commands.Exec(pipCmd)
 }
 
@@ -3336,12 +3336,6 @@ func createBuildConfiguration(c *cli.Context) *utils.BuildConfiguration {
 	buildConfiguration.BuildName, buildConfiguration.BuildNumber = utils.GetBuildNameAndNumber(buildNameArg, buildNumberArg)
 	buildConfiguration.Project = c.String("project")
 	return buildConfiguration
-}
-
-func extractCommand(c *cli.Context) (command []string) {
-	command = make([]string, len(c.Args()))
-	copy(command, c.Args())
-	return command
 }
 
 func deprecatedWarning(projectType utils.ProjectType, command, configCommand string) string {

--- a/plugins/utils/signatureutils.go
+++ b/plugins/utils/signatureutils.go
@@ -8,11 +8,13 @@ import (
 	"github.com/jfrog/jfrog-cli-core/plugins"
 	"github.com/jfrog/jfrog-cli-core/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
+	"github.com/jfrog/jfrog-cli/utils/cliutils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"io"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -116,14 +118,11 @@ func signaturesToCommands(signatures []*components.PluginSignature) []cli.Comman
 
 func getAction(sig components.PluginSignature) func(*cli.Context) error {
 	return func(c *cli.Context) error {
-		output, err := gofrogcmd.RunCmdOutput(
-			&SignatureCmd{
-				sig.ExecutablePath,
-				c.Args()})
-		if err == nil {
-			log.Output(output)
-		}
-		return err
+		cmd := exec.Command(sig.ExecutablePath, cliutils.ExtractCommand(c)...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		return cmd.Run()
 	}
 }
 

--- a/utils/cliutils/codegangstautils.go
+++ b/utils/cliutils/codegangstautils.go
@@ -24,3 +24,9 @@ func GetStringsArrFlagValue(c *cli.Context, flagName string) (resultArray []stri
 	}
 	return
 }
+
+func ExtractCommand(c *cli.Context) (command []string) {
+	command = make([]string, len(c.Args()))
+	copy(command, c.Args())
+	return command
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR fixes the following issue:
JFrog CLI Plugins which issue user prompts cannot be used with JFrog CLI, because the input prompts are invisible.
