### PR TITLE
Annonymous access with url flag produces error

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -3115,7 +3115,7 @@ func createArtifactoryDetailsFromFlags(c *cli.Context) (details *coreConfig.Serv
 }
 
 func credentialsChanged(details *coreConfig.ServerDetails) bool {
-	return details.Url != "" || details.DistributionUrl != "" || details.User != "" || details.Password != "" ||
+	return details.Url != "" || details.ArtifactoryUrl != "" || details.DistributionUrl != "" || details.User != "" || details.Password != "" ||
 		details.ApiKey != "" || details.SshKeyPath != "" || details.SshPassphrase != "" || details.AccessToken != "" ||
 		details.ClientCertKeyPath != "" || details.ClientCertPath != ""
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Resolves #1017 

When no server is configured, artifactory commands with the `--url` flag returns the following error: 
> [Error] the --url option is mandatory

The root cause of this is an attempt to read a configuration from fs that doesn't exist when credentials provided by flags: `credentialsChanged` returns false when it expected to return true: see https://github.com/jfrog/jfrog-cli/blob/v1.45.2/artifactory/cli.go#L3084.