### PR TITLE
Missing quotes in empty summary

### DIFF
--- a/utils/cliutils/utils.go
+++ b/utils/cliutils/utils.go
@@ -138,7 +138,7 @@ func PrintDetailedSummaryReport(success, failed int, reader *content.ContentRead
 	readerLength, _ := reader.Length()
 	// If the reader is empty we will print an empty array.
 	if readerLength == 0 {
-		log.Output("  files: []")
+		log.Output("  \"files\": []")
 	} else {
 		for transferDetails := new(clientutils.FileTransferDetails); reader.NextRecord(transferDetails) == nil; transferDetails = new(clientutils.FileTransferDetails) {
 			writer.Write(getDetailedSummaryRecord(transferDetails, printExtendedDetails))


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Command results summary report is broken when the results are empty. For example:

Good results with 1 file matched:
```json
{
  "status": "success",
  "totals": {
    "success": 1,
    "failure": 0
  },
  "files": [
    {
      "source": "hello",
      "target": "https://ecosysjfrog.jfrog.io/artifactory/generic-local/hello",
      "sha256": "a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447"
    }
  ]
}
```

Empty results (notice the files without quotes):
```json
{
  "status": "success",
  "totals": {
    "success": 0,
    "failure": 0
  },
  files: []
}
```