### PR TITLE
Fix Test for downloading latest version using --build flag

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -2878,7 +2878,7 @@ func TestArtifactoryDownloadByShaAndBuildName(t *testing.T) {
 
 func TestArtifactoryDownloadByBuildUsingSimpleDownload(t *testing.T) {
 	initArtifactoryTest(t)
-	buildNumberA, buildNumberB := "10", "11"
+	buildNumberA, buildNumberB := "b", "a"
 	inttestutils.DeleteBuild(serverDetails.ArtifactoryUrl, tests.RtBuildName1, artHttpDetails)
 
 	// Upload files with buildName and buildNumber


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fix downloading latest version using --build flag

A better test covering the issue - [jfrog/jfrog-cli/issues/1110]
(When trying to download the artifacts from Arifactory using Jfrog CLI and specifying the --build option and it is expected to fetch the latest version but it is not fetching the latest #version.)

depends on jfrog-client-go PR - https://github.com/jfrog/jfrog-client-go/pull/395