### PR TITLE
Update CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,10 +9,16 @@ jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: sign-or-recheck
+        with:
+          text: ${{ github.event.comment.body }}
+          regex: '\s*(I have read the CLA Document and I hereby sign the CLA)|(recheckcla)\s*'
+      
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: ${{ steps.sign-or-recheck.outputs.match != '' }} || github.event_name == 'pull_request_target'
         # Alpha Release
-        uses: cla-assistant/github-action@v2.0.1-alpha
+        uses: cla-assistant/github-action@v2.1.1-beta
         env:
           # Generated and maintained by github
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -20,7 +26,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_SIGN_TOKEN }}
         with:
           path-to-signatures: 'signed_clas.json'
-          path-to-cla-document: 'https://jfrog.com/cla/'
+          path-to-document: 'https://jfrog.com/cla/'
           remote-organization-name: 'jfrog'
           remote-repository-name: 'jfrog-signed-clas'
           # branch should not be protected


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

* Accept sign comments and `recheckcla` with newlines.
* Upgrade `cla-assistant` Action to 2.1.1. One important feature is: "Skip posting a comment in every PR if the contributor has already signed" See [PR-73](https://github.com/cla-assistant/github-action/pull/73). This will prevent spam in every PR we create.

Notice -
GitHub actions do not yet support running an Action from another Action. Therefore for now we'll have to change it manually in all repositories.