### PR TITLE
Move envs from help section to side command

### DIFF
--- a/docs/common/help.go
+++ b/docs/common/help.go
@@ -40,7 +40,8 @@ const GlobalEnvVars string = `	JFROG_CLI_LOG_LEVEL
 	CI
 		[Default: false]
 		If true, disables interactive prompts and progress bar.
-		JFROG_CLI_PLUGINS_SERVER
+	
+	JFROG_CLI_PLUGINS_SERVER
 		[Default: Official JFrog CLI Plugins registry]
 		Configured Artifactory server ID from which to download JFrog CLI Plugins.
 	

--- a/docs/common/help.go
+++ b/docs/common/help.go
@@ -40,4 +40,28 @@ const GlobalEnvVars string = `	JFROG_CLI_LOG_LEVEL
 	CI
 		[Default: false]
 		If true, disables interactive prompts and progress bar.
+		JFROG_CLI_PLUGINS_SERVER
+		[Default: Official JFrog CLI Plugins registry]
+		Configured Artifactory server ID from which to download JFrog CLI Plugins.
+		
+	JFROG_CLI_PLUGINS_REPO
+		[Default: 'jfrog-cli-plugins']
+		Can be optionally used with the JFROG_CLI_PLUGINS_SERVER environment variable.
+		Determines the name of the local repository to use.
+	
+	JFROG_CLI_TRANSITIVE_DOWNLOAD_EXPERIMENTAL
+		[Default: false]
+		Set to true to look for artifacts also in remote repositories. This feature is experimental and available on Artifactory version 7.17.0 or higher.
+	
+	JFROG_CLI_EXTRACTORS_REMOTE
+		Configured Artifactory server ID and repository name from which to download the jar needed by the mvn/gradle command.
+		This environemt variable’s value format should be <server ID>/<repo name>. The repository should proxy https://oss.jfrog.org/artifactory/oss-release-local.
+	
+	JFROG_CLI_DEPENDENCIES_DIR
+		[Default: $JFROG_CLI_HOME_DIR/dependencies]
+		Defines the directory to which JFrog CLI's internal dependencies are downloaded.
+	
+	JFROG_CLI_MIN_CHECKSUM_DEPLOY_SIZE_KB
+		[Default: 10]
+		Minimum file size in KB for which JFrog CLI performs checksum deploy optimization.
 		`

--- a/docs/common/help.go
+++ b/docs/common/help.go
@@ -43,7 +43,7 @@ const GlobalEnvVars string = `	JFROG_CLI_LOG_LEVEL
 		JFROG_CLI_PLUGINS_SERVER
 		[Default: Official JFrog CLI Plugins registry]
 		Configured Artifactory server ID from which to download JFrog CLI Plugins.
-		
+	
 	JFROG_CLI_PLUGINS_REPO
 		[Default: 'jfrog-cli-plugins']
 		Can be optionally used with the JFROG_CLI_PLUGINS_SERVER environment variable.

--- a/docs/common/helputils.go
+++ b/docs/common/helputils.go
@@ -7,6 +7,5 @@ func CreateEnvVars(envVars ...string) string {
 	for _, envVar := range envVars {
 		s = append(s, envVar)
 	}
-	s = append(s, GlobalEnvVars)
 	return strings.Join(s[:], "\n\n")
 }

--- a/main.go
+++ b/main.go
@@ -153,9 +153,9 @@ func getCommands() []cli.Command {
 			},
 		},
 		{
-			Name:        cliutils.CmdEnvironments,
-			Aliases:     []string{"envs"},
-			Description: "Shows a list of environment variables",
+			Name:        cliutils.CmdOptions,
+			Aliases:     []string{"options"},
+			Description: "Show all supported environment variables",
 			Action: func(*cli.Context) {
 				fmt.Printf(common.GlobalEnvVars)
 			},

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/jfrog/jfrog-cli/distribution"
 	"os"
 
@@ -55,8 +56,6 @@ COMMANDS:
 GLOBAL OPTIONS:
    {{range .VisibleFlags}}{{.}}
    {{end}}
-Environment Variables:
-` + common.GlobalEnvVars + `{{end}}
 
 `
 
@@ -74,8 +73,6 @@ Arguments:
 OPTIONS:
    {{range .VisibleFlags}}{{.}}
    {{end}}
-Environment Variables:
-` + common.GlobalEnvVars + `{{end}}
 
 `
 
@@ -144,7 +141,6 @@ func getCommands() []cli.Command {
 			Description: "Config commands",
 			Subcommands: config.GetCommands(),
 		},
-
 		{
 			Name:         "ci-setup",
 			Usage:        cisetup.Description,
@@ -154,6 +150,14 @@ func getCommands() []cli.Command {
 			BashComplete: corecommon.CreateBashCompletionFunc(),
 			Action: func(c *cli.Context) error {
 				return commands.RunCiSetupCmd()
+			},
+		},
+		{
+			Name:        cliutils.CmdEnvironments,
+			Aliases:     []string{"envs"},
+			Description: "Shows a list of environment variables",
+			Action: func(*cli.Context) {
+				fmt.Printf(common.GlobalEnvVars)
 			},
 		},
 	}

--- a/utils/cliutils/cli_consts.go
+++ b/utils/cliutils/cli_consts.go
@@ -13,6 +13,7 @@ const (
 	CmdCompletion     = "completion"
 	CmdPlugin         = "plugin"
 	CmdConfig         = "config"
+	CmdEnvironments   = "environments"
 
 	// Download
 	DownloadMinSplitKb    = 5120

--- a/utils/cliutils/cli_consts.go
+++ b/utils/cliutils/cli_consts.go
@@ -13,7 +13,7 @@ const (
 	CmdCompletion     = "completion"
 	CmdPlugin         = "plugin"
 	CmdConfig         = "config"
-	CmdEnvironments   = "environments"
+	CmdOptions        = "options" 
 
 	// Download
 	DownloadMinSplitKb    = 5120


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Instead of showing all environments under every help command, show them only on "jfrog envs" command 