### PR TITLE
CLA Assistant - restore 'issue_comment'

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,5 +1,8 @@
 name: "CLA Assistant"
 on:
+  # issue_comment triggers this action on each comment on issues and pull requests
+  issue_comment:
+    types: [created]
   pull_request_target:
     types: [opened,synchronize]
 
@@ -14,7 +17,7 @@ jobs:
           regex: '\s*(I have read the CLA Document and I hereby sign the CLA)|(recheckcla)\s*'
       
       - name: "CLA Assistant"
-        if: ${{ steps.sign-or-recheck.outputs.match != '' }} || github.event_name == 'pull_request_target'
+        if: ${{ steps.sign-or-recheck.outputs.match != '' || github.event_name == 'pull_request_target' }}
         # Alpha Release
         uses: cla-assistant/github-action@v2.1.1-beta
         env:


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

1. `issue_comment` is necessary to trigger the action on PR comments. Restore it.
2. Fix a bug whereby the `CLA Assistant` step is running on issues.