### PR TITLE
Fix usage in config add and edit commands

### DIFF
--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -396,10 +396,10 @@ const (
 	configXrUrl       = "xray-url"
 	configMcUrl       = "mission-control-url"
 	configPlUrl       = "pipelines-url"
-	configAccessToken = "config-" + accessToken
-	configUser        = "config-" + user
-	configPassword    = "config-" + password
-	configApiKey      = "config-" + apikey
+	configAccessToken = configPrefix + accessToken
+	configUser        = configPrefix + user
+	configPassword    = configPrefix + password
+	configApiKey      = configPrefix + apikey
 )
 
 var flagsMap = map[string]cli.Flag{

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -396,6 +396,10 @@ const (
 	configXrUrl       = "xray-url"
 	configMcUrl       = "mission-control-url"
 	configPlUrl       = "pipelines-url"
+	configAccessToken = "config-" + accessToken
+	configUser        = "config-" + user
+	configPassword    = "config-" + password
+	configApiKey      = "config-" + apikey
 )
 
 var flagsMap = map[string]cli.Flag{
@@ -1189,11 +1193,27 @@ var flagsMap = map[string]cli.Flag{
 		Name:  configPlUrl,
 		Usage: "[Optional] Pipelines URL.` `",
 	},
+	configUser: cli.StringFlag{
+		Name:  user,
+		Usage: "[Optional] JFrog Platform username. ` `",
+	},
+	configPassword: cli.StringFlag{
+		Name:  password,
+		Usage: "[Optional] JFrog Platform password. ` `",
+	},
+	configApiKey: cli.StringFlag{
+		Name:  apikey,
+		Usage: "[Optional] JFrog Platform API key. ` `",
+	},
+	configAccessToken: cli.StringFlag{
+		Name:  accessToken,
+		Usage: "[Optional] JFrog Platform access token. ` `",
+	},
 }
 
 var commandFlags = map[string][]string{
 	Config: {
-		interactive, encPassword, configPlatformUrl, configRtUrl, distUrl, configXrUrl, configMcUrl, configPlUrl, user, password, apikey, accessToken, sshKeyPath, clientCertPath,
+		interactive, encPassword, configPlatformUrl, configRtUrl, distUrl, configXrUrl, configMcUrl, configPlUrl, configUser, configPassword, configApiKey, configAccessToken, sshKeyPath, clientCertPath,
 		clientCertKeyPath, basicAuthOnly, insecureTls,
 	},
 	RtConfig: {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Fix the usage help of `jfrog c add` and `jfrog c edit` commands flags:
before:
```
  --access-token          [Optional] Artifactory access token.
  --apikey                [Optional] Artifactory API key.
  --user                  [Optional] Artifactory username.
  --password              [Optional] Artifactory password.
```
after:
```
  --access-token          [Optional] JFrog Platform access token.
  --apikey                [Optional] JFrog Platform API key.
  --user                  [Optional] JFrog Platform username.
  --password              [Optional] JFrog Platform password.
```
