### PR TITLE
Releasing jfrog-cli through Repo21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ node("docker") {
     env.GO111MODULE="on"
     env.JFROG_CLI_OFFER_CONFIG="false"
     env.JFROG_CLI_BUILD_NAME="ecosystem-jfrog-cli-release"
-    env.JFROG_CLI_BUILD_NUMBER="${env.BUILD_NUMBER}"
+    env.JFROG_CLI_BUILD_NUMBER="${BUILD_NUMBER}"
     env.JFROG_CLI_BUILD_PROJECT="ecosys"
     // Substract repo name fro the repo url (https://REPO_NAME/ -> REPO_NAME/)
     withCredentials( string(credentialsId: 'repo21-url', variable: 'REPO21_URL')) {
@@ -82,7 +82,7 @@ node("docker") {
             downloadToolsCert()
             print "Uploading version $version to Repo21"
             uploadCli(architectures)
-            // bp
+            buildPublish()
             // SCAN
             distributeCli(version)
         }
@@ -101,6 +101,19 @@ def downloadToolsCert() {
             """
         }
         sh 'tar -xvzf jfrogltd_signingcer_full.tar.gz'
+    }
+}
+
+def buildPublish() {
+    stage('build publish') {
+        withCredentials([
+        string(credentialsId: 'repo21-ecosystem-automation', variable: 'JFROG_CLI_AUTOMATION_ACCESS_TOKEN'),
+        string(credentialsId: 'repo21-url', variable: 'REPO21_URL')
+        ]) {
+        sh """#!/bin/bash
+              builder/jfrog rt bp ${JFROG_CLI_BUILD_NAME} ${JFROG_CLI_BUILD_NUMBER} --url $REPO21_URL/artifactory/ --access-token=$JFROG_CLI_AUTOMATION_ACCESS_TOKEN
+        """
+        }
     }
 }
 

--- a/build/docker/full/Dockerfile
+++ b/build/docker/full/Dockerfile
@@ -1,6 +1,6 @@
 ARG image_name=jfrog-cli-full
 # In order to build this image localy, remove ${REPO_NAME_21}
-FROM ${REPO_NAME_21}golang:1.17.2 as builder
+FROM ${REPO_NAME_21}/jfrog-docker/golang:1.17.2 as builder
 WORKDIR /${image_name}
 COPY . /${image_name}
 RUN sh build/build.sh

--- a/build/docker/full/Dockerfile
+++ b/build/docker/full/Dockerfile
@@ -1,5 +1,6 @@
 ARG image_name=jfrog-cli-full
-FROM golang:1.17.2 as builder
+# In order to build this image localy, remove ${REPO_NAME_21}
+FROM ${REPO_NAME_21}golang:1.17.2 as builder
 WORKDIR /${image_name}
 COPY . /${image_name}
 RUN sh build/build.sh

--- a/build/docker/slim/Dockerfile
+++ b/build/docker/slim/Dockerfile
@@ -1,9 +1,11 @@
 ARG image_name=jfrog-cli
-FROM golang:1.17.2-alpine as builder
+# In order to build this image localy, remove ${REPO_NAME_21}
+FROM ${REPO_NAME_21}golang:1.17.2-alpine as builder
 WORKDIR /${image_name}
 COPY . /${image_name}
 RUN apk add --update git && sh build/build.sh
-FROM alpine:3.12.0
+# In order to build this image localy, remove ${REPO_NAME_21}
+FROM ${REPO_NAME_21}alpine:3.12.0
 ENV CI true
 RUN apk add --no-cache bash tzdata ca-certificates curl
 COPY --from=builder /${image_name}/jfrog /usr/local/bin/jfrog

--- a/build/docker/slim/Dockerfile
+++ b/build/docker/slim/Dockerfile
@@ -1,11 +1,11 @@
 ARG image_name=jfrog-cli
 # In order to build this image localy, remove ${REPO_NAME_21}
-FROM ${REPO_NAME_21}golang:1.17.2-alpine as builder
+FROM ${REPO_NAME_21}/jfrog-docker/golang:1.17.2-alpine as builder
 WORKDIR /${image_name}
 COPY . /${image_name}
 RUN apk add --update git && sh build/build.sh
 # In order to build this image localy, remove ${REPO_NAME_21}
-FROM ${REPO_NAME_21}alpine:3.12.0
+FROM ${REPO_NAME_21}/jfrog-docker/alpine:3.12.0
 ENV CI true
 RUN apk add --no-cache bash tzdata ca-certificates curl
 COPY --from=builder /${image_name}/jfrog /usr/local/bin/jfrog

--- a/cli-release/cli-distribution_rules.json
+++ b/cli-release/cli-distribution_rules.json
@@ -1,0 +1,9 @@
+{
+  "distribution_rules": [
+    {
+      "site_name": "releases.jfrog.io",
+      "city_name": "*",
+      "country_codes": ["*"]
+    }
+  ]
+}

--- a/cli-release/cli-rb-spec.json
+++ b/cli-release/cli-rb-spec.json
@@ -1,0 +1,12 @@
+{
+  "files": [
+    {
+      "pattern": "ecosys-jfrog-cli/v2/scripts/getCli.sh",
+      "target": "jfrog-cli/v2/scripts/getCli.sh"
+    },
+    {
+      "pattern": "ecosys-jfrog-cli/v2/${VERSION}/(*)/(*)",
+      "target": "jfrog-cli/v2/${VERSION}/{1}/{2}"
+    }
+  ]
+}

--- a/cli-release/docker-rb-spec.json
+++ b/cli-release/docker-rb-spec.json
@@ -1,0 +1,12 @@
+{
+  "files": [
+    {
+      "pattern": "ecosys-docker-local/jfrog/jfrog-cli-v2/${VERSION}/(*)",
+      "target": "rb-docker-local/jfrog/jfrog-cli-v2/${VERSION}/{1}"
+    },
+    {
+      "pattern": "ecosys-docker-local/jfrog/jfrog-cli-v2/latest/(*)",
+      "target": "rb-docker-local/jfrog/jfrog-cli-v2/latest/{1}"
+    }
+  ]
+}

--- a/cli-release/releases_distribution_rule.json
+++ b/cli-release/releases_distribution_rule.json
@@ -1,7 +1,7 @@
 {
   "distribution_rules": [
     {
-      "site_name": "releases.jfrog.io",
+      "site_name": "*",
       "city_name": "*",
       "country_codes": ["*"]
     }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Change jfrog-cli release process.
Instead of uploading directly to releases.jfrog.io we first upload to repo21 and distribute to releases.