### PR TITLE
Change jfrog-cli's debian, rpm and docker images to jfrog-cli-v2.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,9 +117,9 @@ def buildRpmAndDeb(version, architectures) {
             withCredentials([string(credentialsId: 'jfrog-cli-automation', variable: 'JFROG_CLI_AUTOMATION_ACCESS_TOKEN')]) {
                 options = "--url https://releases.jfrog.io/artifactory --flat --access-token=$JFROG_CLI_AUTOMATION_ACCESS_TOKEN"
                 sh """#!/bin/bash
-                    builder/jfrog rt u $jfrogCliRepoDir/build/deb_rpm/*.i386.deb jfrog-debs/pool/jfrog-cli/ --deb=xenial,bionic,eoan,focal/contrib/i386 $options
-                    builder/jfrog rt u $jfrogCliRepoDir/build/deb_rpm/*.x86_64.deb jfrog-debs/pool/jfrog-cli/ --deb=xenial,bionic,eoan,focal/contrib/amd64 $options
-                    builder/jfrog rt u $jfrogCliRepoDir/build/deb_rpm/*.rpm jfrog-rpms/jfrog-cli/ $options
+                    builder/jfrog rt u $jfrogCliRepoDir/build/deb_rpm/*.i386.deb jfrog-debs/pool/jfrog-cli-v2/ --deb=xenial,bionic,eoan,focal/contrib/i386 $options
+                    builder/jfrog rt u $jfrogCliRepoDir/build/deb_rpm/*.x86_64.deb jfrog-debs/pool/jfrog-cli-v2/ --deb=xenial,bionic,eoan,focal/contrib/amd64 $options
+                    builder/jfrog rt u $jfrogCliRepoDir/build/deb_rpm/*.rpm jfrog-rpms/jfrog-cli-v2/ $options
                     """
             }
         }
