### PR TITLE
Add Podman & Kaniko support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ go test -v github.com/jfrog/jfrog-cli -test.gradle [flags]
 #### Docker tests
 In addition to [general optional flags](#Usage) you *must* use the following docker flags.
 
+##### Requirements
+* On Linux machines, [Podman](https://podman.io/) tests will be running, so make sure it's available in the local path.
+
 | Flag | Description |
 | --- | --- |
 | `-rt.dockerRepoDomain` | Artifactory Docker registry domain. |

--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ go test -v github.com/jfrog/jfrog-cli -test.gradle [flags]
 
 #### Docker tests
 In addition to [general optional flags](#Usage) you *must* use the following docker flags.
-Kaniko tests will run as well.
 ##### Requirements
 * On Linux machines, [Podman](https://podman.io/) tests will be running, so make sure it's available in the local path.
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ go test -v github.com/jfrog/jfrog-cli -test.gradle [flags]
 
 #### Docker tests
 In addition to [general optional flags](#Usage) you *must* use the following docker flags.
-
+Kaniko tests will run as well.
 ##### Requirements
 * On Linux machines, [Podman](https://podman.io/) tests will be running, so make sure it's available in the local path.
 

--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -458,7 +458,7 @@ func GetCommands() []cli.Command {
 			ArgsUsage:    common.CreateEnvVars(),
 			BashComplete: corecommon.CreateBashCompletionFunc(),
 			Action: func(c *cli.Context) error {
-				return containerPushCmd(c, containerutils.Docker)
+				return containerPushCmd(c, containerutils.DockerClient)
 			},
 		},
 		{
@@ -471,7 +471,7 @@ func GetCommands() []cli.Command {
 			ArgsUsage:    common.CreateEnvVars(),
 			BashComplete: corecommon.CreateBashCompletionFunc(),
 			Action: func(c *cli.Context) error {
-				return containerPullCmd(c, containerutils.Docker)
+				return containerPullCmd(c, containerutils.DockerClient)
 			},
 		},
 		{
@@ -1321,9 +1321,9 @@ func BuildDockerCreateCmd(c *cli.Context) error {
 		return err
 	}
 	sourceRepo := c.Args().Get(0)
-	imageNameWithDigestFile := c.String("image-name-with-digest-file")
+	imageNameWithDigestFile := c.String("image-file")
 	if imageNameWithDigestFile == "" {
-		return cliutils.PrintHelpAndReturnError("Missing the flag 'image-name-with-digest-file'.", c)
+		return cliutils.PrintHelpAndReturnError("The '--image-file' command option was not provided.", c)
 	}
 	buildConfiguration, err := createBuildConfigurationWithModule(c)
 	if err != nil {

--- a/docker_test.go
+++ b/docker_test.go
@@ -26,40 +26,33 @@ func InitDockerTests() {
 	createRequiredRepos()
 }
 
-func initContainerTest(t *testing.T) {
+func initContainerTest(t *testing.T) []container.ContainerManagerType {
 	if !*tests.TestDocker {
 		t.Skip("Skipping docker/podman test. To run docker test add the '-test.docker=true' option.")
 	}
-}
-
-func TestContainerPush(t *testing.T) {
-	initContainerTest(t)
 	containerManagers := []container.ContainerManagerType{container.Docker}
 	if coreutils.IsLinux() {
 		containerManagers = append(containerManagers, container.Podman)
 	}
+	return containerManagers
+}
+
+func TestContainerPush(t *testing.T) {
+	containerManagers := initContainerTest(t)
 	for _, containerManager := range containerManagers {
 		runPushTest(containerManager, tests.DockerImageName, tests.DockerImageName+":1", false, t)
 	}
 }
 
 func TestContainerPushWithModuleName(t *testing.T) {
-	initContainerTest(t)
-	containerManagers := []container.ContainerManagerType{container.Docker}
-	if coreutils.IsLinux() {
-		containerManagers = append(containerManagers, container.Podman)
-	}
+	containerManagers := initContainerTest(t)
 	for _, containerManager := range containerManagers {
 		runPushTest(containerManager, tests.DockerImageName, ModuleNameJFrogTest, true, t)
 	}
 }
 
 func TestContainerPushWithMultipleSlash(t *testing.T) {
-	initContainerTest(t)
-	containerManagers := []container.ContainerManagerType{container.Docker}
-	if coreutils.IsLinux() {
-		containerManagers = append(containerManagers, container.Podman)
-	}
+	containerManagers := initContainerTest(t)
 	for _, containerManager := range containerManagers {
 
 		runPushTest(containerManager, tests.DockerImageName+"/multiple", "multiple:1", false, t)
@@ -87,11 +80,7 @@ func runPushTest(containerManager container.ContainerManagerType, imageName, mod
 
 }
 func TestContainerPushBuildNameNumberFromEnv(t *testing.T) {
-	initContainerTest(t)
-	containerManagers := []container.ContainerManagerType{container.Docker}
-	if coreutils.IsLinux() {
-		containerManagers = append(containerManagers, container.Podman)
-	}
+	containerManagers := initContainerTest(t)
 	for _, containerManager := range containerManagers {
 		imageTag := inttestutils.BuildTestContainerImage(tests.DockerImageName, containerManager)
 		buildNumber := "1"
@@ -112,11 +101,7 @@ func TestContainerPushBuildNameNumberFromEnv(t *testing.T) {
 }
 
 func TestContainerPull(t *testing.T) {
-	initContainerTest(t)
-	containerManagers := []container.ContainerManagerType{container.Docker}
-	if coreutils.IsLinux() {
-		containerManagers = append(containerManagers, container.Podman)
-	}
+	containerManagers := initContainerTest(t)
 	for _, containerManager := range containerManagers {
 		imageTag := inttestutils.BuildTestContainerImage(tests.DockerImageName, containerManager)
 
@@ -164,11 +149,7 @@ func TestDockerClientApiVersionCmd(t *testing.T) {
 }
 
 func TestContainerFatManifestPull(t *testing.T) {
-	initContainerTest(t)
-	containerManagers := []container.ContainerManagerType{container.Docker}
-	if coreutils.IsLinux() {
-		containerManagers = append(containerManagers, container.Podman)
-	}
+	containerManagers := initContainerTest(t)
 	for _, containerManager := range containerManagers {
 		for _, dockerRepo := range [...]string{*tests.DockerRemoteRepo, *tests.DockerVirtualRepo} {
 			imageName := "traefik"

--- a/docker_test.go
+++ b/docker_test.go
@@ -26,41 +26,39 @@ func InitDockerTests() {
 	createRequiredRepos()
 }
 
-func initDockerTest(t *testing.T) {
+func initContainerTest(t *testing.T) {
 	if !*tests.TestDocker {
-		t.Skip("Skipping docker test. To run docker test add the '-test.docker=true' option.")
+		t.Skip("Skipping docker/podman test. To run docker test add the '-test.docker=true' option.")
 	}
 }
 
-func TestDockerPush(t *testing.T) {
-	initDockerTest(t)
-	containerManagers := []string{"docker"}
+func TestContainerPush(t *testing.T) {
+	initContainerTest(t)
+	containerManagers := []container.ContainerManagerType{container.Docker}
 	if coreutils.IsLinux() {
-		containerManagers = append(containerManagers, "podman")
+		containerManagers = append(containerManagers, container.Podman)
 	}
 	for _, containerManager := range containerManagers {
-
 		runPushTest(containerManager, tests.DockerImageName, tests.DockerImageName+":1", false, t)
 	}
 }
 
-func TestDockerPushWithModuleName(t *testing.T) {
-	initDockerTest(t)
-	containerManagers := []string{"docker"}
+func TestContainerPushWithModuleName(t *testing.T) {
+	initContainerTest(t)
+	containerManagers := []container.ContainerManagerType{container.Docker}
 	if coreutils.IsLinux() {
-		containerManagers = append(containerManagers, "podman")
+		containerManagers = append(containerManagers, container.Podman)
 	}
 	for _, containerManager := range containerManagers {
-
 		runPushTest(containerManager, tests.DockerImageName, ModuleNameJFrogTest, true, t)
 	}
 }
 
-func TestDockerPushWithMultipleSlash(t *testing.T) {
-	initDockerTest(t)
-	containerManagers := []string{"docker"}
+func TestContainerPushWithMultipleSlash(t *testing.T) {
+	initContainerTest(t)
+	containerManagers := []container.ContainerManagerType{container.Docker}
 	if coreutils.IsLinux() {
-		containerManagers = append(containerManagers, "podman")
+		containerManagers = append(containerManagers, container.Podman)
 	}
 	for _, containerManager := range containerManagers {
 
@@ -68,89 +66,89 @@ func TestDockerPushWithMultipleSlash(t *testing.T) {
 	}
 }
 
-// Run docker push to Artifactory
-func runPushTest(containerManager, imageName, module string, withModule bool, t *testing.T) {
-	imageTag := inttestutils.BuildTestDockerImage(imageName)
+// Run container push to Artifactory
+func runPushTest(containerManager container.ContainerManagerType, imageName, module string, withModule bool, t *testing.T) {
+	imageTag := inttestutils.BuildTestContainerImage(imageName, containerManager)
 	buildNumber := "1"
 
-	// Push docker image using docker client
+	// Push image
 	if withModule {
-		artifactoryCli.Exec(containerManager+"-push", imageTag, *tests.DockerTargetRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber, "--module="+module)
+		artifactoryCli.Exec(containerManager.String()+"-push", imageTag, *tests.DockerTargetRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber, "--module="+module)
 	} else {
-		artifactoryCli.Exec(containerManager+"-push", imageTag, *tests.DockerTargetRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber)
+		artifactoryCli.Exec(containerManager.String()+"-push", imageTag, *tests.DockerTargetRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber)
 	}
 
 	inttestutils.ValidateGeneratedBuildInfoModule(t, tests.DockerBuildName, buildNumber, []string{module}, buildinfo.Docker)
 	artifactoryCli.Exec("build-publish", tests.DockerBuildName, buildNumber)
 
 	imagePath := path.Join(*tests.DockerTargetRepo, imageName, "1") + "/"
-	validateDockerBuild(tests.DockerBuildName, buildNumber, imagePath, module, 7, 5, 7, t)
-	inttestutils.DockerTestCleanup(artifactoryDetails, artHttpDetails, imageName, tests.DockerBuildName)
+	validateContainerBuild(tests.DockerBuildName, buildNumber, imagePath, module, 7, 5, 7, t)
+	inttestutils.ContainerTestCleanup(artifactoryDetails, artHttpDetails, imageName, tests.DockerBuildName)
 
 }
-func TestDockerPushBuildNameNumberFromEnv(t *testing.T) {
-	initDockerTest(t)
-	containerManagers := []string{"docker"}
+func TestContainerPushBuildNameNumberFromEnv(t *testing.T) {
+	initContainerTest(t)
+	containerManagers := []container.ContainerManagerType{container.Docker}
 	if coreutils.IsLinux() {
-		containerManagers = append(containerManagers, "podman")
+		containerManagers = append(containerManagers, container.Podman)
 	}
 	for _, containerManager := range containerManagers {
-		imageTag := inttestutils.BuildTestDockerImage(tests.DockerImageName)
+		imageTag := inttestutils.BuildTestContainerImage(tests.DockerImageName, containerManager)
 		buildNumber := "1"
 		os.Setenv(coreutils.BuildName, tests.DockerBuildName)
 		os.Setenv(coreutils.BuildNumber, buildNumber)
 		defer os.Unsetenv(coreutils.BuildName)
 		defer os.Unsetenv(coreutils.BuildNumber)
 
-		// Push docker image using docker client
-		artifactoryCli.Exec(containerManager+"-push", imageTag, *tests.DockerTargetRepo)
+		// Push container image
+		artifactoryCli.Exec(containerManager.String()+"-push", imageTag, *tests.DockerTargetRepo)
 		artifactoryCli.Exec("build-publish")
 
 		imagePath := path.Join(*tests.DockerTargetRepo, tests.DockerImageName, "1") + "/"
-		validateDockerBuild(tests.DockerBuildName, buildNumber, imagePath, tests.DockerImageName+":1", 7, 5, 7, t)
+		validateContainerBuild(tests.DockerBuildName, buildNumber, imagePath, tests.DockerImageName+":1", 7, 5, 7, t)
 
-		inttestutils.DockerTestCleanup(artifactoryDetails, artHttpDetails, tests.DockerImageName, tests.DockerBuildName)
+		inttestutils.ContainerTestCleanup(artifactoryDetails, artHttpDetails, tests.DockerImageName, tests.DockerBuildName)
 	}
 }
 
-func TestDockerPull(t *testing.T) {
-	initDockerTest(t)
-	containerManagers := []string{"docker"}
+func TestContainerPull(t *testing.T) {
+	initContainerTest(t)
+	containerManagers := []container.ContainerManagerType{container.Docker}
 	if coreutils.IsLinux() {
-		containerManagers = append(containerManagers, "podman")
+		containerManagers = append(containerManagers, container.Podman)
 	}
 	for _, containerManager := range containerManagers {
-		imageTag := inttestutils.BuildTestDockerImage(tests.DockerImageName)
+		imageTag := inttestutils.BuildTestContainerImage(tests.DockerImageName, containerManager)
 
-		// Push docker image using docker client
-		artifactoryCli.Exec(containerManager+"-push", imageTag, *tests.DockerTargetRepo)
+		// Push container image
+		artifactoryCli.Exec(containerManager.String()+"-push", imageTag, *tests.DockerTargetRepo)
 
 		buildNumber := "1"
 
-		// Pull docker image using docker client
-		artifactoryCli.Exec(containerManager+"-pull", imageTag, *tests.DockerTargetRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber)
+		// Pull container image
+		artifactoryCli.Exec(containerManager.String()+"-pull", imageTag, *tests.DockerTargetRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber)
 		artifactoryCli.Exec("build-publish", tests.DockerBuildName, buildNumber)
 
 		imagePath := path.Join(*tests.DockerTargetRepo, tests.DockerImageName, "1") + "/"
-		validateDockerBuild(tests.DockerBuildName, buildNumber, imagePath, tests.DockerImageName+":1", 0, 7, 7, t)
+		validateContainerBuild(tests.DockerBuildName, buildNumber, imagePath, tests.DockerImageName+":1", 0, 7, 7, t)
 
 		buildNumber = "2"
-		artifactoryCli.Exec(containerManager+"-pull", imageTag, *tests.DockerTargetRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber, "--module="+ModuleNameJFrogTest)
+		artifactoryCli.Exec(containerManager.String()+"-pull", imageTag, *tests.DockerTargetRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber, "--module="+ModuleNameJFrogTest)
 		artifactoryCli.Exec("build-publish", tests.DockerBuildName, buildNumber)
-		validateDockerBuild(tests.DockerBuildName, buildNumber, imagePath, ModuleNameJFrogTest, 0, 7, 7, t)
+		validateContainerBuild(tests.DockerBuildName, buildNumber, imagePath, ModuleNameJFrogTest, 0, 7, 7, t)
 
-		inttestutils.DockerTestCleanup(artifactoryDetails, artHttpDetails, tests.DockerImageName, tests.DockerBuildName)
+		inttestutils.ContainerTestCleanup(artifactoryDetails, artHttpDetails, tests.DockerImageName, tests.DockerBuildName)
 	}
 }
 
-func dockerTestCleanup(imageName, buildName string) {
+func containerTestCleanup(imageName, buildName string) {
 	// Remove build from Artifactory
 	inttestutils.DeleteBuild(artifactoryDetails.Url, buildName, artHttpDetails)
-	inttestutils.DockerTestCleanup(artifactoryDetails, artHttpDetails, tests.DockerImageName, tests.DockerBuildName)
+	inttestutils.ContainerTestCleanup(artifactoryDetails, artHttpDetails, tests.DockerImageName, tests.DockerBuildName)
 }
 
 func TestDockerClientApiVersionCmd(t *testing.T) {
-	initDockerTest(t)
+	initContainerTest(t)
 
 	// Run docker version command and expect no errors
 	cmd := &container.VersionCmd{}
@@ -165,40 +163,46 @@ func TestDockerClientApiVersionCmd(t *testing.T) {
 	assert.True(t, container.IsCompatibleApiVersion(content))
 }
 
-func TestDockerFatManifestPull(t *testing.T) {
-	initDockerTest(t)
-	for _, dockerRepo := range [...]string{*tests.DockerRemoteRepo, *tests.DockerVirtualRepo} {
-		imageName := "traefik"
-		imageTag := path.Join(*tests.DockerRepoDomain, imageName+":2.2")
-		buildNumber := "1"
+func TestContainerFatManifestPull(t *testing.T) {
+	initContainerTest(t)
+	containerManagers := []container.ContainerManagerType{container.Docker}
+	if coreutils.IsLinux() {
+		containerManagers = append(containerManagers, container.Podman)
+	}
+	for _, containerManager := range containerManagers {
+		for _, dockerRepo := range [...]string{*tests.DockerRemoteRepo, *tests.DockerVirtualRepo} {
+			imageName := "traefik"
+			imageTag := path.Join(*tests.DockerRepoDomain, imageName+":2.2")
+			buildNumber := "1"
 
-		// Pull docker image using docker client
-		assert.NoError(t, artifactoryCli.Exec("docker-pull", imageTag, dockerRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber))
-		assert.NoError(t, artifactoryCli.Exec("build-publish", tests.DockerBuildName, buildNumber))
+			// Pull container image
+			assert.NoError(t, artifactoryCli.Exec(containerManager.String()+"-pull", imageTag, dockerRepo, "--build-name="+tests.DockerBuildName, "--build-number="+buildNumber))
+			assert.NoError(t, artifactoryCli.Exec("build-publish", tests.DockerBuildName, buildNumber))
 
-		// Validate
-		publishedBuildInfo, found, err := tests.GetBuildInfo(artifactoryDetails, tests.DockerBuildName, buildNumber)
-		if err != nil {
-			assert.NoError(t, err)
-			return
+			// Validate
+			publishedBuildInfo, found, err := tests.GetBuildInfo(artifactoryDetails, tests.DockerBuildName, buildNumber)
+			if err != nil {
+				assert.NoError(t, err)
+				return
+			}
+			if !found {
+				assert.True(t, found, "build info was expected to be found")
+				return
+			}
+			buildInfo := publishedBuildInfo.BuildInfo
+			validateBuildInfo(buildInfo, t, 6, 0, imageName+":2.2")
+
+			inttestutils.ContainerTestCleanup(artifactoryDetails, artHttpDetails, imageName, tests.DockerBuildName)
+			inttestutils.DeleteTestContainerImage(imageTag, containerManager)
 		}
-		if !found {
-			assert.True(t, found, "build info was expected to be found")
-			return
-		}
-		buildInfo := publishedBuildInfo.BuildInfo
-		validateBuildInfo(buildInfo, t, 6, 0, imageName+":2.2")
-
-		inttestutils.DockerTestCleanup(artifactoryDetails, artHttpDetails, imageName, tests.DockerBuildName)
-		inttestutils.DeleteTestDockerImage(imageTag)
 	}
 }
 
 func TestDockerPromote(t *testing.T) {
-	initDockerTest(t)
+	initContainerTest(t)
 
 	// Build and push image
-	imageTag := inttestutils.BuildTestDockerImage(tests.DockerImageName)
+	imageTag := inttestutils.BuildTestContainerImage(tests.DockerImageName, container.Docker)
 	err := artifactoryCli.Exec("docker-push", imageTag, *tests.DockerTargetRepo)
 	assert.NoError(t, err)
 
@@ -208,19 +212,19 @@ func TestDockerPromote(t *testing.T) {
 
 	// Verify image in source
 	imagePath := path.Join(*tests.DockerTargetRepo, tests.DockerImageName, "1") + "/"
-	validateDockerImage(t, imagePath, 7)
+	validateContainerImage(t, imagePath, 7)
 
 	// Verify image promoted
 	searchSpec, err := tests.CreateSpec(tests.SearchAllDocker)
 	assert.NoError(t, err)
 	verifyExistInArtifactory(tests.GetDockerDeployedManifest(), searchSpec, t)
 
-	inttestutils.DockerTestCleanup(artifactoryDetails, artHttpDetails, tests.DockerImageName, tests.DockerBuildName)
-	inttestutils.DeleteTestDockerImage(imageTag)
+	inttestutils.ContainerTestCleanup(artifactoryDetails, artHttpDetails, tests.DockerImageName, tests.DockerBuildName)
+	inttestutils.DeleteTestContainerImage(imageTag, container.Docker)
 }
 
-func validateDockerBuild(buildName, buildNumber, imagePath, module string, expectedArtifacts, expectedDependencies, expectedItemsInArtifactory int, t *testing.T) {
-	validateDockerImage(t, imagePath, expectedItemsInArtifactory)
+func validateContainerBuild(buildName, buildNumber, imagePath, module string, expectedArtifacts, expectedDependencies, expectedItemsInArtifactory int, t *testing.T) {
+	validateContainerImage(t, imagePath, expectedItemsInArtifactory)
 	publishedBuildInfo, found, err := tests.GetBuildInfo(artifactoryDetails, buildName, buildNumber)
 	if err != nil {
 		assert.NoError(t, err)
@@ -234,7 +238,7 @@ func validateDockerBuild(buildName, buildNumber, imagePath, module string, expec
 	validateBuildInfo(buildInfo, t, expectedDependencies, expectedArtifacts, module)
 }
 
-func validateDockerImage(t *testing.T, imagePath string, expectedItemsInArtifactory int) {
+func validateContainerImage(t *testing.T, imagePath string, expectedItemsInArtifactory int) {
 	specFile := spec.NewBuilder().Pattern(imagePath + "*").BuildSpec()
 	searchCmd := generic.NewSearchCommand()
 	searchCmd.SetRtDetails(artifactoryDetails).SetSpec(specFile)
@@ -242,6 +246,6 @@ func validateDockerImage(t *testing.T, imagePath string, expectedItemsInArtifact
 	assert.NoError(t, err)
 	length, err := reader.Length()
 	assert.NoError(t, err)
-	assert.Equal(t, expectedItemsInArtifactory, length, "Docker build info was not pushed correctly")
+	assert.Equal(t, expectedItemsInArtifactory, length, "Container build info was not pushed correctly")
 	assert.NoError(t, reader.Close())
 }

--- a/docs/artifactory/builddockercreate/help.go
+++ b/docs/artifactory/builddockercreate/help.go
@@ -2,10 +2,10 @@ package builddockercreate
 
 const Description = "Build Docker Create."
 
-var Usage = []string{"jfrog rt build-docker-create <target repo> <--image-name-with-digest-file=*file-path*>"}
+var Usage = []string{"jfrog rt build-docker-create <target repo> <--image-file=*file-path*>"}
 
-const Arguments string = `	image-name-with-digest-file
-		File path to the image name and manifest's digest in Artifactory.
+const Arguments string = `	image-file
+		Path to a file which includes one line in the following format: IMAGE-TAG@sha256:MANIFEST-SHA256.
 	target repo
 		The repository to which the image was pushed.
 `

--- a/docs/artifactory/builddockercreate/help.go
+++ b/docs/artifactory/builddockercreate/help.go
@@ -1,0 +1,11 @@
+package builddockercreate
+
+const Description = "Build Docker Create."
+
+var Usage = []string{"jfrog rt build-docker-create <target repo> <--image-name-with-digest-file=*file-path*>"}
+
+const Arguments string = `	image-name-with-digest-file
+		File path to the image name and manifest's digest in Artifactory.
+	target repo
+		The repository to which the image was pushed.
+`

--- a/docs/artifactory/podmanpull/help.go
+++ b/docs/artifactory/podmanpull/help.go
@@ -1,0 +1,11 @@
+package podmanpull
+
+const Description = "Podman pull."
+
+var Usage = []string{"jfrog rt podman-pull <image tag> <target repo>"}
+
+const Arguments string = `	image tag
+		Podman image tag to pull.
+	target repo
+		Target repository in Artifactory.
+`

--- a/docs/artifactory/podmanpull/help.go
+++ b/docs/artifactory/podmanpull/help.go
@@ -5,7 +5,7 @@ const Description = "Podman pull."
 var Usage = []string{"jfrog rt podman-pull <image tag> <target repo>"}
 
 const Arguments string = `	image tag
-		Podman image tag to pull.
+		Docker image tag to pull.
 	target repo
-		Target repository in Artifactory.
+		Source repository in Artifactory.
 `

--- a/docs/artifactory/podmanpush/help.go
+++ b/docs/artifactory/podmanpush/help.go
@@ -5,7 +5,7 @@ const Description = "Podman push."
 var Usage = []string{"jfrog rt podman-push <image tag> <target repo>"}
 
 const Arguments string = `	image tag
-		Podman image tag to push.
+		Docker image tag to push.
 	target repo
 		Target repository in Artifactory.
 `

--- a/docs/artifactory/podmanpush/help.go
+++ b/docs/artifactory/podmanpush/help.go
@@ -1,0 +1,11 @@
+package podmanpush
+
+const Description = "Podman push."
+
+var Usage = []string{"jfrog rt podman-push <image tag> <target repo>"}
+
+const Arguments string = `	image tag
+		Podman image tag to push.
+	target repo
+		Target repository in Artifactory.
+`

--- a/testdata/docker/TestKanikoBuildCollect
+++ b/testdata/docker/TestKanikoBuildCollect
@@ -1,0 +1,2 @@
+FROM alpine
+RUN echo "created from standard input"

--- a/testdata/kaniko_config.json
+++ b/testdata/kaniko_config.json
@@ -1,0 +1,7 @@
+{
+	"auths": {
+		"${DOCKER_REPO_DOMAIN}" : {
+			"auth": "${RT_CREDENTIALS_BASIC_AUTH}"
+		}
+	}
+}

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -34,6 +34,7 @@ const (
 	DockerPromote           = "docker-promote"
 	ContainerPull           = "container-pull"
 	ContainerPush           = "container-push"
+	BuildDockerCreate       = "build-docker-create"
 	NpmConfig               = "npm-config"
 	Npm                     = "npm"
 	NpmPublish              = "npmPublish"
@@ -290,6 +291,9 @@ const (
 	sourceTag           = "source-tag"
 	targetTag           = "target-tag"
 	dockerPromoteCopy   = dockerPromotePrefix + Copy
+
+	// Unique build docker create
+	imageNameWithDigestFile = "image-name-with-digest-file"
 
 	// Unique npm flags
 	npmPrefix  = "npm-"
@@ -1084,6 +1088,11 @@ var flagsMap = map[string]cli.Flag{
 		Value: "",
 		Usage: "[Default: " + strconv.Itoa(DefaultLicenseCount) + "] The number of licenses to deploy. Minimum value is 1.` `",
 	},
+	imageNameWithDigestFile: cli.StringFlag{
+		Name:  imageNameWithDigestFile,
+		Value: "",
+		Usage: "File path to the image name and manifest's digest in Artifactory.` `",
+	},
 }
 
 var commandFlags = map[string][]string{
@@ -1185,6 +1194,10 @@ var commandFlags = map[string][]string{
 	ContainerPush: {
 		buildName, buildNumber, module, url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath,
 		serverId, skipLogin, threads,
+	},
+	BuildDockerCreate: {
+		buildName, buildNumber, module, url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath,
+		serverId, imageNameWithDigestFile,
 	},
 	ContainerPull: {
 		buildName, buildNumber, module, url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath,

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -293,7 +293,7 @@ const (
 	dockerPromoteCopy   = dockerPromotePrefix + Copy
 
 	// Unique build docker create
-	imageNameWithDigestFile = "image-name-with-digest-file"
+	imageFile = "image-file"
 
 	// Unique npm flags
 	npmPrefix  = "npm-"
@@ -1088,8 +1088,8 @@ var flagsMap = map[string]cli.Flag{
 		Value: "",
 		Usage: "[Default: " + strconv.Itoa(DefaultLicenseCount) + "] The number of licenses to deploy. Minimum value is 1.` `",
 	},
-	imageNameWithDigestFile: cli.StringFlag{
-		Name:  imageNameWithDigestFile,
+	imageFile: cli.StringFlag{
+		Name:  imageFile,
 		Value: "",
 		Usage: "File path to the image name and manifest's digest in Artifactory.` `",
 	},
@@ -1197,7 +1197,7 @@ var commandFlags = map[string][]string{
 	},
 	BuildDockerCreate: {
 		buildName, buildNumber, module, url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath,
-		serverId, imageNameWithDigestFile,
+		serverId, imageFile,
 	},
 	ContainerPull: {
 		buildName, buildNumber, module, url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath,

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -1,10 +1,11 @@
 package cliutils
 
 import (
-	"github.com/codegangsta/cli"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 	"sort"
 	"strconv"
+
+	"github.com/codegangsta/cli"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 const (
@@ -31,8 +32,8 @@ const (
 	Gradle                  = "gradle"
 	GradleConfig            = "gradle-config"
 	DockerPromote           = "docker-promote"
-	DockerPull              = "docker-pull"
-	DockerPush              = "docker-push"
+	ContainerPull           = "container-pull"
+	ContainerPush           = "container-push"
 	NpmConfig               = "npm-config"
 	Npm                     = "npm"
 	NpmPublish              = "npmPublish"
@@ -1181,11 +1182,11 @@ var commandFlags = map[string][]string{
 		targetDockerImage, sourceTag, targetTag, dockerPromoteCopy, url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath,
 		serverId,
 	},
-	DockerPush: {
+	ContainerPush: {
 		buildName, buildNumber, module, url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath,
 		serverId, skipLogin, threads,
 	},
-	DockerPull: {
+	ContainerPull: {
 		buildName, buildNumber, module, url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath,
 		serverId, skipLogin,
 	},

--- a/utils/tests/artifactoryconsts.go
+++ b/utils/tests/artifactoryconsts.go
@@ -43,6 +43,7 @@ const (
 	DistributionUploadSpecA                = "dist_upload_spec_a.json"
 	DistributionUploadSpecB                = "dist_upload_spec_b.json"
 	DockerRepoConfig                       = "docker_repository_config.json"
+	KanikoConfig                           = "kaniko_config.json"
 	DownloadAllRepo1TestResources          = "download_all_repo1_test_resources.json"
 	DownloadEmptyDirs                      = "download_empty_dir_spec.json"
 	DownloadModFileGo                      = "downloadmodfile_go.json"

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -2,11 +2,10 @@ package tests
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
-	"github.com/jfrog/jfrog-client-go/artifactory/services"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -16,6 +15,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jfrog/jfrog-client-go/artifactory/buildinfo"
+	"github.com/jfrog/jfrog-client-go/artifactory/services"
 
 	corelog "github.com/jfrog/jfrog-cli-core/utils/log"
 
@@ -420,35 +422,37 @@ func GetBuildNames() []string {
 // We use substitution map to set repositories and builds with timestamp.
 func getSubstitutionMap() map[string]string {
 	return map[string]string{
-		"${REPO1}":              RtRepo1,
-		"${REPO2}":              RtRepo2,
-		"${REPO_1_AND_2}":       RtRepo1And2,
-		"${VIRTUAL_REPO}":       RtVirtualRepo,
-		"${LFS_REPO}":           RtLfsRepo,
-		"${DEBIAN_REPO}":        RtDebianRepo,
-		"${DOCKER_REPO}":        DockerRepo,
-		"${MAVEN_REPO1}":        MvnRepo1,
-		"${MAVEN_REPO2}":        MvnRepo2,
-		"${MAVEN_REMOTE_REPO}":  MvnRemoteRepo,
-		"${GRADLE_REMOTE_REPO}": GradleRemoteRepo,
-		"${GRADLE_REPO}":        GradleRepo,
-		"${NPM_REPO}":           NpmRepo,
-		"${NPM_REMOTE_REPO}":    NpmRemoteRepo,
-		"${GO_REPO}":            GoRepo,
-		"${RT_SERVER_ID}":       RtServerId,
-		"${RT_URL}":             *RtUrl,
-		"${RT_API_KEY}":         *RtApiKey,
-		"${RT_USERNAME}":        *RtUser,
-		"${RT_PASSWORD}":        *RtPassword,
-		"${RT_ACCESS_TOKEN}":    *RtAccessToken,
-		"${PYPI_REMOTE_REPO}":   PypiRemoteRepo,
-		"${PYPI_VIRTUAL_REPO}":  PypiVirtualRepo,
-		"${BUILD_NAME1}":        RtBuildName1,
-		"${BUILD_NAME2}":        RtBuildName2,
-		"${BINTRAY_REPO}":       BintrayRepo,
-		"${BUNDLE_NAME}":        BundleName,
-		"${DIST_REPO1}":         DistRepo1,
-		"${DIST_REPO2}":         DistRepo2,
+		"${REPO1}":                     RtRepo1,
+		"${REPO2}":                     RtRepo2,
+		"${REPO_1_AND_2}":              RtRepo1And2,
+		"${VIRTUAL_REPO}":              RtVirtualRepo,
+		"${LFS_REPO}":                  RtLfsRepo,
+		"${DEBIAN_REPO}":               RtDebianRepo,
+		"${DOCKER_REPO}":               DockerRepo,
+		"${DOCKER_REPO_DOMAIN}":        *DockerRepoDomain,
+		"${MAVEN_REPO1}":               MvnRepo1,
+		"${MAVEN_REPO2}":               MvnRepo2,
+		"${MAVEN_REMOTE_REPO}":         MvnRemoteRepo,
+		"${GRADLE_REMOTE_REPO}":        GradleRemoteRepo,
+		"${GRADLE_REPO}":               GradleRepo,
+		"${NPM_REPO}":                  NpmRepo,
+		"${NPM_REMOTE_REPO}":           NpmRemoteRepo,
+		"${GO_REPO}":                   GoRepo,
+		"${RT_SERVER_ID}":              RtServerId,
+		"${RT_URL}":                    *RtUrl,
+		"${RT_API_KEY}":                *RtApiKey,
+		"${RT_USERNAME}":               *RtUser,
+		"${RT_PASSWORD}":               *RtPassword,
+		"${RT_CREDENTIALS_BASIC_AUTH}": base64.StdEncoding.EncodeToString([]byte(*RtUser + ":" + *RtPassword)),
+		"${RT_ACCESS_TOKEN}":           *RtAccessToken,
+		"${PYPI_REMOTE_REPO}":          PypiRemoteRepo,
+		"${PYPI_VIRTUAL_REPO}":         PypiVirtualRepo,
+		"${BUILD_NAME1}":               RtBuildName1,
+		"${BUILD_NAME2}":               RtBuildName2,
+		"${BINTRAY_REPO}":              BintrayRepo,
+		"${BUNDLE_NAME}":               BundleName,
+		"${DIST_REPO1}":                DistRepo1,
+		"${DIST_REPO2}":                DistRepo2,
 	}
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR adds support for podman, which includes these commands:
* `jfrog rt podman-pull`
* `jfrog rt podman-push`
* `jfrog rt build-docker-create`

Related PR:
 * https://github.com/jfrog/jfrog-cli-core/pull/39
 * https://github.com/jfrog/jfrog-client-go/pull/238 

Duplicates:
 *https://github.com/jfrog/jfrog-cli/pull/909