### PR TITLE
Support path mapping in distribution

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -3308,6 +3308,7 @@ func createDefaultBuildAddDependenciesSpec(c *cli.Context) *spec.SpecFiles {
 func createDefaultReleaseBundleSpec(c *cli.Context) *spec.SpecFiles {
 	return spec.NewBuilder().
 		Pattern(c.Args().Get(2)).
+		Target(c.String("target")).
 		Props(c.String("props")).
 		Build(c.String("build")).
 		Bundle(c.String("bundle")).

--- a/testdata/specs/dist_create_with_mapping.json
+++ b/testdata/specs/dist_create_with_mapping.json
@@ -1,0 +1,8 @@
+{
+  "files": [
+    {
+      "pattern": "${DIST_REPO1}/data/(*)",
+      "target": "${DIST_REPO2}/target/{1}"
+    }
+  ]
+}

--- a/testdata/specs/dist_mapping_download_spec.json
+++ b/testdata/specs/dist_mapping_download_spec.json
@@ -1,0 +1,8 @@
+{
+    "files": [
+      {
+        "pattern": "${DIST_REPO2}/target/*",
+        "target": "out/download/"
+      }
+    ]
+  }

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -322,6 +322,7 @@ const (
 	rbDryRun            = releaseBundlePrefix + dryRun
 	rbRepo              = releaseBundlePrefix + repo
 	rbPassphrase        = releaseBundlePrefix + passphrase
+	distTarget          = releaseBundlePrefix + target
 	sign                = "sign"
 	desc                = "desc"
 	releaseNotesPath    = "release-notes-path"
@@ -997,6 +998,11 @@ var flagsMap = map[string]cli.Flag{
 		Name:  passphrase,
 		Usage: "[Optional] The passphrase for the signing key. ` `",
 	},
+	distTarget: cli.StringFlag{
+		Name: target,
+		Usage: "[Optional] The target path for artifacts matched in the pattern path. " +
+			"For flexibility in specifying the distribution path, you can include placeholders in the form of {1}, {2} which are replaced by corresponding tokens in the pattern path that are enclosed in parenthesis. ` `",
+	},
 	rbRepo: cli.StringFlag{
 		Name:  repo,
 		Usage: "[Optional] A repository name at source Artifactory to store release bundle artifacts in. If not provided, Artifactory will use the default one.` `",
@@ -1264,11 +1270,11 @@ var commandFlags = map[string][]string{
 	},
 	ReleaseBundleCreate: {
 		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars, targetProps,
-		rbDryRun, sign, desc, exclusions, releaseNotesPath, releaseNotesSyntax, rbPassphrase, rbRepo, insecureTls,
+		rbDryRun, sign, desc, exclusions, releaseNotesPath, releaseNotesSyntax, rbPassphrase, rbRepo, insecureTls, distTarget,
 	},
 	ReleaseBundleUpdate: {
 		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, spec, specVars, targetProps,
-		rbDryRun, sign, desc, exclusions, releaseNotesPath, releaseNotesSyntax, rbPassphrase, rbRepo, insecureTls,
+		rbDryRun, sign, desc, exclusions, releaseNotesPath, releaseNotesSyntax, rbPassphrase, rbRepo, insecureTls, distTarget,
 	},
 	ReleaseBundleSign: {
 		url, distUrl, user, password, apikey, accessToken, sshKeyPath, sshPassPhrase, serverId, rbPassphrase, rbRepo,

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -1000,7 +1000,7 @@ var flagsMap = map[string]cli.Flag{
 	},
 	distTarget: cli.StringFlag{
 		Name: target,
-		Usage: "[Optional] The target path for artifacts matched in the pattern path. " +
+		Usage: "[Optional] The target path for distributed artifacts on the edge node. If not specified, the artifacts will have the same path and name on the edge node, as on the source Artifactory server. " +
 			"For flexibility in specifying the distribution path, you can include placeholders in the form of {1}, {2} which are replaced by corresponding tokens in the pattern path that are enclosed in parenthesis. ` `",
 	},
 	rbRepo: cli.StringFlag{

--- a/utils/tests/artifactoryconsts.go
+++ b/utils/tests/artifactoryconsts.go
@@ -36,6 +36,8 @@ const (
 	DelSpecExclude                         = "delete_spec_exclude.json"
 	DelSpecExclusions                      = "delete_spec_exclusions.json"
 	DistributionCreateByAql                = "dist_create_by_aql.json"
+	DistributionCreateWithMapping          = "dist_create_with_mapping.json"
+	DistributionMappingDownload            = "dist_mapping_download_spec.json"
 	DistributionRepoConfig1                = "dist_repository_config1.json"
 	DistributionRepoConfig2                = "dist_repository_config2.json"
 	DistributionRules                      = "distribution_rules.json"
@@ -416,6 +418,14 @@ func GetBundlePropsExpected() []string {
 		DistRepo1 + "/data/b1.in",
 		DistRepo1 + "/data/b2.in",
 		DistRepo1 + "/data/b3.in",
+	}
+}
+
+func GetBundleMappingExpected() []string {
+	return []string{
+		DistRepo2 + "/target/b1.in",
+		DistRepo2 + "/target/b2.in",
+		DistRepo2 + "/target/b3.in",
 	}
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Depends on: https://github.com/jfrog/jfrog-client-go/pull/274

Add `--target` flag to the `release-bundle-create` and `release-bundle-update` commands to support Distribution path mapping. For more information about the file-spec-based path mapping see https://github.com/jfrog/jfrog-client-go/pull/274.