### PR TITLE
Search, del, sp and delp should work without pattern using build and bundle

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1994,12 +1994,12 @@ func pingCmd(c *cli.Context) error {
 	return err
 }
 
-func downloadCmd(c *cli.Context) error {
+func prepareDownloadCommand(c *cli.Context) (*spec.SpecFiles, error) {
 	if c.NArg() > 0 && c.IsSet("spec") {
-		return cliutils.PrintHelpAndReturnError("No arguments should be sent when the spec option is used.", c)
+		return nil, cliutils.PrintHelpAndReturnError("No arguments should be sent when the spec option is used.", c)
 	}
 	if !(c.NArg() == 1 || c.NArg() == 2 || (c.NArg() == 0 && (c.IsSet("spec") || c.IsSet("build") || c.IsSet("bundle")))) {
-		return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
+		return nil, cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 	}
 
 	var downloadSpec *spec.SpecFiles
@@ -2010,9 +2010,17 @@ func downloadCmd(c *cli.Context) error {
 		downloadSpec, err = createDefaultDownloadSpec(c)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 	err = spec.ValidateSpec(downloadSpec.Files, false, true, false)
+	if err != nil {
+		return nil, err
+	}
+	return downloadSpec, nil
+}
+
+func downloadCmd(c *cli.Context) error {
+	downloadSpec, err := prepareDownloadCommand(c)
 	if err != nil {
 		return err
 	}
@@ -2112,25 +2120,33 @@ func execWithProgress(cmd CommandWithProgress) error {
 	return commands.Exec(cmd)
 }
 
-func moveCmd(c *cli.Context) error {
+func prepareCopyMoveCommand(c *cli.Context) (*spec.SpecFiles, error) {
 	if c.NArg() > 0 && c.IsSet("spec") {
-		return cliutils.PrintHelpAndReturnError("No arguments should be sent when the spec option is used.", c)
+		return nil, cliutils.PrintHelpAndReturnError("No arguments should be sent when the spec option is used.", c)
 	}
-	if !(c.NArg() == 2 || (c.NArg() == 0 && (c.IsSet("spec") || c.IsSet("build")))) {
-		return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
+	if !(c.NArg() == 2 || (c.NArg() == 0 && (c.IsSet("spec")))) {
+		return nil, cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 	}
 
-	var moveSpec *spec.SpecFiles
+	var copyMoveSpec *spec.SpecFiles
 	var err error
 	if c.IsSet("spec") {
-		moveSpec, err = getSpec(c, false)
+		copyMoveSpec, err = getSpec(c, false)
 	} else {
-		moveSpec, err = createDefaultCopyMoveSpec(c)
+		copyMoveSpec, err = createDefaultCopyMoveSpec(c)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
-	err = spec.ValidateSpec(moveSpec.Files, true, true, false)
+	err = spec.ValidateSpec(copyMoveSpec.Files, true, true, false)
+	if err != nil {
+		return nil, err
+	}
+	return copyMoveSpec, nil
+}
+
+func moveCmd(c *cli.Context) error {
+	moveSpec, err := prepareCopyMoveCommand(c)
 	if err != nil {
 		return err
 	}
@@ -2152,24 +2168,7 @@ func moveCmd(c *cli.Context) error {
 }
 
 func copyCmd(c *cli.Context) error {
-	if c.NArg() > 0 && c.IsSet("spec") {
-		return cliutils.PrintHelpAndReturnError("No arguments should be sent when the spec option is used.", c)
-	}
-	if !(c.NArg() == 2 || (c.NArg() == 0 && (c.IsSet("spec") || c.IsSet("build")))) {
-		return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
-	}
-
-	var copySpec *spec.SpecFiles
-	var err error
-	if c.IsSet("spec") {
-		copySpec, err = getSpec(c, false)
-	} else {
-		copySpec, err = createDefaultCopyMoveSpec(c)
-	}
-	if err != nil {
-		return err
-	}
-	err = spec.ValidateSpec(copySpec.Files, true, true, false)
+	copySpec, err := prepareCopyMoveCommand(c)
 	if err != nil {
 		return err
 	}
@@ -2191,12 +2190,12 @@ func copyCmd(c *cli.Context) error {
 	return cliutils.GetCliError(err, result.SuccessCount(), result.FailCount(), isFailNoOp(c))
 }
 
-func deleteCmd(c *cli.Context) error {
+func prepareDeleteCommand(c *cli.Context) (*spec.SpecFiles, error) {
 	if c.NArg() > 0 && c.IsSet("spec") {
-		return cliutils.PrintHelpAndReturnError("No arguments should be sent when the spec option is used.", c)
+		return nil, cliutils.PrintHelpAndReturnError("No arguments should be sent when the spec option is used.", c)
 	}
-	if !(c.NArg() == 1 || (c.NArg() == 0 && (c.IsSet("spec") || c.IsSet("build")))) {
-		return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
+	if !(c.NArg() == 1 || (c.NArg() == 0 && (c.IsSet("spec") || c.IsSet("build") || c.IsSet("bundle")))) {
+		return nil, cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 	}
 
 	var deleteSpec *spec.SpecFiles
@@ -2207,9 +2206,17 @@ func deleteCmd(c *cli.Context) error {
 		deleteSpec, err = createDefaultDeleteSpec(c)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 	err = spec.ValidateSpec(deleteSpec.Files, false, true, false)
+	if err != nil {
+		return nil, err
+	}
+	return deleteSpec, nil
+}
+
+func deleteCmd(c *cli.Context) error {
+	deleteSpec, err := prepareDeleteCommand(c)
 	if err != nil {
 		return err
 	}
@@ -2232,12 +2239,12 @@ func deleteCmd(c *cli.Context) error {
 	return cliutils.GetCliError(err, result.SuccessCount(), result.FailCount(), isFailNoOp(c))
 }
 
-func searchCmd(c *cli.Context) error {
+func prepareSearchCommand(c *cli.Context) (*spec.SpecFiles, error) {
 	if c.NArg() > 0 && c.IsSet("spec") {
-		return cliutils.PrintHelpAndReturnError("No arguments should be sent when the spec option is used.", c)
+		return nil, cliutils.PrintHelpAndReturnError("No arguments should be sent when the spec option is used.", c)
 	}
-	if !(c.NArg() == 1 || (c.NArg() == 0 && (c.IsSet("spec") || c.IsSet("build")))) {
-		return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
+	if !(c.NArg() == 1 || (c.NArg() == 0 && (c.IsSet("spec") || c.IsSet("build") || c.IsSet("bundle")))) {
+		return nil, cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 	}
 
 	var searchSpec *spec.SpecFiles
@@ -2248,9 +2255,17 @@ func searchCmd(c *cli.Context) error {
 		searchSpec, err = createDefaultSearchSpec(c)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 	err = spec.ValidateSpec(searchSpec.Files, false, true, false)
+	if err != nil {
+		return nil, err
+	}
+	return searchSpec, err
+}
+
+func searchCmd(c *cli.Context) error {
+	searchSpec, err := prepareSearchCommand(c)
 	if err != nil {
 		return err
 	}
@@ -2285,7 +2300,7 @@ func preparePropsCmd(c *cli.Context) (*generic.PropsCommand, error) {
 	if c.NArg() > 1 && c.IsSet("spec") {
 		return nil, cliutils.PrintHelpAndReturnError("Only the 'artifact properties' argument should be sent when the spec option is used.", c)
 	}
-	if !(c.NArg() == 2 || (c.NArg() == 1 && c.IsSet("spec"))) {
+	if !(c.NArg() == 2 || (c.NArg() == 1 && (c.IsSet("spec") || c.IsSet("build") || c.IsSet("bundle")))) {
 		return nil, cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 	}
 
@@ -2296,8 +2311,13 @@ func preparePropsCmd(c *cli.Context) (*generic.PropsCommand, error) {
 		props = c.Args()[0]
 		propsSpec, err = getSpec(c, false)
 	} else {
-		props = c.Args()[1]
 		propsSpec, err = createDefaultPropertiesSpec(c)
+		if c.NArg() == 1 {
+			props = c.Args()[0]
+			propsSpec.Get(0).Pattern = "*"
+		} else {
+			props = c.Args()[1]
+		}
 	}
 	if err != nil {
 		return nil, err
@@ -3301,6 +3321,7 @@ func createDefaultDeleteSpec(c *cli.Context) (*spec.SpecFiles, error) {
 		Build(c.String("build")).
 		ExcludeArtifacts(c.Bool("exclude-artifacts")).
 		IncludeDeps(c.Bool("include-deps")).
+		Bundle(c.String("bundle")).
 		Offset(offset).
 		Limit(limit).
 		SortOrder(c.String("sort-order")).

--- a/artifactory/cli_test.go
+++ b/artifactory/cli_test.go
@@ -56,8 +56,8 @@ func TestPrepareSearchDownloadDeleteCommands(t *testing.T) {
 		{"withPattern", []string{"TestPattern"}, []string{}, "TestPattern", "", "", false},
 		{"withBuild", []string{}, []string{"build=buildName/buildNumber"}, "", "buildName/buildNumber", "", false},
 		{"withBundle", []string{}, []string{"bundle=bundleName/bundleVersion"}, "", "", "bundleName/bundleVersion", false},
-		{"withSpec", []string{}, []string{"spec=" + getSpecPath(tests.SearchAllRepo1)}, "${REPO1}/*", "", "", false},
-		{"withSpecAndPattern", []string{"TestPattern"}, []string{"spec=" + getSpecPath(tests.SearchAllRepo1)}, "", "", "", true},
+		{"withSpec", []string{}, []string{"spec=" + getSpecPath(t, tests.SearchAllRepo1)}, "${REPO1}/*", "", "", false},
+		{"withSpecAndPattern", []string{"TestPattern"}, []string{"spec=" + getSpecPath(t, tests.SearchAllRepo1)}, "", "", "", true},
 		{"withBuildAndPattern", []string{"TestPattern"}, []string{"build=buildName/buildNumber"}, "TestPattern", "buildName/buildNumber", "", false},
 	}
 
@@ -69,12 +69,7 @@ func TestPrepareSearchDownloadDeleteCommands(t *testing.T) {
 			}
 			for _, prepareCommandFunc := range funcArray {
 				specFiles, err := prepareCommandFunc(context)
-				if test.expectError {
-					assert.Error(t, err, buffer)
-				} else {
-					assert.NoError(t, err, buffer)
-					assert.Equal(t, test.expectedPattern, specFiles.Get(0).Pattern)
-				}
+				assertGenericCommand(t, err, buffer, test.expectError, test.expectedPattern, test.expectedBuild, test.expectedBundle, specFiles)
 			}
 		})
 	}
@@ -93,8 +88,8 @@ func TestPrepareCopyMoveCommand(t *testing.T) {
 	}{
 		{"withoutArguments", []string{}, []string{}, "", "", "", "", true},
 		{"withPatternAndTarget", []string{"TestPattern", "TestTarget"}, []string{}, "TestPattern", "TestTarget", "", "", false},
-		{"withSpec", []string{}, []string{"spec=" + getSpecPath(tests.CopyItemsSpec)}, "${REPO1}/*/", "${REPO2}/", "", "", false},
-		{"withSpecAndPattern", []string{"TestPattern"}, []string{"spec=" + getSpecPath(tests.CopyItemsSpec)}, "", "", "", "", true},
+		{"withSpec", []string{}, []string{"spec=" + getSpecPath(t, tests.CopyItemsSpec)}, "${REPO1}/*/", "${REPO2}/", "", "", false},
+		{"withSpecAndPattern", []string{"TestPattern"}, []string{"spec=" + getSpecPath(t, tests.CopyItemsSpec)}, "", "", "", "", true},
 		{"withPatternTargetAndBuild", []string{"TestPattern", "TestTarget"}, []string{"build=buildName/buildNumber"}, "TestPattern", "", "buildName/buildNumber", "", false},
 		{"withPatternTargetAndBundle", []string{"TestPattern", "TestTarget"}, []string{"bundle=bundleName/bundleVersion"}, "TestPattern", "", "", "bundleName/bundleVersion", false},
 	}
@@ -103,12 +98,7 @@ func TestPrepareCopyMoveCommand(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			context, buffer := createContext(test.flags, test.args)
 			specFiles, err := prepareCopyMoveCommand(context)
-			if test.expectError {
-				assert.Error(t, err, buffer)
-			} else {
-				assert.NoError(t, err, buffer)
-				assert.Equal(t, test.expectedPattern, specFiles.Get(0).Pattern)
-			}
+			assertGenericCommand(t, err, buffer, test.expectError, test.expectedPattern, test.expectedBuild, test.expectedBundle, specFiles)
 		})
 	}
 }
@@ -128,8 +118,8 @@ func TestPreparePropsCmd(t *testing.T) {
 		{"withPattern", []string{"TestPattern", "key1=val1"}, []string{}, "key1=val1", "TestPattern", "", "", false},
 		{"withBuild", []string{"key1=val1"}, []string{"build=buildName/buildNumber"}, "key1=val1", "*", "buildName/buildNumber", "", false},
 		{"withBundle", []string{"key1=val1"}, []string{"bundle=bundleName/bundleVersion"}, "key1=val1", "*", "", "bundleName/bundleVersion", false},
-		{"withSpec", []string{"key1=val1"}, []string{"spec=" + getSpecPath(tests.SetDeletePropsSpec)}, "key1=val1", "${REPO1}/", "", "", false},
-		{"withSpecAndPattern", []string{"TestPattern", "key1=val1"}, []string{"spec=" + getSpecPath(tests.SetDeletePropsSpec)}, "key1=val1", "", "", "", true},
+		{"withSpec", []string{"key1=val1"}, []string{"spec=" + getSpecPath(t, tests.SetDeletePropsSpec)}, "key1=val1", "${REPO1}/", "", "", false},
+		{"withSpecAndPattern", []string{"TestPattern", "key1=val1"}, []string{"spec=" + getSpecPath(t, tests.SetDeletePropsSpec)}, "key1=val1", "", "", "", true},
 		{"withPatternAndBuild", []string{"TestPattern", "key1=val1"}, []string{"build=buildName/buildNumber"}, "key1=val1", "TestPattern", "buildName/buildNumber", "", false},
 	}
 
@@ -137,14 +127,24 @@ func TestPreparePropsCmd(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			context, buffer := createContext(test.flags, test.args)
 			propsCommand, err := preparePropsCmd(context)
-			if test.expectError {
-				assert.Error(t, err, buffer)
-			} else {
-				assert.NoError(t, err, buffer)
+			var actualSpec *spec.SpecFiles
+			if !test.expectError {
+				actualSpec = propsCommand.Spec()
 				assert.Equal(t, test.expectedProps, propsCommand.Props())
-				assert.Equal(t, test.expectedPattern, propsCommand.Spec().Get(0).Pattern)
 			}
+			assertGenericCommand(t, err, buffer, test.expectError, test.expectedPattern, test.expectedBuild, test.expectedBundle, actualSpec)
 		})
+	}
+}
+
+func assertGenericCommand(t *testing.T, err error, buffer *bytes.Buffer, expectError bool, expectedPattern, expectedBuild, expectedBundle string, actualSpec *spec.SpecFiles) {
+	if expectError {
+		assert.Error(t, err, buffer)
+	} else {
+		assert.NoError(t, err, buffer)
+		assert.Equal(t, expectedPattern, actualSpec.Get(0).Pattern)
+		assert.Equal(t, expectedBuild, actualSpec.Get(0).Build)
+		assert.Equal(t, expectedBundle, actualSpec.Get(0).Bundle)
 	}
 }
 
@@ -159,8 +159,9 @@ func createContext(testFlags, testArgs []string) (*cli.Context, *bytes.Buffer) {
 	return cli.NewContext(app, flagSet, nil), buffer
 }
 
-func getSpecPath(spec string) string {
-	dir, _ := os.Getwd()
+func getSpecPath(t *testing.T, spec string) string {
+	dir, err := os.Getwd()
+	assert.NoError(t, err)
 	return filepath.Join(path.Dir(dir), "testdata", "filespecs", spec)
 }
 
@@ -171,5 +172,7 @@ func setStringFlags(flagSet *flag.FlagSet, flags ...string) []string {
 		flagSet.String(strings.Split(flag, "=")[0], "", "")
 		cmdFlags = append(cmdFlags, "--"+flag)
 	}
+	flagSet.Parse(cmdFlags)
+
 	return cmdFlags
 }

--- a/artifactory/cli_test.go
+++ b/artifactory/cli_test.go
@@ -1,8 +1,19 @@
 package artifactory
 
 import (
-	"github.com/jfrog/jfrog-cli/utils/cliutils"
+	"bytes"
+	"flag"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/codegangsta/cli"
+	"github.com/jfrog/jfrog-cli-core/artifactory/spec"
+	"github.com/jfrog/jfrog-cli/utils/cliutils"
+	"github.com/jfrog/jfrog-cli/utils/tests"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateGoNativeCommand(t *testing.T) {
@@ -29,4 +40,136 @@ func TestValidateGoNativeCommand(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrepareSearchDownloadDeleteCommands(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		flags           []string
+		expectedPattern string
+		expectedBuild   string
+		expectedBundle  string
+		expectError     bool
+	}{
+		{"withoutArgs", []string{}, []string{}, "TestPattern", "", "", true},
+		{"withPattern", []string{"TestPattern"}, []string{}, "TestPattern", "", "", false},
+		{"withBuild", []string{}, []string{"build=buildName/buildNumber"}, "", "buildName/buildNumber", "", false},
+		{"withBundle", []string{}, []string{"bundle=bundleName/bundleVersion"}, "", "", "bundleName/bundleVersion", false},
+		{"withSpec", []string{}, []string{"spec=" + getSpecPath(tests.SearchAllRepo1)}, "${REPO1}/*", "", "", false},
+		{"withSpecAndPattern", []string{"TestPattern"}, []string{"spec=" + getSpecPath(tests.SearchAllRepo1)}, "", "", "", true},
+		{"withBuildAndPattern", []string{"TestPattern"}, []string{"build=buildName/buildNumber"}, "TestPattern", "buildName/buildNumber", "", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			context, buffer := createContext(test.flags, test.args)
+			funcArray := []func(c *cli.Context) (*spec.SpecFiles, error){
+				prepareSearchCommand, prepareDownloadCommand, prepareDeleteCommand,
+			}
+			for _, prepareCommandFunc := range funcArray {
+				specFiles, err := prepareCommandFunc(context)
+				if test.expectError {
+					assert.Error(t, err, buffer)
+				} else {
+					assert.NoError(t, err, buffer)
+					assert.Equal(t, test.expectedPattern, specFiles.Get(0).Pattern)
+				}
+			}
+		})
+	}
+}
+
+func TestPrepareCopyMoveCommand(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		flags           []string
+		expectedPattern string
+		expectedTarget  string
+		expectedBuild   string
+		expectedBundle  string
+		expectError     bool
+	}{
+		{"withoutArguments", []string{}, []string{}, "", "", "", "", true},
+		{"withPatternAndTarget", []string{"TestPattern", "TestTarget"}, []string{}, "TestPattern", "TestTarget", "", "", false},
+		{"withSpec", []string{}, []string{"spec=" + getSpecPath(tests.CopyItemsSpec)}, "${REPO1}/*/", "${REPO2}/", "", "", false},
+		{"withSpecAndPattern", []string{"TestPattern"}, []string{"spec=" + getSpecPath(tests.CopyItemsSpec)}, "", "", "", "", true},
+		{"withPatternTargetAndBuild", []string{"TestPattern", "TestTarget"}, []string{"build=buildName/buildNumber"}, "TestPattern", "", "buildName/buildNumber", "", false},
+		{"withPatternTargetAndBundle", []string{"TestPattern", "TestTarget"}, []string{"bundle=bundleName/bundleVersion"}, "TestPattern", "", "", "bundleName/bundleVersion", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			context, buffer := createContext(test.flags, test.args)
+			specFiles, err := prepareCopyMoveCommand(context)
+			if test.expectError {
+				assert.Error(t, err, buffer)
+			} else {
+				assert.NoError(t, err, buffer)
+				assert.Equal(t, test.expectedPattern, specFiles.Get(0).Pattern)
+			}
+		})
+	}
+}
+
+func TestPreparePropsCmd(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		flags           []string
+		expectedProps   string
+		expectedPattern string
+		expectedBuild   string
+		expectedBundle  string
+		expectError     bool
+	}{
+		{"withoutPattern", []string{"key1=val1"}, []string{}, "key1=val1", "", "", "", true},
+		{"withPattern", []string{"TestPattern", "key1=val1"}, []string{}, "key1=val1", "TestPattern", "", "", false},
+		{"withBuild", []string{"key1=val1"}, []string{"build=buildName/buildNumber"}, "key1=val1", "*", "buildName/buildNumber", "", false},
+		{"withBundle", []string{"key1=val1"}, []string{"bundle=bundleName/bundleVersion"}, "key1=val1", "*", "", "bundleName/bundleVersion", false},
+		{"withSpec", []string{"key1=val1"}, []string{"spec=" + getSpecPath(tests.SetDeletePropsSpec)}, "key1=val1", "${REPO1}/", "", "", false},
+		{"withSpecAndPattern", []string{"TestPattern", "key1=val1"}, []string{"spec=" + getSpecPath(tests.SetDeletePropsSpec)}, "key1=val1", "", "", "", true},
+		{"withPatternAndBuild", []string{"TestPattern", "key1=val1"}, []string{"build=buildName/buildNumber"}, "key1=val1", "TestPattern", "buildName/buildNumber", "", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			context, buffer := createContext(test.flags, test.args)
+			propsCommand, err := preparePropsCmd(context)
+			if test.expectError {
+				assert.Error(t, err, buffer)
+			} else {
+				assert.NoError(t, err, buffer)
+				assert.Equal(t, test.expectedProps, propsCommand.Props())
+				assert.Equal(t, test.expectedPattern, propsCommand.Spec().Get(0).Pattern)
+			}
+		})
+	}
+}
+
+func createContext(testFlags, testArgs []string) (*cli.Context, *bytes.Buffer) {
+	flagSet := flag.NewFlagSet("TestFlagSet", flag.ContinueOnError)
+	flags := append(setStringFlags(flagSet, testFlags...), testArgs...)
+	flagSet.Parse(flags)
+
+	buffer := &bytes.Buffer{}
+	app := cli.NewApp()
+	app.Writer = &bytes.Buffer{}
+	return cli.NewContext(app, flagSet, nil), buffer
+}
+
+func getSpecPath(spec string) string {
+	dir, _ := os.Getwd()
+	return filepath.Join(path.Dir(dir), "testdata", "filespecs", spec)
+}
+
+// Set string flags. Return a slice of their values.
+func setStringFlags(flagSet *flag.FlagSet, flags ...string) []string {
+	cmdFlags := []string{}
+	for _, flag := range flags {
+		flagSet.String(strings.Split(flag, "=")[0], "", "")
+		cmdFlags = append(cmdFlags, "--"+flag)
+	}
+	return cmdFlags
 }

--- a/artifactory/cli_test.go
+++ b/artifactory/cli_test.go
@@ -164,6 +164,7 @@ func getSpecPath(t *testing.T, spec string) string {
 // Create flagset with input flags and arguments.
 func createFlagSet(flags []string, args []string) *flag.FlagSet {
 	flagSet := flag.NewFlagSet("TestFlagSet", flag.ContinueOnError)
+	flags = append(flags, "url=http://127.0.0.1:8081/artifactory")
 	cmdFlags := []string{}
 	for _, flag := range flags {
 		flagSet.String(strings.Split(flag, "=")[0], "", "")


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

* Add support for the following commands:
`jfrog rt s --bundle=bundleName/bundleVersion`
`jfrog rt del --bundle=bundleName/bundleVersion`
`jfrog rt sp --bundle=bundleName/bundleVersion`
`jfrog rt delp --bundle=bundleName/bundleVersion`
`jfrog rt sp --build=buildName/buildNumber`
`jfrog rt delp --build=buildName/buildNumber`

* Copy and move commands with `--build` flag and no arguments should return an error with usage. 
Running the following command:
`jfrog rt copy --build=buildName/buildNumber`
Expected:
  ```
  [Error] Wrong number of arguments....
  ```
  Actual:
  ```
  [Error] Spec must include target.
  ```