### PR TITLE
Fix permission target test

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -4813,25 +4813,12 @@ func TestPermissionTargets(t *testing.T) {
 
 	// Create permission target on specific repo.
 	assert.NoError(t, artifactoryCli.Exec("ptc", templatePath, createPermissionTargetsTemplateVars(tests.RtRepo1)))
-	err = getAndAssertExpectedPermissionTarget(t, servicesManager, tests.RtRepo1)
-	if err != nil {
-		return
-	}
-
-	permissionDeleted := false
-	defer func() {
-		if !permissionDeleted {
-			cleanPermissionTarget()
-		}
-	}()
+	assertPermissionTarget(t, servicesManager, tests.RtRepo1)
 
 	// Update permission target to ANY repo.
 	any := "ANY"
 	assert.NoError(t, artifactoryCli.Exec("ptu", templatePath, createPermissionTargetsTemplateVars(any)))
-	err = getAndAssertExpectedPermissionTarget(t, servicesManager, any)
-	if err != nil {
-		return
-	}
+	assertPermissionTarget(t, servicesManager, any)
 
 	// Delete permission target.
 	assert.NoError(t, artifactoryCli.Exec("ptdel", tests.RtPermissionTargetName))
@@ -4846,15 +4833,14 @@ func createPermissionTargetsTemplateVars(reposValue string) string {
 	return fmt.Sprintf("--vars=%s=%s;%s=%s", ptNameVarKey, tests.RtPermissionTargetName, reposVarKey, reposValue)
 }
 
-func getAndAssertExpectedPermissionTarget(t *testing.T, manager artifactory.ArtifactoryServicesManager, repoValue string) error {
+func assertPermissionTarget(t *testing.T, manager artifactory.ArtifactoryServicesManager, repoValue string) {
 	actual, err := manager.GetPermissionTarget(tests.RtPermissionTargetName)
 	if err != nil {
 		assert.NoError(t, err)
-		return err
+		return
 	}
 	expected := tests.GetExpectedPermissionTarget(repoValue)
 	assert.EqualValues(t, expected, *actual)
-	return nil
 }
 
 func assertPermissionTargetDeleted(t *testing.T, manager artifactory.ArtifactoryServicesManager) {

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -4835,10 +4835,7 @@ func TestPermissionTargets(t *testing.T) {
 
 	// Delete permission target.
 	assert.NoError(t, artifactoryCli.Exec("ptdel", tests.RtPermissionTargetName))
-	permissionDeleted, err = assertPermissionTargetDeleted(t, servicesManager)
-	if err != nil {
-		return
-	}
+	assertPermissionTargetDeleted(t, servicesManager)
 
 	cleanArtifactoryTest()
 }
@@ -4860,17 +4857,13 @@ func getAndAssertExpectedPermissionTarget(t *testing.T, manager artifactory.Arti
 	return nil
 }
 
-func assertPermissionTargetDeleted(t *testing.T, manager artifactory.ArtifactoryServicesManager) (bool, error) {
+func assertPermissionTargetDeleted(t *testing.T, manager artifactory.ArtifactoryServicesManager) {
 	_, err := manager.GetPermissionTarget(tests.RtPermissionTargetName)
 	if err == nil {
 		assert.Error(t, err)
-		return false, nil
+		return
 	}
-	if strings.Contains(err.Error(), "404 Not Found") {
-		return true, nil
-	}
-	assert.Contains(t, err.Error(), "404 Not Found")
-	return false, err
+	assert.Contains(t, err.Error(), "404")
 }
 
 func cleanPermissionTarget() {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

In the latest Artifactory get permission target REST API, in case the permission target doesn't exist, `404 Not Found` is no longer returned. The updated return message is: `Artifactory response: 404 \n{\n  \"errors\": [\n    {\n      \"status\": 404,\n      \"message\": \"Not Found\"\n    }\n  ]\n}`.
To be compatible with all Artifactory versions, let's just check for 404 in the error returned.