### PR TITLE
Run go mod tidy before Docker tests

### DIFF
--- a/pipelines.yml
+++ b/pipelines.yml
@@ -137,7 +137,7 @@ pipelines:
             # Install Golang
             - curl -LO https://get.golang.org/$(uname)/go_installer && chmod +x go_installer && SHELL=bash ./go_installer && rm go_installer
             - export PATH=/$HOME/.go/bin:$PATH
-            - go version
+            - go version && go mod tidy
             # Install Podman
             - echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
             - curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/Release.key | apt-key add -


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

May resolve:
> go: updates to go.mod needed; to update it:
	go mod tidy

Analysis:
The Go version in Docker tests may be different since we install the latest version every running.

See:
https://ecosysjfrog.jfrog.io/ui/pipelines/myPipelines/default/test_cli/418/Docker?branch=dev