### PR TITLE
Fix permission target test

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -4854,12 +4854,9 @@ func assertPermissionTarget(t *testing.T, manager artifactory.ArtifactoryService
 }
 
 func assertPermissionTargetDeleted(t *testing.T, manager artifactory.ArtifactoryServicesManager) {
-	_, err := manager.GetPermissionTarget(tests.RtPermissionTargetName)
-	if err == nil {
-		assert.Error(t, err)
-		return
-	}
-	assert.Contains(t, err.Error(), "404")
+	permission, err := manager.GetPermissionTarget(tests.RtPermissionTargetName)
+	assert.NoError(t, err)
+	assert.Nil(t, permission)
 }
 
 func cleanPermissionTarget() {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Following the https://github.com/jfrog/jfrog-client-go/pull/337 which now causes the "get permission target" API to return nil, if the permission target does not exist, instead of an error, I'm adapting the test to reflect  this change.