### PR TITLE
Bugfix - 'go' commands fails to detect backward compatibility

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1759,8 +1759,8 @@ func goCmd(c *cli.Context, goCmd func(*cli.Context, string) error, legacyGoCmd f
 		return err
 	}
 	// Verify config file is found.
-	// Fallback to legacy use if version & repo args are passed.
-	if exists && c.NArg() == 1 {
+	// Fallback to legacy use if version & repo args are passed along with go-publish command.
+	if exists && !cliutils.IsLegacyGoPublish(c) {
 		log.Debug("Go config file was found in:", configFilePath)
 		return goCmd(c, configFilePath)
 	}

--- a/utils/cliutils/utils.go
+++ b/utils/cliutils/utils.go
@@ -239,3 +239,7 @@ func CreateServerDetailsFromFlags(c *cli.Context) (details *config.ServerDetails
 	}
 	return
 }
+
+func IsLegacyGoPublish(c *cli.Context) bool {
+	return c.Command.Name == "go-publish" && c.NArg() > 1
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
https://github.com/jfrog/jfrog-cli/commit/f4652b5685ad2efe0040200b66b8f30d4fbb7ab5 breaks the backward compatibility (legacy) detection of the 'go' command.
This fix adds an extra validation step to the backward compatibility detection of the 'gp' command without interfering 'go' command flow.