### PR TITLE
Update getCli.sh to also support jfrog-cli v2

### DIFF
--- a/build/getCli.sh
+++ b/build/getCli.sh
@@ -2,23 +2,34 @@
 
 CLI_OS="na"
 CLI_UNAME="na"
+CLI_MAJOR_VER="v1"
 
-if [ $# -eq 0 ]
-  then
-	VERSION="[RELEASE]"
-	echo "Downloading the latest version of JFrog CLI..."
-  else
-	VERSION=$1
-	echo "Downloading version $1 of JFrog CLI..."
+if [[ $# -eq 1 ]] && [[ $1 -eq v2 ]]
+then
+    CLI_MAJOR_VER="v2"
+    VERSION="[RELEASE]"
+    echo "Downloading the latest v2 version of JFrog CLI..."
+elif [[ $# -eq 2 ]] && [[ $1 -eq "v2" ]] 
+then
+    CLI_MAJOR_VER="v2"
+    VERSION=$2
+    echo "Downloading version $2 of JFrog CLI..."
+elif [ $# -eq 0 ]
+then
+VERSION="[RELEASE]"
+    echo "Downloading the latest v1 version of JFrog CLI..."
+else
+    VERSION=$1
+    echo "Downloading version $1 of JFrog CLI..."
 fi
 
 if $(echo "${OSTYPE}" | grep -q msys); then
     CLI_OS="windows"
-    URL="https://releases.jfrog.io/artifactory/jfrog-cli/v1/${VERSION}/jfrog-cli-windows-amd64/jfrog.exe"
+    URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-windows-amd64/jfrog.exe"
     FILE_NAME="jfrog.exe"
 elif $(echo "${OSTYPE}" | grep -q darwin); then
     CLI_OS="mac"
-    URL="https://releases.jfrog.io/artifactory/jfrog-cli/v1/${VERSION}/jfrog-cli-mac-386/jfrog"
+    URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-mac-386/jfrog"
     FILE_NAME="jfrog"
 else
     CLI_OS="linux"

--- a/build/getCli.sh
+++ b/build/getCli.sh
@@ -4,12 +4,12 @@ CLI_OS="na"
 CLI_UNAME="na"
 CLI_MAJOR_VER="v1"
 
-if [[ $# -eq 1 ]] && [[ $1 -eq v2 ]]
+if [ $# -eq 1 ] && [ $1 -eq v2 ]
 then
     CLI_MAJOR_VER="v2"
     VERSION="[RELEASE]"
     echo "Downloading the latest v2 version of JFrog CLI..."
-elif [[ $# -eq 2 ]] && [[ $1 -eq "v2" ]] 
+elif [ $# -eq 2 ] && [ $1 -eq "v2" ]
 then
     CLI_MAJOR_VER="v2"
     VERSION=$2
@@ -61,7 +61,7 @@ else
             exit -1
             ;;
     esac
-    URL="https://releases.jfrog.io/artifactory/jfrog-cli/v1/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/jfrog"
+    URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/jfrog"
     FILE_NAME="jfrog"
 fi
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
The current getCli.sh supports the following syntax:
```
# Doenload the latest JFrog CLI version
./getCli.sh

# Download a specific vereion
./getCli.sh 1.49.0
```

The modified getCli.sh is backward compatible and supports the following:
```
# Doenload the latest v1 version of JFrog CLI
./getCli.sh

# Download a specific v1 vereion
./getCli.sh 1.49.0

# Doenload the latest v2 version of JFrog CLI
./getCli.sh v2

# Download a specific v2 vereion
./getCli.sh v2 2.1.0
```