### PR TITLE
V1: Update getCli.sh to support the 'v2' option

### DIFF
--- a/build/getCli.sh
+++ b/build/getCli.sh
@@ -1,24 +1,32 @@
 #!/bin/bash
-
 CLI_OS="na"
 CLI_UNAME="na"
-
-if [ $# -eq 0 ]
-  then
-	VERSION="[RELEASE]"
-	echo "Downloading the latest version of JFrog CLI..."
-  else
-	VERSION=$1
-	echo "Downloading version $1 of JFrog CLI..."
+CLI_MAJOR_VER="v1"
+if [ $# -eq 1 ] && [ $1 == "v2" ]
+then
+    CLI_MAJOR_VER="v2"
+    VERSION="[RELEASE]"
+    echo "Downloading the latest v2 version of JFrog CLI..."
+elif [ $# -eq 2 ] && [ $1 == "v2" ] 
+then
+    CLI_MAJOR_VER="v2"
+    VERSION=$2
+    echo "Downloading version $2 of JFrog CLI..."
+elif [ $# -eq 0 ]
+then
+    VERSION="[RELEASE]"
+    echo "Downloading the latest v1 version of JFrog CLI..."
+else
+    VERSION=$1
+    echo "Downloading version $1 of JFrog CLI..."
 fi
-
 if $(echo "${OSTYPE}" | grep -q msys); then
     CLI_OS="windows"
-    URL="https://releases.jfrog.io/artifactory/jfrog-cli/v1/${VERSION}/jfrog-cli-windows-amd64/jfrog.exe"
+    URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-windows-amd64/jfrog.exe"
     FILE_NAME="jfrog.exe"
 elif $(echo "${OSTYPE}" | grep -q darwin); then
     CLI_OS="mac"
-    URL="https://releases.jfrog.io/artifactory/jfrog-cli/v1/${VERSION}/jfrog-cli-mac-386/jfrog"
+    URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-mac-386/jfrog"
     FILE_NAME="jfrog"
 else
     CLI_OS="linux"
@@ -50,9 +58,8 @@ else
             exit -1
             ;;
     esac
-    URL="https://releases.jfrog.io/artifactory/jfrog-cli/v1/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/jfrog"
+    URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/jfrog"
     FILE_NAME="jfrog"
 fi
-
 curl -XGET "$URL" -L -k -g > $FILE_NAME
 chmod u+x $FILE_NAME


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Updating the getCli.sh script, which is part of the v1 branch, to support also downloading v2 versions.
This change is needed, to avoid scripts from breaking, following the change introduced in https://github.com/jfrog/jfrog-cli/pull/1211.
The change in https://github.com/jfrog/jfrog-cli/pull/1211 affects the v2 branch, which this PR affects the v1 branch.