### PR TITLE
Add '-g' flag to the curl command in getCli

### DIFF
--- a/build/getCli.sh
+++ b/build/getCli.sh
@@ -48,5 +48,5 @@ else
     FILE_NAME="jfrog"
 fi
 
-curl -XGET "$URL" -L -k > $FILE_NAME
+curl -XGET "$URL" -L -k -g > $FILE_NAME
 chmod u+x $FILE_NAME


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Resolves the following error in some systems:
> curl: (3) [globbing] error: bad range specification after pos 53