### PR TITLE
Allow adding properties in release bundle commands 

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -3273,7 +3273,7 @@ func createDefaultUploadSpec(c *cli.Context) (*spec.SpecFiles, error) {
 	return spec.NewBuilder().
 		Pattern(c.Args().Get(0)).
 		Props(c.String("props")).
-		AddedProps(c.String("added-props")).
+		AddProps(c.String("add-props")).
 		Build(c.String("build")).
 		Offset(offset).
 		Limit(limit).
@@ -3313,7 +3313,7 @@ func createDefaultReleaseBundleSpec(c *cli.Context) *spec.SpecFiles {
 		Bundle(c.String("bundle")).
 		Exclusions(cliutils.GetStringsArrFlagValue(c, "exclusions")).
 		Regexp(c.Bool("regexp")).
-		AddedProps(c.String("added-props")).
+		AddProps(c.String("add-props")).
 		BuildSpec()
 }
 
@@ -3454,7 +3454,7 @@ func overrideFieldsIfSet(spec *spec.File, c *cli.Context) {
 	overrideIntIfSet(&spec.Limit, c, "limit")
 	overrideStringIfSet(&spec.SortOrder, c, "sort-order")
 	overrideStringIfSet(&spec.Props, c, "props")
-	overrideStringIfSet(&spec.AddedProps, c, "added-props")
+	overrideStringIfSet(&spec.AddProps, c, "add-props")
 	overrideStringIfSet(&spec.ExcludeProps, c, "exclude-props")
 	overrideStringIfSet(&spec.Build, c, "build")
 	overrideStringIfSet(&spec.ExcludeArtifacts, c, "exclude-artifacts")

--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -3182,6 +3182,7 @@ func createReleaseBundleCreateUpdateParams(c *cli.Context, bundleName, bundleVer
 	releaseBundleParams.StoringRepository = c.String("repo")
 	releaseBundleParams.GpgPassphrase = c.String("passphrase")
 	releaseBundleParams.Description = c.String("desc")
+	releaseBundleParams.AddedProps = c.String("added-props")
 	if c.IsSet("release-notes-path") {
 		bytes, err := ioutil.ReadFile(c.String("release-notes-path"))
 		if err != nil {

--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -142,7 +142,7 @@ func GetCommands() []cli.Command {
 		},
 		{
 			Name:         "upload",
-			Flags:        cliutils.GetCommandFlags("upload"), //(cliutils.Upload),
+			Flags:        cliutils.GetCommandFlags(cliutils.Upload),
 			Aliases:      []string{"u"},
 			Usage:        upload.Description,
 			HelpName:     corecommon.CreateUsage("rt upload", upload.Description, upload.Usage),
@@ -1902,7 +1902,7 @@ func downloadCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = spec.ValidateSpec(downloadSpec.Files, false, true)
+	err = spec.ValidateSpec(downloadSpec.Files, false, true, false)
 	if err != nil {
 		return err
 	}
@@ -1952,7 +1952,7 @@ func uploadCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = spec.ValidateSpec(uploadSpec.Files, true, false)
+	err = spec.ValidateSpec(uploadSpec.Files, true, false, true)
 	if err != nil {
 		return err
 	}
@@ -2020,7 +2020,7 @@ func moveCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = spec.ValidateSpec(moveSpec.Files, true, true)
+	err = spec.ValidateSpec(moveSpec.Files, true, true, false)
 	if err != nil {
 		return err
 	}
@@ -2059,7 +2059,7 @@ func copyCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = spec.ValidateSpec(copySpec.Files, true, true)
+	err = spec.ValidateSpec(copySpec.Files, true, true, false)
 	if err != nil {
 		return err
 	}
@@ -2099,7 +2099,7 @@ func deleteCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = spec.ValidateSpec(deleteSpec.Files, false, true)
+	err = spec.ValidateSpec(deleteSpec.Files, false, true, false)
 	if err != nil {
 		return err
 	}
@@ -2140,7 +2140,7 @@ func searchCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = spec.ValidateSpec(searchSpec.Files, false, true)
+	err = spec.ValidateSpec(searchSpec.Files, false, true, false)
 	if err != nil {
 		return err
 	}
@@ -2192,7 +2192,7 @@ func preparePropsCmd(c *cli.Context) (*generic.PropsCommand, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = spec.ValidateSpec(propsSpec.Files, false, true)
+	err = spec.ValidateSpec(propsSpec.Files, false, true, false)
 	if err != nil {
 		return nil, err
 	}
@@ -2451,7 +2451,7 @@ func releaseBundleCreateCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = spec.ValidateSpec(releaseBundleCreateSpec.Files, false, true)
+	err = spec.ValidateSpec(releaseBundleCreateSpec.Files, false, true, false)
 	if err != nil {
 		return err
 	}
@@ -2484,7 +2484,7 @@ func releaseBundleUpdateCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = spec.ValidateSpec(releaseBundleUpdateSpec.Files, false, true)
+	err = spec.ValidateSpec(releaseBundleUpdateSpec.Files, false, true, false)
 	if err != nil {
 		return err
 	}
@@ -3182,7 +3182,6 @@ func createReleaseBundleCreateUpdateParams(c *cli.Context, bundleName, bundleVer
 	releaseBundleParams.StoringRepository = c.String("repo")
 	releaseBundleParams.GpgPassphrase = c.String("passphrase")
 	releaseBundleParams.Description = c.String("desc")
-	releaseBundleParams.AddedProps = c.String("added-props")
 	if c.IsSet("release-notes-path") {
 		bytes, err := ioutil.ReadFile(c.String("release-notes-path"))
 		if err != nil {
@@ -3274,6 +3273,7 @@ func createDefaultUploadSpec(c *cli.Context) (*spec.SpecFiles, error) {
 	return spec.NewBuilder().
 		Pattern(c.Args().Get(0)).
 		Props(c.String("props")).
+		AddedProps(c.String("added-props")).
 		Build(c.String("build")).
 		Offset(offset).
 		Limit(limit).
@@ -3313,6 +3313,7 @@ func createDefaultReleaseBundleSpec(c *cli.Context) *spec.SpecFiles {
 		Bundle(c.String("bundle")).
 		Exclusions(cliutils.GetStringsArrFlagValue(c, "exclusions")).
 		Regexp(c.Bool("regexp")).
+		AddedProps(c.String("added-props")).
 		BuildSpec()
 }
 
@@ -3453,6 +3454,7 @@ func overrideFieldsIfSet(spec *spec.File, c *cli.Context) {
 	overrideIntIfSet(&spec.Limit, c, "limit")
 	overrideStringIfSet(&spec.SortOrder, c, "sort-order")
 	overrideStringIfSet(&spec.Props, c, "props")
+	overrideStringIfSet(&spec.AddedProps, c, "added-props")
 	overrideStringIfSet(&spec.ExcludeProps, c, "exclude-props")
 	overrideStringIfSet(&spec.Build, c, "build")
 	overrideStringIfSet(&spec.ExcludeArtifacts, c, "exclude-artifacts")

--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -3273,7 +3273,7 @@ func createDefaultUploadSpec(c *cli.Context) (*spec.SpecFiles, error) {
 	return spec.NewBuilder().
 		Pattern(c.Args().Get(0)).
 		Props(c.String("props")).
-		AddProps(c.String("add-props")).
+		TargetProps(c.String("target-props")).
 		Build(c.String("build")).
 		Offset(offset).
 		Limit(limit).
@@ -3313,7 +3313,7 @@ func createDefaultReleaseBundleSpec(c *cli.Context) *spec.SpecFiles {
 		Bundle(c.String("bundle")).
 		Exclusions(cliutils.GetStringsArrFlagValue(c, "exclusions")).
 		Regexp(c.Bool("regexp")).
-		AddProps(c.String("add-props")).
+		TargetProps(c.String("target-props")).
 		BuildSpec()
 }
 
@@ -3454,7 +3454,7 @@ func overrideFieldsIfSet(spec *spec.File, c *cli.Context) {
 	overrideIntIfSet(&spec.Limit, c, "limit")
 	overrideStringIfSet(&spec.SortOrder, c, "sort-order")
 	overrideStringIfSet(&spec.Props, c, "props")
-	overrideStringIfSet(&spec.AddProps, c, "add-props")
+	overrideStringIfSet(&spec.TargetProps, c, "target-props")
 	overrideStringIfSet(&spec.ExcludeProps, c, "exclude-props")
 	overrideStringIfSet(&spec.Build, c, "build")
 	overrideStringIfSet(&spec.ExcludeArtifacts, c, "exclude-artifacts")

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -1372,6 +1372,13 @@ func createFileInHomeDir(t *testing.T, fileName string) (testFileRelPath string,
 	return
 }
 
+func TestArtifactoryUploadLegacyProps(t *testing.T) {
+	initArtifactoryTest(t)
+	artifactoryCli.Exec("upload", "testdata/a/a*", tests.RtRepo1 + "/data/", "--props=key1=val1;key2=val2,val3")
+	verifyExistInArtifactoryByProps(tests.GetUploadLegacyPropsExpected(), tests.RtRepo1, "key1=val1;key2=val2;key2=val3", t)
+	cleanArtifactoryTest()
+}
+
 func TestArtifactoryUploadExcludeByCli1Wildcard(t *testing.T) {
 	initArtifactoryTest(t)
 	// Upload files
@@ -3071,7 +3078,7 @@ func TestArtifactorySortByCreated(t *testing.T) {
 	initArtifactoryTest(t)
 
 	// Upload files separately so we can sort by created.
-	artifactoryCli.Exec("upload", "testdata/created/or", tests.RtRepo1, `--props=k1=v1`)
+	artifactoryCli.Exec("upload", "testdata/created/or", tests.RtRepo1, `--added-props=k1=v1`)
 	artifactoryCli.Exec("upload", "testdata/created/o", tests.RtRepo1)
 	artifactoryCli.Exec("upload", "testdata/created/org", tests.RtRepo1)
 
@@ -3764,7 +3771,7 @@ func preUploadBasicTestResources() {
 	uploadPath := tests.GetTestResourcesPath() + "a/(.*)"
 	targetPath := tests.RtRepo1 + "/test_resources/{1}"
 	artifactoryCli.Exec("upload", uploadPath, targetPath,
-		"--threads=10", "--regexp=true", "--props=searchMe=true", "--flat=false")
+		"--threads=10", "--regexp=true", "--added-props=searchMe=true", "--flat=false")
 }
 
 func execDeleteRepo(repoName string) {

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -1374,7 +1374,7 @@ func createFileInHomeDir(t *testing.T, fileName string) (testFileRelPath string,
 
 func TestArtifactoryUploadLegacyProps(t *testing.T) {
 	initArtifactoryTest(t)
-	artifactoryCli.Exec("upload", "testdata/a/a*", tests.RtRepo1 + "/data/", "--props=key1=val1;key2=val2,val3")
+	artifactoryCli.Exec("upload", "testdata/a/a*", tests.RtRepo1+"/data/", "--props=key1=val1;key2=val2,val3")
 	verifyExistInArtifactoryByProps(tests.GetUploadLegacyPropsExpected(), tests.RtRepo1, "key1=val1;key2=val2;key2=val3", t)
 	cleanArtifactoryTest()
 }
@@ -3078,7 +3078,7 @@ func TestArtifactorySortByCreated(t *testing.T) {
 	initArtifactoryTest(t)
 
 	// Upload files separately so we can sort by created.
-	artifactoryCli.Exec("upload", "testdata/created/or", tests.RtRepo1, `--added-props=k1=v1`)
+	artifactoryCli.Exec("upload", "testdata/created/or", tests.RtRepo1, `--add-props=k1=v1`)
 	artifactoryCli.Exec("upload", "testdata/created/o", tests.RtRepo1)
 	artifactoryCli.Exec("upload", "testdata/created/org", tests.RtRepo1)
 
@@ -3771,7 +3771,7 @@ func preUploadBasicTestResources() {
 	uploadPath := tests.GetTestResourcesPath() + "a/(.*)"
 	targetPath := tests.RtRepo1 + "/test_resources/{1}"
 	artifactoryCli.Exec("upload", uploadPath, targetPath,
-		"--threads=10", "--regexp=true", "--added-props=searchMe=true", "--flat=false")
+		"--threads=10", "--regexp=true", "--add-props=searchMe=true", "--flat=false")
 }
 
 func execDeleteRepo(repoName string) {

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -3078,7 +3078,7 @@ func TestArtifactorySortByCreated(t *testing.T) {
 	initArtifactoryTest(t)
 
 	// Upload files separately so we can sort by created.
-	artifactoryCli.Exec("upload", "testdata/created/or", tests.RtRepo1, `--add-props=k1=v1`)
+	artifactoryCli.Exec("upload", "testdata/created/or", tests.RtRepo1, `--target-props=k1=v1`)
 	artifactoryCli.Exec("upload", "testdata/created/o", tests.RtRepo1)
 	artifactoryCli.Exec("upload", "testdata/created/org", tests.RtRepo1)
 
@@ -3771,7 +3771,7 @@ func preUploadBasicTestResources() {
 	uploadPath := tests.GetTestResourcesPath() + "a/(.*)"
 	targetPath := tests.RtRepo1 + "/test_resources/{1}"
 	artifactoryCli.Exec("upload", uploadPath, targetPath,
-		"--threads=10", "--regexp=true", "--add-props=searchMe=true", "--flat=false")
+		"--threads=10", "--regexp=true", "--target-props=searchMe=true", "--flat=false")
 }
 
 func execDeleteRepo(repoName string) {

--- a/distribution_test.go
+++ b/distribution_test.go
@@ -391,7 +391,7 @@ func TestCreateBundleProps(t *testing.T) {
 	runRt(t, "u", "--spec="+specFile)
 
 	// Create and distribute release bundle with added props
-	runRb(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*", "--add-props=key1=val1;key2=val2,val3", "--sign")
+	runRb(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*", "--target-props=key1=val1;key2=val2,val3", "--sign")
 	inttestutils.VerifyLocalBundleExistence(t, tests.BundleName, bundleVersion, true, distHttpDetails)
 	runRb(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
 
@@ -411,7 +411,7 @@ func TestUpdateBundleProps(t *testing.T) {
 
 	// Create, update and distribute release bundle with added props
 	runRb(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*")
-	runRb(t, "rbu", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*", "--add-props=key1=val1", "--sign")
+	runRb(t, "rbu", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*", "--target-props=key1=val1", "--sign")
 	inttestutils.VerifyLocalBundleExistence(t, tests.BundleName, bundleVersion, true, distHttpDetails)
 	runRb(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
 

--- a/distribution_test.go
+++ b/distribution_test.go
@@ -77,7 +77,7 @@ func initDistributionTest(t *testing.T) {
 }
 
 func cleanDistributionTest(t *testing.T) {
-	distributionCli.Exec("rbdel", tests.BundleName, bundleVersion, "--site=*", "--delete-from-dist", "--quiet", "--sync")
+	distributionCli.Exec("rbdel", tests.BundleName, bundleVersion, "--site=*", "--delete-from-dist", "--quiet")
 	inttestutils.WaitForDeletion(t, tests.BundleName, bundleVersion, distHttpDetails)
 	inttestutils.CleanDistributionRepositories(t, artifactoryDetails)
 	tests.CleanFileSystem()

--- a/distribution_test.go
+++ b/distribution_test.go
@@ -2,15 +2,17 @@ package main
 
 import (
 	"errors"
-	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+
+	"github.com/jfrog/jfrog-cli-core/utils/coreutils"
 
 	"github.com/jfrog/jfrog-cli-core/utils/config"
 	"github.com/jfrog/jfrog-cli/inttestutils"
 	"github.com/jfrog/jfrog-cli/utils/tests"
 	"github.com/jfrog/jfrog-client-go/auth"
+	clientDistUtils "github.com/jfrog/jfrog-client-go/distribution/services/utils"
 	"github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
@@ -75,7 +77,7 @@ func initDistributionTest(t *testing.T) {
 }
 
 func cleanDistributionTest(t *testing.T) {
-	distributionCli.Exec("rbdel", tests.BundleName, bundleVersion, "--site=*", "--delete-from-dist", "--quiet")
+	distributionCli.Exec("rbdel", tests.BundleName, bundleVersion, "--site=*", "--delete-from-dist", "--quiet", "--sync")
 	inttestutils.WaitForDeletion(t, tests.BundleName, bundleVersion, distHttpDetails)
 	inttestutils.CleanDistributionRepositories(t, artifactoryDetails)
 	tests.CleanFileSystem()
@@ -374,8 +376,47 @@ func TestCreateBundleText(t *testing.T) {
 		releaseNotes, err := ioutil.ReadFile(releaseNotesPath)
 		assert.NoError(t, err)
 		assert.Equal(t, string(releaseNotes), distributableResponse.ReleaseNotes.Content)
-		assert.Equal(t, "markdown", distributableResponse.ReleaseNotes.Syntax)
+		assert.Equal(t, clientDistUtils.Markdown, distributableResponse.ReleaseNotes.Syntax)
 	}
+
+	cleanDistributionTest(t)
+}
+
+func TestCreateBundleProps(t *testing.T) {
+	initDistributionTest(t)
+
+	// Upload files
+	specFile, err := tests.CreateSpec(tests.DistributionUploadSpecB)
+	assert.NoError(t, err)
+	runRt(t, "u", "--spec="+specFile)
+
+	// Create and distribute release bundle with added props
+	runRb(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*", "--added-props=key1=val1;key2=val2,val3", "--sign")
+	inttestutils.VerifyLocalBundleExistence(t, tests.BundleName, bundleVersion, true, distHttpDetails)
+	runRb(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
+
+	// Verify props are added to the distributes artifact
+	verifyExistInArtifactoryByProps(tests.GetBundlePropsExpected(), tests.DistRepo1+"/data/", "key1=val1;key2=val2;key2=val3", t)
+
+	cleanDistributionTest(t)
+}
+
+func TestUpdateBundleProps(t *testing.T) {
+	initDistributionTest(t)
+
+	// Upload files
+	specFile, err := tests.CreateSpec(tests.DistributionUploadSpecB)
+	assert.NoError(t, err)
+	runRt(t, "u", "--spec="+specFile)
+
+	// Create, update and distribute release bundle with added props
+	runRb(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*")
+	runRb(t, "rbu", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*", "--added-props=key1=val1", "--sign")
+	inttestutils.VerifyLocalBundleExistence(t, tests.BundleName, bundleVersion, true, distHttpDetails)
+	runRb(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
+
+	// Verify props are added to the distributes artifact
+	verifyExistInArtifactoryByProps(tests.GetBundlePropsExpected(), tests.DistRepo1+"/data/", "key1=val1", t)
 
 	cleanDistributionTest(t)
 }

--- a/distribution_test.go
+++ b/distribution_test.go
@@ -391,7 +391,7 @@ func TestCreateBundleProps(t *testing.T) {
 	runRt(t, "u", "--spec="+specFile)
 
 	// Create and distribute release bundle with added props
-	runRb(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*", "--added-props=key1=val1;key2=val2,val3", "--sign")
+	runRb(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*", "--add-props=key1=val1;key2=val2,val3", "--sign")
 	inttestutils.VerifyLocalBundleExistence(t, tests.BundleName, bundleVersion, true, distHttpDetails)
 	runRb(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
 
@@ -411,7 +411,7 @@ func TestUpdateBundleProps(t *testing.T) {
 
 	// Create, update and distribute release bundle with added props
 	runRb(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*")
-	runRb(t, "rbu", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*", "--added-props=key1=val1", "--sign")
+	runRb(t, "rbu", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*", "--add-props=key1=val1", "--sign")
 	inttestutils.VerifyLocalBundleExistence(t, tests.BundleName, bundleVersion, true, distHttpDetails)
 	runRb(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
 

--- a/inttestutils/distribution.go
+++ b/inttestutils/distribution.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jfrog/jfrog-cli-core/artifactory/spec"
 	"github.com/jfrog/jfrog-cli-core/utils/config"
 	"github.com/jfrog/jfrog-cli/utils/tests"
+	"github.com/jfrog/jfrog-client-go/distribution/services/utils"
 	"github.com/jfrog/jfrog-client-go/http/httpclient"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/io/httputils"
@@ -51,16 +52,10 @@ const (
 // GET api/v1/release_bundle/:name/:version
 // Retreive the status of a release bundle before distribution.
 type distributableResponse struct {
-	Name         string                          `json:"name,omitempty"`
-	Version      string                          `json:"version,omitempty"`
-	State        distributableDistributionStatus `json:"state,omitempty"`
-	Description  string                          `json:"description,omitempty"`
-	ReleaseNotes releaseNotesResponse            `json:"release_notes,omitempty"`
-}
-
-type releaseNotesResponse struct {
-	Content string `json:"content,omitempty"`
-	Syntax  string `json:"syntax,omitempty"`
+	utils.ReleaseBundleBody
+	Name    string                          `json:"name,omitempty"`
+	Version string                          `json:"version,omitempty"`
+	State   distributableDistributionStatus `json:"state,omitempty"`
 }
 
 // Get api/v1/release_bundle/:name/:version/distribution

--- a/testdata/specs/bundle_download_spec.json
+++ b/testdata/specs/bundle_download_spec.json
@@ -3,7 +3,8 @@
       {
         "pattern": "${DIST_REPO1}/data/*",
         "target": "out/download/simple_by_build/",
-        "bundle": "${BUNDLE_NAME}/10"
+        "bundle": "${BUNDLE_NAME}/10",
+        "props": "key1=val1"
       }
     ]
   }

--- a/testdata/specs/dist_upload_spec_b.json
+++ b/testdata/specs/dist_upload_spec_b.json
@@ -4,7 +4,8 @@
       "pattern": "testdata/a/b/*",
       "target": "${DIST_REPO1}/data/",
       "flat": "true",
-      "recursive": "false"
+      "recursive": "false",
+      "addedProps": "key1=val1"
     }
   ]
 }

--- a/testdata/specs/dist_upload_spec_b.json
+++ b/testdata/specs/dist_upload_spec_b.json
@@ -5,7 +5,7 @@
       "target": "${DIST_REPO1}/data/",
       "flat": "true",
       "recursive": "false",
-      "addedProps": "key1=val1"
+      "addProps": "key1=val1"
     }
   ]
 }

--- a/testdata/specs/dist_upload_spec_b.json
+++ b/testdata/specs/dist_upload_spec_b.json
@@ -5,7 +5,7 @@
       "target": "${DIST_REPO1}/data/",
       "flat": "true",
       "recursive": "false",
-      "addProps": "key1=val1"
+      "targetProps": "key1=val1"
     }
   ]
 }

--- a/testdata/specs/upload_multiple_file_specs.json
+++ b/testdata/specs/upload_multiple_file_specs.json
@@ -8,7 +8,7 @@
       "pattern": "testdata/a/b/b2.in",
       "target": "${REPO1}/multiple/properties/",
       "flat": "false",
-      "addProps": "searchMe=true"
+      "targetProps": "searchMe=true"
     }
   ]
 }

--- a/testdata/specs/upload_multiple_file_specs.json
+++ b/testdata/specs/upload_multiple_file_specs.json
@@ -8,7 +8,7 @@
       "pattern": "testdata/a/b/b2.in",
       "target": "${REPO1}/multiple/properties/",
       "flat": "false",
-      "addedProps": "searchMe=true"
+      "addProps": "searchMe=true"
     }
   ]
 }

--- a/testdata/specs/upload_multiple_file_specs.json
+++ b/testdata/specs/upload_multiple_file_specs.json
@@ -8,7 +8,7 @@
       "pattern": "testdata/a/b/b2.in",
       "target": "${REPO1}/multiple/properties/",
       "flat": "false",
-      "props": "searchMe=true"
+      "addedProps": "searchMe=true"
     }
   ]
 }

--- a/testdata/specs/upload_with_props_spec.json
+++ b/testdata/specs/upload_with_props_spec.json
@@ -3,47 +3,47 @@
     {
       "pattern": "testdata/a/b/c/c1.in",
       "target": "${REPO1}/a/b/c/c1.in",
-      "addedProps": "b=1"
+      "addProps": "b=1"
     },
     {
       "pattern": "testdata/a/b/c/c2.in",
       "target": "${REPO1}/a/b/c/c2.in",
-      "addedProps": "c=3"
+      "addProps": "c=3"
     },
     {
       "pattern": "testdata/a/b/c/c3.in",
       "target": "${REPO1}/a/b/c/c3.in",
-      "addedProps": "c=3"
+      "addProps": "c=3"
     },
     {
       "pattern": "testdata/a/b/b1.in",
       "target": "${REPO1}/a/b/b1.in",
-      "addedProps": "a=1;c=5"
+      "addProps": "a=1;c=5"
     },
     {
       "pattern": "testdata/a/b/b2.in",
       "target": "${REPO1}/a/b/b2.in",
-      "addedProps": "b=1;c=3"
+      "addProps": "b=1;c=3"
     },
     {
       "pattern": "testdata/a/b/b3.in",
       "target": "${REPO1}/a/b/b3.in",
-      "addedProps": "a=1;b=2;c=3"
+      "addProps": "a=1;b=2;c=3"
     },
     {
       "pattern": "testdata/a/a1.in",
       "target": "${REPO1}/a/a1.in",
-      "addedProps": "a=2;b=3"
+      "addProps": "a=2;b=3"
     },
     {
       "pattern": "testdata/a/a2.in",
       "target": "${REPO1}/a/a2.in",
-      "addedProps": "a=1"
+      "addProps": "a=1"
     },
     {
       "pattern": "testdata/a/a3.in",
       "target": "${REPO1}/a/a3.in",
-      "addedProps": "a=1;b=3;c=3"
+      "addProps": "a=1;b=3;c=3"
     }
   ]
 }

--- a/testdata/specs/upload_with_props_spec.json
+++ b/testdata/specs/upload_with_props_spec.json
@@ -3,47 +3,47 @@
     {
       "pattern": "testdata/a/b/c/c1.in",
       "target": "${REPO1}/a/b/c/c1.in",
-      "addProps": "b=1"
+      "targetProps": "b=1"
     },
     {
       "pattern": "testdata/a/b/c/c2.in",
       "target": "${REPO1}/a/b/c/c2.in",
-      "addProps": "c=3"
+      "targetProps": "c=3"
     },
     {
       "pattern": "testdata/a/b/c/c3.in",
       "target": "${REPO1}/a/b/c/c3.in",
-      "addProps": "c=3"
+      "targetProps": "c=3"
     },
     {
       "pattern": "testdata/a/b/b1.in",
       "target": "${REPO1}/a/b/b1.in",
-      "addProps": "a=1;c=5"
+      "targetProps": "a=1;c=5"
     },
     {
       "pattern": "testdata/a/b/b2.in",
       "target": "${REPO1}/a/b/b2.in",
-      "addProps": "b=1;c=3"
+      "targetProps": "b=1;c=3"
     },
     {
       "pattern": "testdata/a/b/b3.in",
       "target": "${REPO1}/a/b/b3.in",
-      "addProps": "a=1;b=2;c=3"
+      "targetProps": "a=1;b=2;c=3"
     },
     {
       "pattern": "testdata/a/a1.in",
       "target": "${REPO1}/a/a1.in",
-      "addProps": "a=2;b=3"
+      "targetProps": "a=2;b=3"
     },
     {
       "pattern": "testdata/a/a2.in",
       "target": "${REPO1}/a/a2.in",
-      "addProps": "a=1"
+      "targetProps": "a=1"
     },
     {
       "pattern": "testdata/a/a3.in",
       "target": "${REPO1}/a/a3.in",
-      "addProps": "a=1;b=3;c=3"
+      "targetProps": "a=1;b=3;c=3"
     }
   ]
 }

--- a/testdata/specs/upload_with_props_spec.json
+++ b/testdata/specs/upload_with_props_spec.json
@@ -3,47 +3,47 @@
     {
       "pattern": "testdata/a/b/c/c1.in",
       "target": "${REPO1}/a/b/c/c1.in",
-      "props": "b=1"
+      "addedProps": "b=1"
     },
     {
       "pattern": "testdata/a/b/c/c2.in",
       "target": "${REPO1}/a/b/c/c2.in",
-      "props": "c=3"
+      "addedProps": "c=3"
     },
     {
       "pattern": "testdata/a/b/c/c3.in",
       "target": "${REPO1}/a/b/c/c3.in",
-      "props": "c=3"
+      "addedProps": "c=3"
     },
     {
       "pattern": "testdata/a/b/b1.in",
       "target": "${REPO1}/a/b/b1.in",
-      "props": "a=1;c=5"
+      "addedProps": "a=1;c=5"
     },
     {
       "pattern": "testdata/a/b/b2.in",
       "target": "${REPO1}/a/b/b2.in",
-      "props": "b=1;c=3"
+      "addedProps": "b=1;c=3"
     },
     {
       "pattern": "testdata/a/b/b3.in",
       "target": "${REPO1}/a/b/b3.in",
-      "props": "a=1;b=2;c=3"
+      "addedProps": "a=1;b=2;c=3"
     },
     {
       "pattern": "testdata/a/a1.in",
       "target": "${REPO1}/a/a1.in",
-      "props": "a=2;b=3"
+      "addedProps": "a=2;b=3"
     },
     {
       "pattern": "testdata/a/a2.in",
       "target": "${REPO1}/a/a2.in",
-      "props": "a=1"
+      "addedProps": "a=1"
     },
     {
       "pattern": "testdata/a/a3.in",
       "target": "${REPO1}/a/a3.in",
-      "props": "a=1;b=3;c=3"
+      "addedProps": "a=1;b=3;c=3"
     }
   ]
 }

--- a/testdata/specs/upload_with_props_spec_delete_exclude_props.json
+++ b/testdata/specs/upload_with_props_spec_delete_exclude_props.json
@@ -15,7 +15,7 @@
     {
       "pattern": "testdata/a/b/c/c1.in",
       "target": "${REPO1}/a/",
-      "addedProps": "c=1"
+      "addProps": "c=1"
     },
     {
       "pattern": "testdata/a/b/*",
@@ -24,7 +24,7 @@
     {
       "pattern": "testdata/a/b/c/c1.in",
       "target": "${REPO1}/e/",
-      "addedProps": "c=1"
+      "addProps": "c=1"
     }
   ]
 }

--- a/testdata/specs/upload_with_props_spec_delete_exclude_props.json
+++ b/testdata/specs/upload_with_props_spec_delete_exclude_props.json
@@ -15,7 +15,7 @@
     {
       "pattern": "testdata/a/b/c/c1.in",
       "target": "${REPO1}/a/",
-      "addProps": "c=1"
+      "targetProps": "c=1"
     },
     {
       "pattern": "testdata/a/b/*",
@@ -24,7 +24,7 @@
     {
       "pattern": "testdata/a/b/c/c1.in",
       "target": "${REPO1}/e/",
-      "addProps": "c=1"
+      "targetProps": "c=1"
     }
   ]
 }

--- a/testdata/specs/upload_with_props_spec_delete_exclude_props.json
+++ b/testdata/specs/upload_with_props_spec_delete_exclude_props.json
@@ -15,7 +15,7 @@
     {
       "pattern": "testdata/a/b/c/c1.in",
       "target": "${REPO1}/a/",
-      "props": "c=1"
+      "addedProps": "c=1"
     },
     {
       "pattern": "testdata/a/b/*",
@@ -24,7 +24,7 @@
     {
       "pattern": "testdata/a/b/c/c1.in",
       "target": "${REPO1}/e/",
-      "props": "c=1"
+      "addedProps": "c=1"
     }
   ]
 }

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -331,6 +331,7 @@ const (
 	sync                = "sync"
 	maxWaitMinutes      = "max-wait-minutes"
 	deleteFromDist      = "delete-from-dist"
+	addedProps          = "added-props"
 
 	// Template user flags
 	vars = "vars"
@@ -1023,6 +1024,10 @@ var flagsMap = map[string]cli.Flag{
 		Name:  deleteFromDist,
 		Usage: "[Default: false] Set to true to delete release bundle version in JFrog Distribution itself after deletion is complete in the specified Edge node/s.` `",
 	},
+	addedProps: cli.StringFlag{
+		Name:  addedProps,
+		Usage: "[Optional] The list of properties, in the form of key1=value1;key2=value2,..., to be added to the artifacts after distribution of the release bundle.` `",
+	},
 	vars: cli.StringFlag{
 		Name:  vars,
 		Usage: "[Optional] List of variables in the form of \"key1=value1;key2=value2;...\" to be replaced in the template. In the template, the variables should be used as follows: ${key1}.` `",
@@ -1253,11 +1258,11 @@ var commandFlags = map[string][]string{
 		buildName, buildNumber, module,
 	},
 	ReleaseBundleCreate: {
-		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars,
+		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars, addedProps,
 		rbDryRun, sign, desc, exclusions, releaseNotesPath, releaseNotesSyntax, rbPassphrase, rbRepo, insecureTls,
 	},
 	ReleaseBundleUpdate: {
-		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars,
+		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars, addedProps,
 		rbDryRun, sign, desc, exclusions, releaseNotesPath, releaseNotesSyntax, rbPassphrase, rbRepo, insecureTls,
 	},
 	ReleaseBundleSign: {

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -126,7 +126,7 @@ const (
 	explode          = "explode"
 	includeDirs      = "include-dirs"
 	props            = "props"
-	addProps         = "add-props"
+	targetProps      = "target-props"
 	excludeProps     = "exclude-props"
 	failNoOp         = "fail-no-op"
 	threads          = "threads"
@@ -152,7 +152,7 @@ const (
 	uploadRetries         = uploadPrefix + retries
 	uploadExplode         = uploadPrefix + explode
 	uploadProps           = uploadPrefix + props
-	uploadAddProps        = uploadPrefix + addProps
+	uploadTargetProps     = uploadPrefix + targetProps
 	uploadSyncDeletes     = uploadPrefix + syncDeletes
 	deb                   = "deb"
 	symlinks              = "symlinks"
@@ -582,7 +582,7 @@ var flagsMap = map[string]cli.Flag{
 		Name:  props,
 		Usage: "[Deprecated] [Optional] List of properties in the form of \"key1=value1;key2=value2,...\". Those properties will be attached to the uploaded artifacts.` `",
 	},
-	uploadAddProps: cli.StringFlag{
+	uploadTargetProps: cli.StringFlag{
 		Name:  props,
 		Usage: "[Optional] List of properties in the form of \"key1=value1;key2=value2,...\". Those properties will be attached to the uploaded artifacts.` `",
 	},
@@ -1029,8 +1029,8 @@ var flagsMap = map[string]cli.Flag{
 		Name:  deleteFromDist,
 		Usage: "[Default: false] Set to true to delete release bundle version in JFrog Distribution itself after deletion is complete in the specified Edge node/s.` `",
 	},
-	addProps: cli.StringFlag{
-		Name:  addProps,
+	targetProps: cli.StringFlag{
+		Name:  targetProps,
 		Usage: "[Optional] The list of properties, in the form of key1=value1;key2=value2,..., to be added to the artifacts after distribution of the release bundle.` `",
 	},
 	vars: cli.StringFlag{
@@ -1110,7 +1110,7 @@ var commandFlags = map[string][]string{
 		clientCertKeyPath, basicAuthOnly, insecureTls,
 	},
 	Upload: {
-		url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath, serverId, clientCertPath, addProps,
+		url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath, serverId, clientCertPath, targetProps,
 		clientCertKeyPath, spec, specVars, buildName, buildNumber, module, uploadExcludePatterns, uploadExclusions, deb,
 		uploadRecursive, uploadFlat, uploadRegexp, uploadRetries, dryRun, uploadExplode, symlinks, includeDirs,
 		uploadProps, failNoOp, threads, uploadSyncDeletes, syncDeletesQuiet, insecureTls, detailedSummary,
@@ -1263,11 +1263,11 @@ var commandFlags = map[string][]string{
 		buildName, buildNumber, module,
 	},
 	ReleaseBundleCreate: {
-		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars, addProps,
+		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars, targetProps,
 		rbDryRun, sign, desc, exclusions, releaseNotesPath, releaseNotesSyntax, rbPassphrase, rbRepo, insecureTls,
 	},
 	ReleaseBundleUpdate: {
-		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars, addProps,
+		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars, targetProps,
 		rbDryRun, sign, desc, exclusions, releaseNotesPath, releaseNotesSyntax, rbPassphrase, rbRepo, insecureTls,
 	},
 	ReleaseBundleSign: {

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -126,6 +126,7 @@ const (
 	explode          = "explode"
 	includeDirs      = "include-dirs"
 	props            = "props"
+	addedProps       = "added-props"
 	excludeProps     = "exclude-props"
 	failNoOp         = "fail-no-op"
 	threads          = "threads"
@@ -151,6 +152,7 @@ const (
 	uploadRetries         = uploadPrefix + retries
 	uploadExplode         = uploadPrefix + explode
 	uploadProps           = uploadPrefix + props
+	uploadAddedProps      = uploadPrefix + addedProps
 	uploadSyncDeletes     = uploadPrefix + syncDeletes
 	deb                   = "deb"
 	symlinks              = "symlinks"
@@ -331,7 +333,6 @@ const (
 	sync                = "sync"
 	maxWaitMinutes      = "max-wait-minutes"
 	deleteFromDist      = "delete-from-dist"
-	addedProps          = "added-props"
 
 	// Template user flags
 	vars = "vars"
@@ -578,6 +579,10 @@ var flagsMap = map[string]cli.Flag{
 		Usage: "[Default: false] Set to true to preserve symbolic links structure in Artifactory.` `",
 	},
 	uploadProps: cli.StringFlag{
+		Name:  props,
+		Usage: "[Deprecated] [Optional] List of properties in the form of \"key1=value1;key2=value2,...\". Those properties will be attached to the uploaded artifacts.` `",
+	},
+	uploadAddedProps: cli.StringFlag{
 		Name:  props,
 		Usage: "[Optional] List of properties in the form of \"key1=value1;key2=value2,...\". Those properties will be attached to the uploaded artifacts.` `",
 	},
@@ -1105,7 +1110,7 @@ var commandFlags = map[string][]string{
 		clientCertKeyPath, basicAuthOnly, insecureTls,
 	},
 	Upload: {
-		url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath, serverId, clientCertPath,
+		url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath, serverId, clientCertPath, addedProps,
 		clientCertKeyPath, spec, specVars, buildName, buildNumber, module, uploadExcludePatterns, uploadExclusions, deb,
 		uploadRecursive, uploadFlat, uploadRegexp, uploadRetries, dryRun, uploadExplode, symlinks, includeDirs,
 		uploadProps, failNoOp, threads, uploadSyncDeletes, syncDeletesQuiet, insecureTls, detailedSummary,

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -126,7 +126,7 @@ const (
 	explode          = "explode"
 	includeDirs      = "include-dirs"
 	props            = "props"
-	addedProps       = "added-props"
+	addProps         = "add-props"
 	excludeProps     = "exclude-props"
 	failNoOp         = "fail-no-op"
 	threads          = "threads"
@@ -152,7 +152,7 @@ const (
 	uploadRetries         = uploadPrefix + retries
 	uploadExplode         = uploadPrefix + explode
 	uploadProps           = uploadPrefix + props
-	uploadAddedProps      = uploadPrefix + addedProps
+	uploadAddProps        = uploadPrefix + addProps
 	uploadSyncDeletes     = uploadPrefix + syncDeletes
 	deb                   = "deb"
 	symlinks              = "symlinks"
@@ -582,7 +582,7 @@ var flagsMap = map[string]cli.Flag{
 		Name:  props,
 		Usage: "[Deprecated] [Optional] List of properties in the form of \"key1=value1;key2=value2,...\". Those properties will be attached to the uploaded artifacts.` `",
 	},
-	uploadAddedProps: cli.StringFlag{
+	uploadAddProps: cli.StringFlag{
 		Name:  props,
 		Usage: "[Optional] List of properties in the form of \"key1=value1;key2=value2,...\". Those properties will be attached to the uploaded artifacts.` `",
 	},
@@ -1029,8 +1029,8 @@ var flagsMap = map[string]cli.Flag{
 		Name:  deleteFromDist,
 		Usage: "[Default: false] Set to true to delete release bundle version in JFrog Distribution itself after deletion is complete in the specified Edge node/s.` `",
 	},
-	addedProps: cli.StringFlag{
-		Name:  addedProps,
+	addProps: cli.StringFlag{
+		Name:  addProps,
 		Usage: "[Optional] The list of properties, in the form of key1=value1;key2=value2,..., to be added to the artifacts after distribution of the release bundle.` `",
 	},
 	vars: cli.StringFlag{
@@ -1110,7 +1110,7 @@ var commandFlags = map[string][]string{
 		clientCertKeyPath, basicAuthOnly, insecureTls,
 	},
 	Upload: {
-		url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath, serverId, clientCertPath, addedProps,
+		url, user, password, apikey, accessToken, sshPassPhrase, sshKeyPath, serverId, clientCertPath, addProps,
 		clientCertKeyPath, spec, specVars, buildName, buildNumber, module, uploadExcludePatterns, uploadExclusions, deb,
 		uploadRecursive, uploadFlat, uploadRegexp, uploadRetries, dryRun, uploadExplode, symlinks, includeDirs,
 		uploadProps, failNoOp, threads, uploadSyncDeletes, syncDeletesQuiet, insecureTls, detailedSummary,
@@ -1263,11 +1263,11 @@ var commandFlags = map[string][]string{
 		buildName, buildNumber, module,
 	},
 	ReleaseBundleCreate: {
-		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars, addedProps,
+		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars, addProps,
 		rbDryRun, sign, desc, exclusions, releaseNotesPath, releaseNotesSyntax, rbPassphrase, rbRepo, insecureTls,
 	},
 	ReleaseBundleUpdate: {
-		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars, addedProps,
+		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars, addProps,
 		rbDryRun, sign, desc, exclusions, releaseNotesPath, releaseNotesSyntax, rbPassphrase, rbRepo, insecureTls,
 	},
 	ReleaseBundleSign: {

--- a/utils/tests/artifactoryconsts.go
+++ b/utils/tests/artifactoryconsts.go
@@ -172,6 +172,14 @@ func GetSimpleUploadExpectedRepo1() []string {
 	}
 }
 
+func GetUploadLegacyPropsExpected() []string {
+	return []string{
+		RtRepo1 + "/data/a1.in",
+		RtRepo1 + "/data/a2.in",
+		RtRepo1 + "/data/a3.in",
+	}
+}
+
 func GetSimpleWildcardUploadExpectedRepo1() []string {
 	return []string{
 		RtRepo1 + "/upload_simple_wildcard/github.com/github.in",

--- a/utils/tests/artifactoryconsts.go
+++ b/utils/tests/artifactoryconsts.go
@@ -403,6 +403,14 @@ func GetBundleCopyExpected() []string {
 	}
 }
 
+func GetBundlePropsExpected() []string {
+	return []string{
+		DistRepo1 + "/data/b1.in",
+		DistRepo1 + "/data/b2.in",
+		DistRepo1 + "/data/b3.in",
+	}
+}
+
 func GetGitLfsExpected() []string {
 	return []string{
 		RtLfsRepo + "/objects/4b/f4/4bf4c8c0fef3f5c8cf6f255d1c784377138588c0a9abe57e440bce3ccb350c2e",


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Depends on: https://github.com/jfrog/jfrog-cli-core/pull/60, https://github.com/jfrog/jfrog-client-go/pull/272
Partialy resolves https://github.com/jfrog/jfrog-cli/issues/898

* Allow adding props to release bundles, during release bundle create or update.
* Add AddProps to upload commands.

**Example 1 - Add props by flag**:
```sh
# Upload a file
jfrog rt u ./a.zip generic-local/

# Create a signed release bundle
jfrog rt release-bundle-create mando 16 generic-local/a.zip --target-props="jedy=luke" --sign

# Distribute release bundle
jfrog rt release-bundle mando 16
```

**Example 2 - Add props by file spec:**
filespec.json:
```json
{
  "files": [
    {
      "pattern": "./a.zip",
      "target": "generic-local/",
      "targetProps": "jedy=luke"
    }
  ]
}
```
```sh
# Upload a file
jfrog rt u ./a.zip generic-local/

# Create a signed release bundle
jfrog rt release-bundle-create mando 16 --spec=filespec.json --sign

# Distribute release bundle
jfrog rt release-bundle mando 16
```