### PR TITLE
Fix access token create without username

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -2785,7 +2785,7 @@ func accessTokenCreateCmd(c *cli.Context) error {
 	if c.NArg() > 0 {
 		userName = c.Args().Get(0)
 	} else {
-		userName = rtDetails.GetUrl()
+		userName = rtDetails.GetUser()
 	}
 	expiry, err := cliutils.GetIntFlagValue(c, "expiry", cliutils.TokenExpiry)
 	if err != nil {

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -4276,8 +4276,8 @@ func TestAccessTokenCreate(t *testing.T) {
 	// Check access token
 	checkAccessToken(t, buffer)
 
-	// Create access token for current user, explicitly
-	err = artifactoryCli.Exec("atc", *tests.RtUser)
+	// Create access token for a dummy user
+	err = artifactoryCli.Exec("atc", "dummy-user")
 	assert.NoError(t, err)
 
 	// Check access token

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -4269,18 +4269,18 @@ func TestAccessTokenCreate(t *testing.T) {
 	// Restore previous logger when the function returns
 	defer log.SetLogger(previousLog)
 
+	// If access token is provided, use a new Artifactory CLI with username and password
 	accessTokenCli := artifactoryCli
 	if *tests.RtAccessToken != "" {
 		origAccessToken := *tests.RtAccessToken
-		*tests.RtAccessToken = ""
 		origUsername, origPassword := tests.SetBasicAuthFromAccessToken(t)
 		defer func() {
 			*tests.RtUser = origUsername
 			*tests.RtPassword = origPassword
 			*tests.RtAccessToken = origAccessToken
 		}()
-		cred := authenticate()
-		accessTokenCli = tests.NewJfrogCli(execMain, "jfrog rt", cred)
+		*tests.RtAccessToken = ""
+		accessTokenCli = tests.NewJfrogCli(execMain, "jfrog rt", authenticate())
 	}
 
 	// Create access token for current user, implicitly


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Using `jfrog rt access-token-create` without username uses Artifactory's URL as the token username.