### PR TITLE
Fix: Upload with archive and include-dirs leaves out empty directories

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -1096,7 +1096,7 @@ func TestArtifactoryUploadAsArchiveToDir(t *testing.T) {
 
 func TestArtifactoryUploadAsArchiveWithIncludeDirs(t *testing.T) {
 	initArtifactoryTest(t)
-
+	assert.NoError(t, createEmptyTestDir())
 	uploadSpecFile, err := tests.CreateSpec(tests.UploadAsArchiveEmptyDirs)
 	assert.NoError(t, err)
 	err = artifactoryCli.Exec("upload", "--spec="+uploadSpecFile)
@@ -1109,15 +1109,21 @@ func TestArtifactoryUploadAsArchiveWithIncludeDirs(t *testing.T) {
 	paths, err := fileutils.ListFilesRecursiveWalkIntoDirSymlink(tests.Out, false)
 	assert.NoError(t, err)
 	downloadedEmptyDirs := tests.GetDownloadArchiveAndExplodeWithIncludeDirs()
-	// verify dirs exists.
+	// Verify dirs exists.
 	tests.VerifyExistLocally(downloadedEmptyDirs, paths, t)
-	// verify empty dirs.
+	// Verify empty dirs.
 	for _, path := range downloadedEmptyDirs {
 		empty, err := fileutils.IsDirEmpty(path)
 		assert.NoError(t, err)
 		assert.True(t, empty)
 	}
 	cleanArtifactoryTest()
+}
+
+func createEmptyTestDir() error {
+	dirInnerPath := filepath.Join("empty", "folder")
+	canonicalPath := tests.GetTestResourcesPath() + dirInnerPath
+	return os.MkdirAll(canonicalPath, 0777)
 }
 
 func TestArtifactoryDownloadAndSyncDeletes(t *testing.T) {
@@ -2566,10 +2572,7 @@ func TestArtifactoryFlatFolderDownload1(t *testing.T) {
 
 func TestArtifactoryFolderUploadRecursiveUsingSpec(t *testing.T) {
 	initArtifactoryTest(t)
-	dirInnerPath := filepath.Join("empty", "folder")
-	canonicalPath := tests.GetTestResourcesPath() + dirInnerPath
-	err := os.MkdirAll(canonicalPath, 0777)
-	assert.NoError(t, err)
+	assert.NoError(t, createEmptyTestDir())
 	specFile, err := tests.CreateSpec(tests.UploadEmptyDirs)
 	assert.NoError(t, err)
 	artifactoryCli.Exec("upload", "--spec="+specFile)

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -1094,6 +1094,32 @@ func TestArtifactoryUploadAsArchiveToDir(t *testing.T) {
 	cleanArtifactoryTest()
 }
 
+func TestArtifactoryUploadAsArchiveWithIncludeDirs(t *testing.T) {
+	initArtifactoryTest(t)
+
+	uploadSpecFile, err := tests.CreateSpec(tests.UploadAsArchiveEmptyDirs)
+	assert.NoError(t, err)
+	err = artifactoryCli.Exec("upload", "--spec="+uploadSpecFile)
+	assert.NoError(t, err)
+
+	// Check the empty directories inside the archive by downloading and exploding it.
+	downloadSpecFile, err := tests.CreateSpec(tests.DownloadAndExplodeArchives)
+	assert.NoError(t, err)
+	artifactoryCli.Exec("download", "--spec="+downloadSpecFile)
+	paths, err := fileutils.ListFilesRecursiveWalkIntoDirSymlink(tests.Out, false)
+	assert.NoError(t, err)
+	downloadedEmptyDirs := tests.GetDownloadArchiveAndExplodeWithIncludeDirs()
+	// verify dirs exists.
+	tests.VerifyExistLocally(downloadedEmptyDirs, paths, t)
+	// verify empty dirs.
+	for _, path := range downloadedEmptyDirs {
+		empty, err := fileutils.IsDirEmpty(path)
+		assert.NoError(t, err)
+		assert.True(t, empty)
+	}
+	cleanArtifactoryTest()
+}
+
 func TestArtifactoryDownloadAndSyncDeletes(t *testing.T) {
 	initArtifactoryTest(t)
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,12 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
+replace github.com/jfrog/jfrog-client-go => github.com/gailazar300/jfrog-client-go v0.18.1-0.20210816121456-abc677a70ccf
+
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/gailazar300/jfrog-cli-core/v2 v2.0.0-20210809160508-6338f12dcd0c
+
+//replace github.com/jfrog/jfrog-client-go => ../jfrog-client-go
+//replace github.com/jfrog/jfrog-cli-core/v2 => ../jfrog-cli-core
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.1.1-0.20210808162748-3c2e98c7692a
 
 // replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.1.2-0.20210808170941-6b8e6dedd504

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gookit/color v1.4.2
 	github.com/jfrog/gofrog v1.0.7
-	github.com/jfrog/jfrog-cli-core/v2 v2.2.0
-	github.com/jfrog/jfrog-client-go v1.2.0
+	github.com/jfrog/jfrog-cli-core/v2 v2.2.1
+	github.com/jfrog/jfrog-client-go v1.2.1
 	github.com/jszwec/csvutil v1.4.0
 	github.com/mholt/archiver v2.1.0+incompatible
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
@@ -22,14 +22,9 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/gailazar300/jfrog-client-go v0.18.1-0.20210816121456-abc677a70ccf
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.2.2-0.20210819122944-2a0aab005e85
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/gailazar300/jfrog-cli-core/v2 v2.0.0-20210809160508-6338f12dcd0c
-
-
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.1.1-0.20210808162748-3c2e98c7692a
-
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.1.2-0.20210808170941-6b8e6dedd504
+// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.2.1-0.20210815142834-252f651cb573
 
 // replace github.com/jfrog/gocmd => github.com/jfrog/gocmd v0.4.2-0.20210711151504-537a5ef5b8e1
 

--- a/go.mod
+++ b/go.mod
@@ -26,8 +26,7 @@ replace github.com/jfrog/jfrog-client-go => github.com/gailazar300/jfrog-client-
 
 replace github.com/jfrog/jfrog-cli-core/v2 => github.com/gailazar300/jfrog-cli-core/v2 v2.0.0-20210809160508-6338f12dcd0c
 
-//replace github.com/jfrog/jfrog-client-go => ../jfrog-client-go
-//replace github.com/jfrog/jfrog-cli-core/v2 => ../jfrog-cli-core
+
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.1.1-0.20210808162748-3c2e98c7692a
 
 // replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.1.2-0.20210808170941-6b8e6dedd504

--- a/go.sum
+++ b/go.sum
@@ -77,10 +77,6 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
-github.com/gailazar300/jfrog-cli-core/v2 v2.0.0-20210809160508-6338f12dcd0c h1:c0pdqEnInl+VyA2HfHsEbzPZDkdDgbI9QfqkbhXCmZ0=
-github.com/gailazar300/jfrog-cli-core/v2 v2.0.0-20210809160508-6338f12dcd0c/go.mod h1:yimmtzZTSTS5TO9bSTO58/aIqkH0j7W4IpjBDPjX5lU=
-github.com/gailazar300/jfrog-client-go v0.18.1-0.20210816121456-abc677a70ccf h1:CSJje7em42khz38YMPdu/pa+92L+vMghipJw8J4p1mo=
-github.com/gailazar300/jfrog-client-go v0.18.1-0.20210816121456-abc677a70ccf/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
@@ -164,6 +160,10 @@ github.com/jfrog/gocmd v0.4.2/go.mod h1:+nQOc+GQQu2e3dJBxymq9/y3ReLHDz6Eg/+QkGHP
 github.com/jfrog/gofrog v1.0.6/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
 github.com/jfrog/gofrog v1.0.7 h1:sHR5IDGFY61+mGqTH/dIZlojTeIb6kXdK74oxMAjTgc=
 github.com/jfrog/gofrog v1.0.7/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
+github.com/jfrog/jfrog-cli-core/v2 v2.2.1 h1:61+a5UVDI1GBphopp4I/oSTNwHxuRsMGiKTWDMog0SA=
+github.com/jfrog/jfrog-cli-core/v2 v2.2.1/go.mod h1:GfG1jIy6WnCVSq+RX0HavpbxzwJotUmEhiZnFNDNikA=
+github.com/jfrog/jfrog-client-go v1.2.2-0.20210819122944-2a0aab005e85 h1:LVEMtT8dpsBA22bTJ8MHYY+WLyPvqA4XAOkKGaPFG2I=
+github.com/jfrog/jfrog-client-go v1.2.2-0.20210819122944-2a0aab005e85/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,10 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
+github.com/gailazar300/jfrog-cli-core/v2 v2.0.0-20210809160508-6338f12dcd0c h1:c0pdqEnInl+VyA2HfHsEbzPZDkdDgbI9QfqkbhXCmZ0=
+github.com/gailazar300/jfrog-cli-core/v2 v2.0.0-20210809160508-6338f12dcd0c/go.mod h1:yimmtzZTSTS5TO9bSTO58/aIqkH0j7W4IpjBDPjX5lU=
+github.com/gailazar300/jfrog-client-go v0.18.1-0.20210816121456-abc677a70ccf h1:CSJje7em42khz38YMPdu/pa+92L+vMghipJw8J4p1mo=
+github.com/gailazar300/jfrog-client-go v0.18.1-0.20210816121456-abc677a70ccf/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
@@ -160,11 +164,6 @@ github.com/jfrog/gocmd v0.4.2/go.mod h1:+nQOc+GQQu2e3dJBxymq9/y3ReLHDz6Eg/+QkGHP
 github.com/jfrog/gofrog v1.0.6/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
 github.com/jfrog/gofrog v1.0.7 h1:sHR5IDGFY61+mGqTH/dIZlojTeIb6kXdK74oxMAjTgc=
 github.com/jfrog/gofrog v1.0.7/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
-github.com/jfrog/jfrog-cli-core/v2 v2.2.0 h1:Z4nUfPPyeIBzcgIdZNOpJZr8lUukVkbxuDVBNn51j0w=
-github.com/jfrog/jfrog-cli-core/v2 v2.2.0/go.mod h1:yimmtzZTSTS5TO9bSTO58/aIqkH0j7W4IpjBDPjX5lU=
-github.com/jfrog/jfrog-client-go v1.1.0/go.mod h1:bjBL6Svr951HZH7JvMtzPJ9Xy5cO0OweNjkhUzxKmtw=
-github.com/jfrog/jfrog-client-go v1.2.0 h1:xBlg9hz7DqMbXfrw6zxUwulY6HS5inoeRyssOB7elpc=
-github.com/jfrog/jfrog-client-go v1.2.0/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -337,7 +336,6 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/testdata/filespecs/upload_archive_empty_dir_spec.json
+++ b/testdata/filespecs/upload_archive_empty_dir_spec.json
@@ -1,0 +1,18 @@
+{
+  "files": [
+    {
+      "pattern": "testdata/empty/*",
+      "target": "${REPO1}/archive/archive.zip",
+      "includeDirs": "true",
+      "archive": "zip"
+    },
+    {
+      "pattern": "testdata/*/c",
+      "target": "${REPO1}/archive/archive.zip",
+      "flat": "true",
+      "recursive": "true",
+      "includeDirs": "true",
+      "archive": "zip"
+    }
+  ]
+}

--- a/utils/tests/artifactoryconsts.go
+++ b/utils/tests/artifactoryconsts.go
@@ -109,6 +109,7 @@ const (
 	UploadAntPattern                       = "upload_ant_pattern.json"
 	UploadAntPatternExclusions             = "upload_ant_pattern_exclusions.json"
 	UploadEmptyDirs                        = "upload_empty_dir_spec.json"
+	UploadAsArchiveEmptyDirs               = "upload_archive_empty_dir_spec.json"
 	UploadFileWithParenthesesSpec          = "upload_file_with_parentheses.json"
 	UploadFlatNonRecursive                 = "upload_flat_non_recursive.json"
 	UploadFlatRecursive                    = "upload_flat_recursive.json"
@@ -430,6 +431,13 @@ func GetDownloadArchiveAndExplode() []string {
 		filepath.Join(Out, "archive/b/b1.in"),
 		filepath.Join(Out, "archive/b/b2.in"),
 		filepath.Join(Out, "archive/b/b3.in"),
+	}
+}
+
+func GetDownloadArchiveAndExplodeWithIncludeDirs() []string {
+	return []string{
+		filepath.Join(Out, "archive/archive/c"),
+		filepath.Join(Out, "archive/archive/folder"),
 	}
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Uploading a folder as a zip file with --include-dirs will exclude any empty directories in the folder.
Related PR: https://github.com/jfrog/jfrog-client-go/pull/415