### PR TITLE
Hide deprecated flag & shorten git URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func execMain() error {
 
 	app := cli.NewApp()
 	app.Name = "jfrog"
-	app.Usage = "See https://github.com/jfrog/jfrog-cli-go for usage instructions."
+	app.Usage = "See https://github.com/jfrog/jfrog-cli for usage instructions."
 	app.Version = cliutils.GetVersion()
 	args := os.Args
 	app.EnableBashCompletion = true

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -591,8 +591,9 @@ var flagsMap = map[string]cli.Flag{
 		Usage: "[Default: false] Set to true to preserve symbolic links structure in Artifactory.` `",
 	},
 	uploadProps: cli.StringFlag{
-		Name:  props,
-		Usage: "[Deprecated] [Optional] List of properties in the form of \"key1=value1;key2=value2,...\". Those properties will be attached to the uploaded artifacts.` `",
+		Name:   props,
+		Usage:  "[Deprecated] [Optional] List of properties in the form of \"key1=value1;key2=value2,...\". Those properties will be attached to the uploaded artifacts.` `",
+		Hidden: true,
 	},
 	uploadTargetProps: cli.StringFlag{
 		Name:  props,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Following the introduction of the new ```target-props``` upload command option and the deprecation of the ```props``` option, this PR hides the ```props``` option.
It also modifies the the project's git URL to its newer form.