### PR TITLE
V1 Fix: Upload with archive and include-dirs leaves out empty directories

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -1157,6 +1157,38 @@ func TestArtifactorySelfSignedCert(t *testing.T) {
 	cleanArtifactoryTest()
 }
 
+func TestArtifactoryUploadAsArchiveWithIncludeDirs(t *testing.T) {
+	initArtifactoryTest(t)
+	assert.NoError(t, createEmptyTestDir())
+	uploadSpecFile, err := tests.CreateSpec(tests.UploadAsArchiveEmptyDirs)
+	assert.NoError(t, err)
+	err = artifactoryCli.Exec("upload", "--spec="+uploadSpecFile)
+	assert.NoError(t, err)
+
+	// Check the empty directories inside the archive by downloading and exploding it.
+	downloadSpecFile, err := tests.CreateSpec(tests.DownloadAndExplodeArchives)
+	assert.NoError(t, err)
+	artifactoryCli.Exec("download", "--spec="+downloadSpecFile)
+	paths, err := fileutils.ListFilesRecursiveWalkIntoDirSymlink(tests.Out, false)
+	assert.NoError(t, err)
+	downloadedEmptyDirs := tests.GetDownloadArchiveAndExplodeWithIncludeDirs()
+	// Verify dirs exists.
+	tests.VerifyExistLocally(downloadedEmptyDirs, paths, t)
+	// Verify empty dirs.
+	for _, path := range downloadedEmptyDirs {
+		empty, err := fileutils.IsDirEmpty(path)
+		assert.NoError(t, err)
+		assert.True(t, empty)
+	}
+	cleanArtifactoryTest()
+}
+
+func createEmptyTestDir() error {
+	dirInnerPath := filepath.Join("empty", "folder")
+	canonicalPath := tests.GetTestResourcesPath() + dirInnerPath
+	return os.MkdirAll(canonicalPath, 0777)
+}
+
 // Test client certificates with Artifactory. For the test, we set up a reverse proxy server.
 func TestArtifactoryClientCert(t *testing.T) {
 	initArtifactoryTest(t)
@@ -2491,10 +2523,7 @@ func TestArtifactoryFlatFolderDownload1(t *testing.T) {
 
 func TestArtifactoryFolderUploadRecursiveUsingSpec(t *testing.T) {
 	initArtifactoryTest(t)
-	dirInnerPath := filepath.Join("empty", "folder")
-	canonicalPath := tests.GetTestResourcesPath() + dirInnerPath
-	err := os.MkdirAll(canonicalPath, 0777)
-	assert.NoError(t, err)
+	assert.NoError(t, createEmptyTestDir())
 	specFile, err := tests.CreateSpec(tests.UploadEmptyDirs)
 	assert.NoError(t, err)
 	artifactoryCli.Exec("upload", "--spec="+specFile)

--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,10 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.0.1-0.20210815141452-d980d0b5cd25
+//replace github.com/jfrog/jfrog-client-go => ../jfrog-client-go
+replace github.com/jfrog/jfrog-client-go => github.com/gailazar300/jfrog-client-go v0.18.1-0.20210818135620-8d1d33be01bb
 
+//replace github.com/jfrog/jfrog-cli-core => ../jfrog-cli-core
 replace github.com/jfrog/jfrog-cli-core => github.com/jfrog/jfrog-cli-core v1.9.1-0.20210815142935-34bdc55915cc
 
 // replace github.com/jfrog/gocmd => github.com/jfrog/gocmd v0.3.1-0.20210623152326-422f211f4e7f

--- a/go.mod
+++ b/go.mod
@@ -23,10 +23,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-//replace github.com/jfrog/jfrog-client-go => ../jfrog-client-go
-replace github.com/jfrog/jfrog-client-go => github.com/gailazar300/jfrog-client-go v0.18.1-0.20210818135620-8d1d33be01bb
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.0.1-0.20210819124929-41422c806cc0
 
-//replace github.com/jfrog/jfrog-cli-core => ../jfrog-cli-core
 replace github.com/jfrog/jfrog-cli-core => github.com/jfrog/jfrog-cli-core v1.9.1-0.20210815142935-34bdc55915cc
 
 // replace github.com/jfrog/gocmd => github.com/jfrog/gocmd v0.3.1-0.20210623152326-422f211f4e7f

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebP
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gailazar300/jfrog-client-go v0.18.1-0.20210818135620-8d1d33be01bb h1:rl+ZigOuxAzytKnYH4lQ9iOpl0aCwVnXNgmkEQNKSTk=
+github.com/gailazar300/jfrog-client-go v0.18.1-0.20210818135620-8d1d33be01bb/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
@@ -158,8 +160,6 @@ github.com/jfrog/gofrog v1.0.6 h1:yUDxSCw8gTK6vC4PvtG0HTnEOQJSZ+O4lWGCgkev1nU=
 github.com/jfrog/gofrog v1.0.6/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
 github.com/jfrog/jfrog-cli-core v1.9.1-0.20210815142935-34bdc55915cc h1:Jupk97ifbDmTbAJgl/2A3i6837LhG+5qq5TWuEe7Zt8=
 github.com/jfrog/jfrog-cli-core v1.9.1-0.20210815142935-34bdc55915cc/go.mod h1:UL+zbO2VirBi+mS6OXpxmTlrrlngcqYMtJfPgjxG+ic=
-github.com/jfrog/jfrog-client-go v1.0.1-0.20210815141452-d980d0b5cd25 h1:CccMoBnfjAhseBc+Dbe+gkxixkYEiF+is0Af77iQkVc=
-github.com/jfrog/jfrog-client-go v1.0.1-0.20210815141452-d980d0b5cd25/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,6 @@ github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebP
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/gailazar300/jfrog-client-go v0.18.1-0.20210818135620-8d1d33be01bb h1:rl+ZigOuxAzytKnYH4lQ9iOpl0aCwVnXNgmkEQNKSTk=
-github.com/gailazar300/jfrog-client-go v0.18.1-0.20210818135620-8d1d33be01bb/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
@@ -160,6 +158,8 @@ github.com/jfrog/gofrog v1.0.6 h1:yUDxSCw8gTK6vC4PvtG0HTnEOQJSZ+O4lWGCgkev1nU=
 github.com/jfrog/gofrog v1.0.6/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
 github.com/jfrog/jfrog-cli-core v1.9.1-0.20210815142935-34bdc55915cc h1:Jupk97ifbDmTbAJgl/2A3i6837LhG+5qq5TWuEe7Zt8=
 github.com/jfrog/jfrog-cli-core v1.9.1-0.20210815142935-34bdc55915cc/go.mod h1:UL+zbO2VirBi+mS6OXpxmTlrrlngcqYMtJfPgjxG+ic=
+github.com/jfrog/jfrog-client-go v1.0.1-0.20210819124929-41422c806cc0 h1:E5PJB04ETiUGeDeUDiPOuHELenCg6uvYLIjqeSojWTI=
+github.com/jfrog/jfrog-client-go v1.0.1-0.20210819124929-41422c806cc0/go.mod h1:dR0Z+zjSAoMWT5phrPIVjj+kjYYHHAEq1JnvA7klwvI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/testdata/filespecs/upload_archive_empty_dir_spec.json
+++ b/testdata/filespecs/upload_archive_empty_dir_spec.json
@@ -1,0 +1,18 @@
+{
+  "files": [
+    {
+      "pattern": "testdata/empty/*",
+      "target": "${REPO1}/archive/archive.zip",
+      "includeDirs": "true",
+      "archive": "zip"
+    },
+    {
+      "pattern": "testdata/*/c",
+      "target": "${REPO1}/archive/archive.zip",
+      "flat": "true",
+      "recursive": "true",
+      "includeDirs": "true",
+      "archive": "zip"
+    }
+  ]
+}

--- a/utils/tests/artifactoryconsts.go
+++ b/utils/tests/artifactoryconsts.go
@@ -110,6 +110,7 @@ const (
 	UploadAntPattern                       = "upload_ant_pattern.json"
 	UploadAntPatternExclusions             = "upload_ant_pattern_exclusions.json"
 	UploadEmptyDirs                        = "upload_empty_dir_spec.json"
+	UploadAsArchiveEmptyDirs               = "upload_archive_empty_dir_spec.json"
 	UploadFileWithParenthesesSpec          = "upload_file_with_parentheses.json"
 	UploadFlatNonRecursive                 = "upload_flat_non_recursive.json"
 	UploadFlatRecursive                    = "upload_flat_recursive.json"
@@ -429,6 +430,13 @@ func GetDownloadArchiveAndExplode() []string {
 		filepath.Join(Out, "archive/b/b1.in"),
 		filepath.Join(Out, "archive/b/b2.in"),
 		filepath.Join(Out, "archive/b/b3.in"),
+	}
+}
+
+func GetDownloadArchiveAndExplodeWithIncludeDirs() []string {
+	return []string{
+		filepath.Join(Out, "archive/archive/c"),
+		filepath.Join(Out, "archive/archive/folder"),
 	}
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Uploading a folder as a zip file with --include-dirs will exclude any empty directories in the folder.
Related PR: https://github.com/jfrog/jfrog-client-go/pull/420

Reviewed in PR: https://github.com/jfrog/jfrog-cli/pull/1203