### PR TITLE
Unit tests - use jfrog home from core

### DIFF
--- a/plugins/commands/uninstall_test.go
+++ b/plugins/commands/uninstall_test.go
@@ -16,17 +16,18 @@ func init() {
 	log.SetDefaultLogger()
 }
 
-const jfrogPluginTestsHome = ".jfrogCliPluginsTest"
 const pluginMockPath = "../../testdata/plugins/plugin-mock"
 
 func TestRunUninstallCmd(t *testing.T) {
 	// Create temp jfrog home
-	oldHome, err := coreTests.SetJfrogHome(jfrogPluginTestsHome)
+	oldHome, err := coreTests.SetJfrogHome()
 	if err != nil {
 		return
 	}
 	defer os.Setenv(coreutils.HomeDir, oldHome)
-	defer os.RemoveAll(jfrogPluginTestsHome)
+	// Clean from previous tests.
+	coreTests.CleanUnitTestsJfrogHome()
+	defer coreTests.CleanUnitTestsJfrogHome()
 
 	// Set CI to true to prevent interactive.
 	oldCi := os.Getenv(coreutils.CI)

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -15,20 +15,19 @@ import (
 	"testing"
 )
 
-const jfrogPluginTestsHome = ".jfrogCliPluginsTest"
 const pluginTemplateName = "hello-frog"
 
 func TestPluginFullCycle(t *testing.T) {
 	initPluginsTest(t)
 	// Create temp jfrog home
-	oldHome, err := coreTests.SetJfrogHome(jfrogPluginTestsHome)
+	oldHome, err := coreTests.SetJfrogHome()
 	if err != nil {
 		return
 	}
 	defer os.Setenv(coreutils.HomeDir, oldHome)
 	// Clean from previous tests.
-	os.RemoveAll(jfrogPluginTestsHome)
-	defer os.RemoveAll(jfrogPluginTestsHome)
+	coreTests.CleanUnitTestsJfrogHome()
+	defer coreTests.CleanUnitTestsJfrogHome()
 
 	// Set CI to true to prevent interactive.
 	oldCi := os.Getenv(coreutils.CI)

--- a/unit_test.go
+++ b/unit_test.go
@@ -1,14 +1,14 @@
 package main
 
 import (
+	"os"
+	"testing"
+
 	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
 	coreTests "github.com/jfrog/jfrog-cli-core/utils/tests"
 	"github.com/jfrog/jfrog-cli/utils/tests"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	clientTests "github.com/jfrog/jfrog-client-go/utils/tests"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 const (
@@ -17,21 +17,17 @@ const (
 )
 
 func TestUnitTests(t *testing.T) {
-	homePath, err := filepath.Abs(JfrogTestsHome)
-	if err != nil {
-		log.Error(err)
-		os.Exit(1)
-	}
-
-	oldHome, err := coreTests.SetJfrogHome(homePath)
+	oldHome, err := coreTests.SetJfrogHome()
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)
 	}
 	defer os.Setenv(coreutils.HomeDir, oldHome)
+	// Clean from previous tests.
+	coreTests.CleanUnitTestsJfrogHome()
+	defer coreTests.CleanUnitTestsJfrogHome()
 
 	packages := clientTests.GetTestPackages("./...")
 	packages = clientTests.ExcludeTestsPackage(packages, CliIntegrationTests)
 	clientTests.RunTests(packages, *tests.HideUnitTestLog)
-	coreTests.CleanUnitTestsJfrogHome(homePath)
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Adjust to changes from https://github.com/jfrog/jfrog-cli-core/pull/53.
Always use `.jfrogHome` as the unit tests' CLI home.