### PR TITLE
Delete ArtifactoryUploadLegacyProps test

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -1665,13 +1665,6 @@ func createFileInHomeDir(t *testing.T, fileName string) (testFileRelPath string,
 	return
 }
 
-func TestArtifactoryUploadLegacyProps(t *testing.T) {
-	initArtifactoryTest(t)
-	artifactoryCli.Exec("upload", "testdata/a/a*", tests.RtRepo1+"/data/", "--props=key1=val1;key2=val2,val3", "--flat=true")
-	verifyExistInArtifactoryByProps(tests.GetUploadLegacyPropsExpected(), tests.RtRepo1, "key1=val1;key2=val2;key2=val3", t)
-	cleanArtifactoryTest()
-}
-
 func TestArtifactoryUploadExcludeByCli1Wildcard(t *testing.T) {
 	initArtifactoryTest(t)
 	// Upload files


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

TestArtifactoryUploadLegacyProps is not relevant to V2, because the `--props` doesn't exist in the upload command.