### PR TITLE
Bug fix - The "jfrog rt bpr" command ignores the JFROG_CLI_BUILD_PROJ…

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -3304,7 +3304,7 @@ func createBuildPromoteConfiguration(c *cli.Context) services.PromotionParams {
 	promotionParamsImpl.IncludeDependencies = c.Bool("include-dependencies")
 	promotionParamsImpl.Copy = c.Bool("copy")
 	promotionParamsImpl.Properties = c.String("props")
-	promotionParamsImpl.ProjectKey = c.String("project")
+	promotionParamsImpl.ProjectKey = utils.GetBuildProject(c.String("project"))
 
 	// If the command received 3 args, read the build name, build number
 	// and target repo as ags.


### PR DESCRIPTION
…ECT env var

The "jfrog rt bpr" command respects the --project command option. It ignores however the JFROG_CLI_BUILD_PROJECT environment varoable. This PR fixes that, making the command respect the env var.

- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
