### PR TITLE
Remove rt URL validation on config command

### DIFF
--- a/config/cli.go
+++ b/config/cli.go
@@ -218,9 +218,6 @@ func validateServerExistence(serverId string, expectExist bool) error {
 }
 
 func validateConfigFlags(configCommandConfiguration *commands.ConfigCommandConfiguration) error {
-	if !configCommandConfiguration.Interactive && configCommandConfiguration.ServerDetails.ArtifactoryUrl == "" {
-		return errors.New("the --artifactory-url option is mandatory when the --interactive option is set to false or the CI environment variable is set to true.")
-	}
 	// Validate the option is not used along with an access token
 	if configCommandConfiguration.BasicAuthOnly && configCommandConfiguration.ServerDetails.AccessToken != "" {
 		return errors.New("the --basic-auth-only option is only supported when username and password/API key are provided")


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Allow configuring server details without Artifactory server. For example:
```
➜  ~ CI=true jfrog c add local --xray-url=http://127.0.0.1:8081/xray --user=admin --password=password
[Error] the --artifactory-url option is mandatory when the --interactive option is set to false or the CI environment variable is set to true.
```