@@ -138,8 +138,8 @@ def uploadCli(architectures) {
 def buildPublishDockerImages(version, jfrogCliRepoDir) {
     def images = [
             // Pushing the second slim name for backward compatibility.
-            [dockerFile:'build/docker/slim/Dockerfile', names:['releases-docker.jfrog.io/jfrog/jfrog-cli', 'releases-docker.jfrog.io/jfrog/jfrog-cli-go']],
-            [dockerFile:'build/docker/full/Dockerfile', names:['releases-docker.jfrog.io/jfrog/jfrog-cli-full']]
+            [dockerFile:'build/docker/slim/Dockerfile', names:['releases-docker.jfrog.io/jfrog/jfrog-cli-v2']],
+            [dockerFile:'build/docker/full/Dockerfile', names:['releases-docker.jfrog.io/jfrog/jfrog-cli-full-v2']]
     ]
     for (int i = 0; i < images.size(); i++) {
         def currentImage = images[i]

--- a/build/deb_rpm/README.md
+++ b/build/deb_rpm/README.md
@@ -9,6 +9,6 @@ Build rpm and debian package for JFrog cli.
 
 #### Output
 ```bash
-pkg/jfrog-cli-<version>.<arch>.deb
-pkg/jfrog-cli-<version>.<arch>.rpm
+pkg/jfrog-cli-v2-<version>.<arch>.deb
+pkg/jfrog-cli-v2-<version>.<arch>.rpm
 ```

--- a/build/deb_rpm/build-scripts/deb-install.sh
+++ b/build/deb_rpm/build-scripts/deb-install.sh
@@ -1,4 +1,4 @@
 wget -qO - https://releases.jfrog.io/artifactory/api/gpg/key/public | apt-key add -;
 echo "deb https://releases.jfrog.io/artifactory/jfrog-debs xenial contrib" | sudo tee -a /etc/apt/sources.list;
 apt update;
-sudo apt install -y jfrog-cli
+sudo apt install -y jfrog-cli-v2

--- a/build/deb_rpm/build-scripts/rpm-install.sh
+++ b/build/deb_rpm/build-scripts/rpm-install.sh
@@ -4,4 +4,4 @@ echo "baseurl=https://releases.jfrog.io/artifactory/jfrog-rpms" >> jfrog-cli.rep
 echo "enabled=1" >> jfrog-cli.repo;
 echo "gpgcheck=0" >> jfrog-cli.repo;
 sudo mv jfrog-cli.repo /etc/yum.repos.d/;
-yum install -y jfrog-cli;
+yum install -y jfrog-cli-v2;

--- a/build/deb_rpm/deb/debian/README
+++ b/build/deb_rpm/deb/debian/README
@@ -1,4 +1,4 @@
-The Debian Package jfrog-cli
-----------------------------
+The Debian Package jfrog-cli-v2
+-------------------------------
 
- -- Jfrog <dev@jfrog.com>  Wed, 14 May 2020 09:59:32 +0000
+ -- Jfrog <dev@jfrog.com>  Wed, 30 June 2021 09:59:32 +0000

--- a/build/deb_rpm/deb/debian/changelog
+++ b/build/deb_rpm/deb/debian/changelog
@@ -1,4 +1,8 @@
-jfrog-cli (__VERSION__) unstable; urgency=low
+jfrog-cli-v2 (__VERSION__) unstable; urgency=low
+
+  * JFrog CLI v2 Release.
+
+ -- Jfrog <dev@jfrog.com>  Wed, 30 June 2021 09:59:32 +0000
 
   * Initial Release.
 

--- a/build/deb_rpm/deb/debian/changelog
+++ b/build/deb_rpm/deb/debian/changelog
@@ -2,8 +2,4 @@ jfrog-cli-v2 (__VERSION__) unstable; urgency=low
 
   * JFrog CLI v2 Release.
 
- -- Jfrog <dev@jfrog.com>  Wed, 30 June 2021 09:59:32 +0000
-
-  * Initial Release.
-
- -- Jfrog <dev@jfrog.com>  Wed, 14 May 2020 09:59:32 +0000
+ -- Jfrog <dev@jfrog.com>  Wed, 30 Jun 2021 09:59:32 +0000

--- a/build/deb_rpm/deb/debian/control
+++ b/build/deb_rpm/deb/debian/control
@@ -1,4 +1,4 @@
-Source: jfrog-cli
+Source: jfrog-cli-v2
 Section: misc
 Priority: optional
 Maintainer: Jfrog <devops@jfrog.com>
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>=8~)
 Standards-Version: 3.9.7
 Homepage: https://www.jfrog.com/confluence/display/CLI/JFrog+CLI
 
-Package: jfrog-cli
+Package: jfrog-cli-v2
 Architecture: any 
 Depends: ${misc:Depends}
 Description: Smart client that provides a simple interface that automates access to JFrog products

--- a/build/deb_rpm/deb/debian/rules
+++ b/build/deb_rpm/deb/debian/rules
@@ -14,7 +14,7 @@
 
 override_dh_clean:
 	dh_clean
-	rm -f debian/jfrog-cli
+	rm -f debian/jfrog-cli-v2
 override_dh_auto_build:
 	dh_auto_build
 

--- a/build/deb_rpm/rpm/jfrog-cli.spec
+++ b/build/deb_rpm/rpm/jfrog-cli.spec
@@ -1,4 +1,4 @@
-Name:           jfrog-cli
+Name:           jfrog-cli-v2
 Version:        %{cli_version}
 Release:        %{cli_release}
 Summary:        Smart client that provides a simple interface that automates access to JFrog products
@@ -29,11 +29,11 @@ echo post transaction %{name} \$1 = $1 >>/tmp/rpminst
 
 exit 0
 
-%triggerpostun -- jfrog-cli
+%triggerpostun -- jfrog-cli-v2
 echo trigger post uninstall %{name} \$1 = $1 >>/tmp/rpminst
 exit 0
 
-%triggerun -- jfrog-cli
+%triggerun -- jfrog-cli-v2
 echo trigger uninstall %{name} \$1 = $1 >>/tmp/rpminst
 exit 0
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Change jfrog-cli's debian, rpm and docker images to jfrog-cli-v2.