### PR TITLE
Fix Projects Api tests in appveyor.yml (#1191)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,9 +43,13 @@ environment:
     secure: Um8o75MQIieSavIemF4ySA==
   JFROG_CLI_DIST_URL:
     secure: RIh0gGFDn2JAnLUEEqLsQrfLmtDrzDd5Qphea4gOE0Lu1Uz2Xa/y+D0Mld917gwy
+  JFROG_CLI_ACCESS_TOKEN:
+    secure: sStoT/GxZjEl/toWXau6wanS9NdCTsTxApUZCE7TTt4Wp4lVUwg1OqzdwWNic4R9YnAu90VY+5F/vI7I6Ijl1V/GcSCFLSVEr03rJj7OfzRkt5+obiNNotiBR9cP7bKQrCCAf2044fOukKPrjvZW7cV2tFoBQP8TmetaVmogBk52BMNcC44+MsLmh060htRFVHnigloE73U+TE3w1pgDd5QMM+z8sj+UGLGOj8W8KHprfYUS/JfUUuYWQYLAJIRvyGMxci5KIn6VygQzHagJ6rAUUFmZgxaWyJ5yRGufgteKTreIiwU0nk/iqTYPWgZJzagsfgrVWz0mkZG7d+Yjqw13N0qhCYRzRcyc4md4jBb4zrTUIcIdI+Ot0khhmFx1rq7sutWyqeCshN3bPk4vZ4AROczLJg8v91+2+keXzI3z/0LqswNqj0v1+15D+FHF86rxToun2HK765INHgCOMjhMxz4hOSWsz/IK0jhLxNX7S5geW/5+1UPh+FPZq4MLfwi1HWltg3Pi9PLdGacLmpxCAL/1MaqtI5Du2BxjuiSWPnOjAfsvScqoj6lyT8Sk3pwUGVPY8AK/Bu7vyQbB80v1yFind5+Rqvt8wPTPL72CPmjIMl8w4qrb1nEheOj8JQO1s701qF9xbKcOr9HXaaLpHuakw4sfha7jFhhgY1q+EQ06WbPHYl3DxEglDlioX/xHURRfSq39tpF6Auwl1GoiKNAsRLcQn+zi7fuf4VuM63zZuH+oWgJxwqm4CYkSb/MXErqvxjRVjD/L2Tn6d1TeSo9s4hyfb8T/gyyT2lVmQX5WqaDejcXFL1bEJNvQ15pkJfMRZlZlmtVCyC98YJ1QPf3NRmEyIXmH0S+kFCzcphbID1gI47vNJtRv0Wnaabo0uAV6bky/7o9KsWib0g==
+  JFROG_CLI_ACCESS_URL:
+    secure: RIh0gGFDn2JAnLUEEqLsQph5j1FANSk/QUtRJvh8kSfFYyaZd4ONAf1aP/WV9BOA
 
   COMMON_TESTS_ARGS:
-    go test -v github.com\jfrog\jfrog-cli --timeout 0 --rt.url="%JFROG_CLI_RT_URL%" --rt.user="%JFROG_CLI_RT_USER%" --rt.password="%JFROG_CLI_RT_PASSWORD%"
+    go test -v github.com\jfrog\jfrog-cli --timeout 0 --rt.url="%JFROG_CLI_RT_URL%" --rt.user="%JFROG_CLI_RT_USER%" --rt.password="%JFROG_CLI_RT_PASSWORD%" --access.url="%JFROG_CLI_ACCESS_URL%" --access.accessToken="%JFROG_CLI_ACCESS_TOKEN%"
 
   matrix:
   - VET:
@@ -61,7 +65,7 @@ environment:
       "%COMMON_TESTS_ARGS% --test.npm=true"
   - MAVEN_TESTS:
     TEST_SUIT:
-     "%COMMON_TESTS_ARGS% --test.maven=true"
+      "%COMMON_TESTS_ARGS% --test.maven=true"
   - GRADLE_TESTS:
     TEST_SUIT:
       "choco install gradle -s %JFROG_CLI_RT_URL%/api/nuget/choco -u %JFROG_CLI_RT_USER% -p %JFROG_CLI_RT_PASSWORD% &&


### PR DESCRIPTION
* Add sverdlov93_jfrog_cli_pipeline

* michael test commit

* Add support for commands with build and project flags combined, and also api to artifactory Access/projects RestApi.

Signed-off-by: sverdlov93 <sverdlov93@gmail.com>

* Fix most of CR requests

Signed-off-by: sverdlov93 <sverdlov93@gmail.com>

* Fix CR requests

Signed-off-by: sverdlov93 <sverdlov93@gmail.com>

* Fix CR requests

Signed-off-by: sverdlov93 <sverdlov93@gmail.com>

* Fix CR requests

Signed-off-by: sverdlov93 <sverdlov93@gmail.com>

* Revert pipelines.yml

Signed-off-by: sverdlov93 <sverdlov93@gmail.com>

* Add access.url to tests data

Signed-off-by: sverdlov93 <sverdlov93@gmail.com>

* fix appveyor.yml

Signed-off-by: sverdlov93 <sverdlov93@gmail.com>

* fix appveyor.yml

Signed-off-by: sverdlov93 <sverdlov93@gmail.com>

* Update appveyor.yml

- [ ] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
