### PR TITLE
Please update the license to Apache-2.0 License

### DIFF
--- a/build/deb_rpm/rpm/jfrog-cli.spec
+++ b/build/deb_rpm/rpm/jfrog-cli.spec
@@ -4,7 +4,7 @@ Release:        %{cli_release}
 Summary:        Smart client that provides a simple interface that automates access to JFrog products
 Vendor:         JFrog Ltd.
 Group:          Development/Tools
-License:        Commercial
+License:        Apache-2.0 License
 URL:            http://www.jfrog.org
 BuildRoot:      %{_tmppath}/build-%{name}-%{version}
 BuildArch:      %{build_arch}


### PR DESCRIPTION
The license field in the RPM says "Commerical" but the source on GitHub says "jfrog/jfrog-cli is licensed under the Apache License 2.0".

- [ ] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
