### PR TITLE
V1: Show help on native commands when -h is provided

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1763,12 +1763,12 @@ func yarnCmd(c *cli.Context) error {
 
 // This function checks whether the command received --help as a single option.
 // If it did, the command's help is shown and true is returned.
-// This function should be uesd iff the SkipFlagParsing option is used.
+// This function should be used iff the SkipFlagParsing option is used.
 func showCmdHelpIfNeeded(c *cli.Context) (bool, error) {
 	if len(c.Args()) != 1 {
 		return false, nil
 	}
-	if c.Args()[0] == "--help" {
+	if c.Args()[0] == "--help" || c.Args()[0] == "-h" {
 		err := cli.ShowCommandHelp(c, c.Command.Name)
 		return true, err
 	}


### PR DESCRIPTION
Currently the `-h` is passed as an option to the native command itself.