### PR TITLE
Add support for new "full" docker image

### DIFF
--- a/build/docker/full/Dockerfile
+++ b/build/docker/full/Dockerfile
@@ -1,0 +1,9 @@
+ARG image_name=jfrog-cli-full
+FROM golang:1.14 as builder
+WORKDIR /${image_name}
+COPY . /${image_name}
+RUN sh build/build.sh
+FROM releases-docker.jfrog.io/jfrog-ecosystem-integration-env:latest
+ENV CI true
+COPY --from=builder /${image_name}/jfrog /usr/local/bin/jfrog
+RUN chmod +x /usr/local/bin/jfrog

--- a/build/docker/slim/Dockerfile
+++ b/build/docker/slim/Dockerfile
@@ -1,9 +1,10 @@
+ARG image_name=jfrog-cli
 FROM golang:1.14-alpine as builder
-WORKDIR /jfrog-cli-go
-COPY . /jfrog-cli-go
+WORKDIR /${image_name}
+COPY . /${image_name}
 RUN apk add --update git && sh build/build.sh
 FROM alpine:3.12.0
 ENV CI true
 RUN apk add --no-cache bash tzdata ca-certificates curl
-COPY --from=builder /jfrog-cli-go/jfrog /usr/local/bin/jfrog
+COPY --from=builder /${image_name}/jfrog /usr/local/bin/jfrog
 RUN chmod +x /usr/local/bin/jfrog


### PR DESCRIPTION
A new JFrog CLI image will now be published to release.jfrog.io. This image is based on the `jfrog-ecosystem-integration-env` image, so it contains all the build tools needed for all the CLI's functionality, besides the CLI itself.
The image will available from `releases-docker.jfrog.io/jfrog/jfrog-cli-full`.

The old and slim JFrog CLI image is still available, now from `releases-docker.jfrog.io/jfrog/jfrog-cli`.
