### PR TITLE
CLA Asistant - Disable running on issues

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,7 +1,5 @@
 name: "CLA Assistant"
 on:
-  issue_comment:
-    types: [created]
   pull_request_target:
     types: [opened,synchronize]
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Running the CLA assistant on issues comments leads to unexpected behavior - see https://github.com/jfrog/jfrog-cli/runs/2128954697?check_suite_focus=true.
Let's run the CLA assistant only on pull requests.