### PR TITLE
Bugfix - 'gp' backward compatibility fails

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1764,7 +1764,6 @@ func goCmd(c *cli.Context, goCmd func(*cli.Context, string) error, legacyGoCmd f
 		log.Debug("Go config file was found in:", configFilePath)
 		return goCmd(c, configFilePath)
 	}
-	// If config file not found, use Go legacy command
 	return legacyGoCmd(c)
 }
 

--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1759,7 +1759,7 @@ func goCmd(c *cli.Context, goCmd func(*cli.Context, string) error, legacyGoCmd f
 		return err
 	}
 	// Verify config file is found.
-	// Falback to legcy use if version & repo arges are passed.
+	// Fallback to legacy use if version & repo args are passed.
 	if exists && c.NArg() == 1 {
 		log.Debug("Go config file was found in:", configFilePath)
 		return goCmd(c, configFilePath)

--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1758,11 +1758,12 @@ func goCmd(c *cli.Context, goCmd func(*cli.Context, string) error, legacyGoCmd f
 	if err != nil {
 		return err
 	}
-	if exists {
+	// Verify config file is found.
+	// Falback to legcy use if version & repo arges are passed.
+	if exists && c.NArg() == 1 {
 		log.Debug("Go config file was found in:", configFilePath)
 		return goCmd(c, configFilePath)
 	}
-	log.Debug("Go config file wasn't found.")
 	// If config file not found, use Go legacy command
 	return legacyGoCmd(c)
 }
@@ -1808,9 +1809,6 @@ func goLegacyCmd(c *cli.Context) error {
 }
 
 func goPublishCmd(c *cli.Context, configFilePath string) error {
-	if c.NArg() != 1 {
-		return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
-	}
 	buildConfiguration, err := createBuildConfigurationWithModule(c)
 	if err != nil {
 		return err


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Since v1.46.1, 'gp' command supports config file while other go commands were using it a long time before.
Now, 'gp' fails to detect whether it runs as a legacy mode or not.