### PR TITLE
Change insecure TLS description in config

### DIFF
--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -401,6 +401,7 @@ const (
 	configUser        = configPrefix + user
 	configPassword    = configPrefix + password
 	configApiKey      = configPrefix + apikey
+	configInsecureTls = configPrefix + insecureTls
 )
 
 var flagsMap = map[string]cli.Flag{
@@ -1210,16 +1211,21 @@ var flagsMap = map[string]cli.Flag{
 		Name:  accessToken,
 		Usage: "[Optional] JFrog Platform access token. ` `",
 	},
+	configInsecureTls: cli.StringFlag{
+		Name: insecureTls,
+		Usage: "[Default: false] Set to true to skip TLS certificates verification, while encrypting the Artifactory password during the config process.` `",
+	},
 }
 
 var commandFlags = map[string][]string{
 	Config: {
 		interactive, encPassword, configPlatformUrl, configRtUrl, distUrl, configXrUrl, configMcUrl, configPlUrl, configUser, configPassword, configApiKey, configAccessToken, sshKeyPath, clientCertPath,
-		clientCertKeyPath, basicAuthOnly, insecureTls,
+		clientCertKeyPath, basicAuthOnly, configInsecureTls,
 	},
+	// Deprecated
 	RtConfig: {
 		interactive, encPassword, url, distUrl, user, password, apikey, accessToken, sshKeyPath, clientCertPath,
-		clientCertKeyPath, basicAuthOnly, insecureTls,
+		clientCertKeyPath, basicAuthOnly, configInsecureTls,
 	},
 	DeleteConfig: {
 		deleteQuiet,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

During `jfrog config add` and `jfrog config edit` commands, the `--insecure-tls` flag is relevant only for the password.