### PR TITLE
Bugfix - dotnet panic whenever nuget-config doesn't exist

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1501,8 +1501,8 @@ func dotnetCmd(c *cli.Context) error {
 		return err
 	}
 	if !exists {
-		return errors.New(fmt.Sprintf("Error occurred while attempting to read dotnet-configuration file: %s\n"+
-			"Please run 'jfrog rt dotnet-config' command prior to running 'jfrog rt dotnet'.", err.Error()))
+		return errors.New(fmt.Sprintf("Error occurred while attempting to read dotnet-configuration file.\n" +
+			"Please run 'jfrog rt dotnet-config' command prior to running 'jfrog rt dotnet'."))
 	}
 
 	rtDetails, targetRepo, useNugetV2, err := getNugetAndDotnetConfigFields(configFilePath)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
