### PR TITLE
Add NuGet v3 support

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1314,11 +1314,11 @@ func nugetLegacyCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	nugetCmd.SetBasicCommand(c.Args().Get(0)).SetArgAndFlags(c.String("nuget-args")).
+	nugetCmd.SetBasicCommand(c.Args().Get(0)).SetArgAndFlags(c.String(cliutils.NugetArgs)).
 		SetRepoName(c.Args().Get(1)).
 		SetBuildConfiguration(buildConfiguration).
-		SetSolutionPath(c.String("solution-root")).
-		SetUseNugetV2(c.Bool("nuget-v2-protocol")).
+		SetSolutionPath(c.String(cliutils.SolutionRoot)).
+		SetUseNugetV2(c.Bool(cliutils.LegacyNugetV2)).
 		SetRtDetails(rtDetails)
 
 	return commands.Exec(nugetCmd)

--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1267,12 +1267,8 @@ func nugetCmd(c *cli.Context) error {
 		if c.NArg() < 1 {
 			return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 		}
-		nugetConfig, err := utils.ReadResolutionOnlyConfiguration(configFilePath)
-		if err != nil {
-			return errors.New(fmt.Sprintf("Error occurred while attempting to read nuget-configuration file: %s", err.Error()))
-		}
-		// Set arg values.
-		rtDetails, err := nugetConfig.RtDetails()
+
+		rtDetails, targetRepo, useNugetV2, err := getNugetAndDotnetConfigFields(configFilePath)
 		if err != nil {
 			return err
 		}
@@ -1291,7 +1287,8 @@ func nugetCmd(c *cli.Context) error {
 		}
 
 		nugetCmd := dotnet.NewNugetCommand()
-		nugetCmd.SetRtDetails(rtDetails).SetRepoName(nugetConfig.TargetRepo()).SetBuildConfiguration(buildConfiguration).SetBasicCommand(filteredNugetArgs[0])
+		nugetCmd.SetRtDetails(rtDetails).SetRepoName(targetRepo).SetBuildConfiguration(buildConfiguration).
+			SetBasicCommand(filteredNugetArgs[0]).SetUseNugetV2(useNugetV2)
 		// Since we are using the values of the command's arguments and flags along the buildInfo collection process,
 		// we want to separate the actual NuGet basic command (restore/build...) from the arguments and flags
 		if len(filteredNugetArgs) > 1 {
@@ -1321,6 +1318,7 @@ func nugetLegacyCmd(c *cli.Context) error {
 		SetRepoName(c.Args().Get(1)).
 		SetBuildConfiguration(buildConfiguration).
 		SetSolutionPath(c.String("solution-root")).
+		SetUseNugetV2(c.Bool("nuget-v2-protocol")).
 		SetRtDetails(rtDetails)
 
 	return commands.Exec(nugetCmd)
@@ -1343,15 +1341,17 @@ func dotnetCmd(c *cli.Context) error {
 		return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 	}
 
-	// Get dotnet configuration.
-	dotnetConfig, err := utils.GetResolutionOnlyConfiguration(utils.Dotnet)
+	// Get configuration file path.
+	configFilePath, exists, err := utils.GetProjectConfFilePath(utils.Dotnet)
 	if err != nil {
+		return err
+	}
+	if !exists {
 		return errors.New(fmt.Sprintf("Error occurred while attempting to read dotnet-configuration file: %s\n"+
 			"Please run 'jfrog rt dotnet-config' command prior to running 'jfrog rt dotnet'.", err.Error()))
 	}
 
-	// Set arg values.
-	rtDetails, err := dotnetConfig.RtDetails()
+	rtDetails, targetRepo, useNugetV2, err := getNugetAndDotnetConfigFields(configFilePath)
 	if err != nil {
 		return err
 	}
@@ -1365,13 +1365,32 @@ func dotnetCmd(c *cli.Context) error {
 
 	// Run command.
 	dotnetCmd := dotnet.NewDotnetCoreCliCommand()
-	dotnetCmd.SetRtDetails(rtDetails).SetRepoName(dotnetConfig.TargetRepo()).SetBuildConfiguration(buildConfiguration).SetBasicCommand(filteredDotnetArgs[0])
+	dotnetCmd.SetRtDetails(rtDetails).SetRepoName(targetRepo).SetBuildConfiguration(buildConfiguration).
+		SetBasicCommand(filteredDotnetArgs[0]).SetUseNugetV2(useNugetV2)
 	// Since we are using the values of the command's arguments and flags along the buildInfo collection process,
 	// we want to separate the actual .NET basic command (restore/build...) from the arguments and flags
 	if len(filteredDotnetArgs) > 1 {
 		dotnetCmd.SetArgAndFlags(strings.Join(filteredDotnetArgs[1:], " "))
 	}
 	return commands.Exec(dotnetCmd)
+}
+
+func getNugetAndDotnetConfigFields(configFilePath string) (rtDetails *config.ArtifactoryDetails, targetRepo string, useNugetV2 bool, err error) {
+	vConfig, err := utils.ReadConfigFile(configFilePath, utils.YAML)
+	if err != nil {
+		return nil, "", false, errors.New(fmt.Sprintf("Error occurred while attempting to read nuget-configuration file: %s", err.Error()))
+	}
+	projectConfig, err := utils.GetRepoConfigByPrefix(configFilePath, utils.ProjectConfigResolverPrefix, vConfig)
+	if err != nil {
+		return nil, "", false, err
+	}
+	rtDetails, err = projectConfig.RtDetails()
+	if err != nil {
+		return nil, "", false, err
+	}
+	targetRepo = projectConfig.TargetRepo()
+	useNugetV2 = vConfig.GetBool(utils.ProjectConfigResolverPrefix + "." + "nugetV2")
+	return
 }
 
 func npmLegacyInstallCmd(c *cli.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v0.16.0
 
-replace github.com/jfrog/jfrog-cli-core => github.com/RobiNino/jfrog-cli-core v0.0.0-20201208100219-e326e02a4356
+replace github.com/jfrog/jfrog-cli-core => github.com/RobiNino/jfrog-cli-core nuget-v3
 
 // replace github.com/jfrog/gocmd => github.com/jfrog/gocmd master
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v0.16.0
 
-replace github.com/jfrog/jfrog-cli-core => github.com/RobiNino/jfrog-cli-core nuget-v3
+replace github.com/jfrog/jfrog-cli-core => github.com/jfrog/jfrog-cli-core dev
 
 // replace github.com/jfrog/gocmd => github.com/jfrog/gocmd master
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v0.16.0
 
-// replace github.com/jfrog/jfrog-cli-core => github.com/jfrog/jfrog-cli-core v1.1.2-0.20201118101632-f498d864d81b
+replace github.com/jfrog/jfrog-cli-core => github.com/RobiNino/jfrog-cli-core v0.0.0-20201208100219-e326e02a4356
 
 // replace github.com/jfrog/gocmd => github.com/jfrog/gocmd master
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/RobiNino/jfrog-cli-core v0.0.0-20201208100219-e326e02a4356 h1:cGd271p9CKABQBZirIlDYYt1l9RxfU5AXTbOLreepRM=
+github.com/RobiNino/jfrog-cli-core v0.0.0-20201208100219-e326e02a4356/go.mod h1:tazUzga9nleV1/SKxJ1CB8Dho6qjvMtuFz4XJ8R81j8=
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
@@ -40,8 +42,6 @@ github.com/jfrog/gocmd v0.1.17 h1:LGFihK2juVKiVGx7LQOig/r1eFik/n1+rL47bBhN240=
 github.com/jfrog/gocmd v0.1.17/go.mod h1:O8mGn5+aEC3ru2NzyTkZ0a6hL5EIai4NNjYNzyFz/4A=
 github.com/jfrog/gofrog v1.0.6 h1:yUDxSCw8gTK6vC4PvtG0HTnEOQJSZ+O4lWGCgkev1nU=
 github.com/jfrog/gofrog v1.0.6/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
-github.com/jfrog/jfrog-cli-core v1.1.2 h1:BfDJYS+3K+qhWy5c6iFM48UYRYtX+0VtFj80QzfmYwQ=
-github.com/jfrog/jfrog-cli-core v1.1.2/go.mod h1:tazUzga9nleV1/SKxJ1CB8Dho6qjvMtuFz4XJ8R81j8=
 github.com/jfrog/jfrog-client-go v0.15.0/go.mod h1:v365V7GVxhzgrirZAxg81bZB+PQZMOKrHLXkon6vKp4=
 github.com/jfrog/jfrog-client-go v0.16.0 h1:b84v5ybkKUpcfP+dKjtOJNqn7l/je/IHVmYrsb5Rwo8=
 github.com/jfrog/jfrog-client-go v0.16.0/go.mod h1:v365V7GVxhzgrirZAxg81bZB+PQZMOKrHLXkon6vKp4=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/RobiNino/jfrog-cli-core v0.0.0-20201208100219-e326e02a4356 h1:cGd271p9CKABQBZirIlDYYt1l9RxfU5AXTbOLreepRM=
-github.com/RobiNino/jfrog-cli-core v0.0.0-20201208100219-e326e02a4356/go.mod h1:tazUzga9nleV1/SKxJ1CB8Dho6qjvMtuFz4XJ8R81j8=
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
@@ -42,6 +40,8 @@ github.com/jfrog/gocmd v0.1.17 h1:LGFihK2juVKiVGx7LQOig/r1eFik/n1+rL47bBhN240=
 github.com/jfrog/gocmd v0.1.17/go.mod h1:O8mGn5+aEC3ru2NzyTkZ0a6hL5EIai4NNjYNzyFz/4A=
 github.com/jfrog/gofrog v1.0.6 h1:yUDxSCw8gTK6vC4PvtG0HTnEOQJSZ+O4lWGCgkev1nU=
 github.com/jfrog/gofrog v1.0.6/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
+github.com/jfrog/jfrog-cli-core v1.1.3-0.20201213084905-7cc18f1ce2ba h1:fXFdrILmpl+tg/DqEwPUnPCRe7kaeVyIbU5qFELsgg0=
+github.com/jfrog/jfrog-cli-core v1.1.3-0.20201213084905-7cc18f1ce2ba/go.mod h1:ET16qrmamV1fXLttbpXVBqO/4JoMce8SqEilBiQSqQQ=
 github.com/jfrog/jfrog-client-go v0.15.0/go.mod h1:v365V7GVxhzgrirZAxg81bZB+PQZMOKrHLXkon6vKp4=
 github.com/jfrog/jfrog-client-go v0.16.0 h1:b84v5ybkKUpcfP+dKjtOJNqn7l/je/IHVmYrsb5Rwo8=
 github.com/jfrog/jfrog-client-go v0.16.0/go.mod h1:v365V7GVxhzgrirZAxg81bZB+PQZMOKrHLXkon6vKp4=

--- a/nuget_test.go
+++ b/nuget_test.go
@@ -160,66 +160,72 @@ func runNuGet(t *testing.T, args ...string) {
 	assert.NoError(t, err)
 }
 
-func TestInitNewConfig(t *testing.T) {
-	t.Run("useNugetAddSource", func(t *testing.T) {
-		runInitNewConfig(t, true)
-	})
-	t.Run("DoNotUseNugetAddSource", func(t *testing.T) {
-		runInitNewConfig(t, false)
-	})
+type testInitNewConfigDescriptor struct {
+	testName          string
+	useNugetAddSource bool
+	useNugetV2        bool
+	expectedSourceUrl string
 }
 
-func runInitNewConfig(t *testing.T, useNugetAddSource bool) {
+func TestInitNewConfig(t *testing.T) {
+	baseRtUrl := "http://some/url"
+	expectedV2Url := baseRtUrl + "/api/nuget"
+	expectedV3Url := baseRtUrl + "/api/nuget/v3"
+	testsSuites := []testInitNewConfigDescriptor{
+		{"useNugetAddSourceV2", true, true, expectedV2Url},
+		{"useNugetAddSourceV3", true, false, expectedV3Url},
+		{"doNotUseNugetAddSourceV2", false, true, expectedV2Url},
+		{"doNotUseNugetAddSourceV3", false, false, expectedV3Url},
+	}
+
+	for _, test := range testsSuites {
+		t.Run(test.testName, func(t *testing.T) {
+			runInitNewConfig(t, test, baseRtUrl)
+		})
+	}
+}
+
+func runInitNewConfig(t *testing.T, testSuite testInitNewConfigDescriptor, baseRtUrl string) {
 	initNugetTest(t)
 
 	tempDirPath, err := fileutils.CreateTempDir()
 	if err != nil {
-		t.Error(err)
+		assert.NoError(t, err)
+		return
 	}
 	defer fileutils.RemoveTempDir(tempDirPath)
 
 	params := &dotnet.DotnetCommand{}
-	params.SetRtDetails(&config.ArtifactoryDetails{Url: "http://some/url", User: "user", Password: "password"}).SetUseNugetAddSource(useNugetAddSource)
+	params.SetRtDetails(&config.ArtifactoryDetails{Url: baseRtUrl, User: "user", Password: "password"}).
+		SetUseNugetAddSource(testSuite.useNugetAddSource).SetUseNugetV2(testSuite.useNugetV2)
 	// Prepare the config file with NuGet authentication
 	configFile, err := params.InitNewConfig(tempDirPath)
 	if err != nil {
-		t.Error(err)
+		assert.NoError(t, err)
+		return
 	}
 
 	content, err := ioutil.ReadFile(configFile.Name())
 	if err != nil {
-		t.Error(err)
+		assert.NoError(t, err)
+		return
 	}
 
 	nugetConfig := NugetConfig{}
 	err = xml.Unmarshal(content, &nugetConfig)
 	if err != nil {
-		t.Error("Unmarshalling failed with an error:", err.Error())
+		assert.NoError(t, err, "unmarshalling failed with an error")
+		return
 	}
 
-	if len(nugetConfig.PackageSources) != 1 {
-		t.Error("Expected one package sources, got", len(nugetConfig.PackageSources))
-	}
-
-	source := "http://some/url/api/nuget"
+	assert.Len(t, nugetConfig.PackageSources, 1)
 
 	for _, packageSource := range nugetConfig.PackageSources {
-		if packageSource.Key != dotnet.SourceName {
-			t.Error("Expected", dotnet.SourceName, ",got", packageSource.Key)
-		}
-
-		if packageSource.Value != source {
-			t.Error("Expected", source, ", got", packageSource.Value)
-		}
+		assert.Equal(t, dotnet.SourceName, packageSource.Key)
+		assert.Equal(t, testSuite.expectedSourceUrl, packageSource.Value)
 	}
-
-	if len(nugetConfig.PackageSourceCredentials) != 1 {
-		t.Error("Expected one packageSourceCredentials, got", len(nugetConfig.PackageSourceCredentials))
-	}
-
-	if len(nugetConfig.PackageSourceCredentials[0].JFrogCli) != 2 {
-		t.Error("Expected two fields in the JFrogCli credentials, got", len(nugetConfig.PackageSourceCredentials[0].JFrogCli))
-	}
+	assert.Len(t, nugetConfig.PackageSourceCredentials, 1)
+	assert.Len(t, nugetConfig.PackageSourceCredentials[0].JFrogCli, 2)
 }
 
 type NugetConfig struct {

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -293,8 +293,12 @@ const (
 	npmArgs    = "npm-args"
 
 	// Unique nuget flags
-	nugetArgs    = "nuget-args"
-	solutionRoot = "solution-root"
+	nugetArgs     = "nuget-args"
+	solutionRoot  = "solution-root"
+	legacyNugetV2 = "nuget-v2-protocol"
+
+	// Unique nuget/dotnet config flags
+	nugetV2 = "nuget-v2"
 
 	// Unique go flags
 	deps        = "deps"
@@ -918,6 +922,15 @@ var flagsMap = map[string]cli.Flag{
 		Usage:  "[Deprecated] [Default: .] Path to the root directory of the solution. If the directory includes more than one sln files, then the first argument passed in the --nuget-args option should be the name (not the path) of the sln file.` `",
 		Hidden: true,
 	},
+	legacyNugetV2: cli.BoolFlag{
+		Name:   legacyNugetV2,
+		Usage:  "[Deprecated] [Default: false] Set to true if you'd like to use the NuGet V2 protocol when restoring packages from Artifactory.` `",
+		Hidden: true,
+	},
+	nugetV2: cli.BoolFlag{
+		Name:   nugetV2,
+		Usage:  "[Default: false] Set to true if you'd like to use the NuGet V2 protocol when restoring packages from Artifactory.` `",
+	},
 	deps: cli.StringFlag{
 		Name:  deps,
 		Value: "",
@@ -1172,14 +1185,14 @@ var commandFlags = map[string][]string{
 		buildNumber, module,
 	},
 	NugetConfig: {
-		global, serverIdResolve, repoResolve,
+		global, serverIdResolve, repoResolve, nugetV2,
 	},
 	Nuget: {
-		nugetArgs, solutionRoot, deprecatedUrl, deprecatedUser, deprecatedPassword, deprecatedApikey,
+		nugetArgs, solutionRoot, legacyNugetV2, deprecatedUrl, deprecatedUser, deprecatedPassword, deprecatedApikey,
 		deprecatedAccessToken, buildName, buildNumber, module,
 	},
 	DotnetConfig: {
-		global, serverIdResolve, repoResolve,
+		global, serverIdResolve, repoResolve, nugetV2,
 	},
 	Dotnet: {
 		buildName, buildNumber, module,
@@ -1302,7 +1315,7 @@ var deprecatedFlags = []string{deprecatedUrl, deprecatedUser, deprecatedPassword
 
 // This function is used for legacy (deprecated) nuget command validation
 func GetLegacyNugetFlags() (flags []cli.Flag) {
-	legacyNugetFlags := []string{nugetArgs, solutionRoot}
+	legacyNugetFlags := []string{nugetArgs, solutionRoot, legacyNugetV2}
 	legacyNugetFlags = append(legacyNugetFlags, deprecatedFlags...)
 	return buildAndSortFlags(legacyNugetFlags)
 }

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -293,9 +293,10 @@ const (
 	npmArgs    = "npm-args"
 
 	// Unique nuget flags
-	nugetArgs     = "nuget-args"
-	solutionRoot  = "solution-root"
-	legacyNugetV2 = "nuget-v2-protocol"
+	NugetArgs    = "nuget-args"
+	SolutionRoot = "solution-root"
+	// This flag is different than the nugetV2 since it is hidden and used in the 'nuget' cmd, and not the 'nugetc' cmd.
+	LegacyNugetV2 = "nuget-v2-protocol"
 
 	// Unique nuget/dotnet config flags
 	nugetV2 = "nuget-v2"
@@ -912,24 +913,24 @@ var flagsMap = map[string]cli.Flag{
 		Value: "",
 		Usage: "[Default: 3] Number of working threads for build-info collection.` `",
 	},
-	nugetArgs: cli.StringFlag{
-		Name:   nugetArgs,
+	NugetArgs: cli.StringFlag{
+		Name:   NugetArgs,
 		Usage:  "[Deprecated] [Optional] A list of NuGet arguments and options in the form of \"arg1 arg2 arg3\"` `",
 		Hidden: true,
 	},
-	solutionRoot: cli.StringFlag{
-		Name:   solutionRoot,
+	SolutionRoot: cli.StringFlag{
+		Name:   SolutionRoot,
 		Usage:  "[Deprecated] [Default: .] Path to the root directory of the solution. If the directory includes more than one sln files, then the first argument passed in the --nuget-args option should be the name (not the path) of the sln file.` `",
 		Hidden: true,
 	},
-	legacyNugetV2: cli.BoolFlag{
-		Name:   legacyNugetV2,
+	LegacyNugetV2: cli.BoolFlag{
+		Name:   LegacyNugetV2,
 		Usage:  "[Deprecated] [Default: false] Set to true if you'd like to use the NuGet V2 protocol when restoring packages from Artifactory.` `",
 		Hidden: true,
 	},
 	nugetV2: cli.BoolFlag{
-		Name:   nugetV2,
-		Usage:  "[Default: false] Set to true if you'd like to use the NuGet V2 protocol when restoring packages from Artifactory.` `",
+		Name:  nugetV2,
+		Usage: "[Default: false] Set to true if you'd like to use the NuGet V2 protocol when restoring packages from Artifactory.` `",
 	},
 	deps: cli.StringFlag{
 		Name:  deps,
@@ -1188,7 +1189,7 @@ var commandFlags = map[string][]string{
 		global, serverIdResolve, repoResolve, nugetV2,
 	},
 	Nuget: {
-		nugetArgs, solutionRoot, legacyNugetV2, deprecatedUrl, deprecatedUser, deprecatedPassword, deprecatedApikey,
+		NugetArgs, SolutionRoot, LegacyNugetV2, deprecatedUrl, deprecatedUser, deprecatedPassword, deprecatedApikey,
 		deprecatedAccessToken, buildName, buildNumber, module,
 	},
 	DotnetConfig: {
@@ -1315,7 +1316,7 @@ var deprecatedFlags = []string{deprecatedUrl, deprecatedUser, deprecatedPassword
 
 // This function is used for legacy (deprecated) nuget command validation
 func GetLegacyNugetFlags() (flags []cli.Flag) {
-	legacyNugetFlags := []string{nugetArgs, solutionRoot, legacyNugetV2}
+	legacyNugetFlags := []string{NugetArgs, SolutionRoot, LegacyNugetV2}
 	legacyNugetFlags = append(legacyNugetFlags, deprecatedFlags...)
 	return buildAndSortFlags(legacyNugetFlags)
 }


### PR DESCRIPTION
Fixes #881.
Depends on [jfrog/jfrog-cli-core#45](https://github.com/jfrog/jfrog-cli-core/pull/45).

NuGet v3 will now be the default protocol. 
Using v2 can be configured in the project config file (by running `nugetc` or `dotnetc`, with `--nuget-v2` or interactively), or by option for the legacy nuget command (`--nuget-v2-protocol`).