### PR TITLE
Export default server if no args was given to "jfrog c export" command

### DIFF
--- a/config/cli.go
+++ b/config/cli.go
@@ -190,10 +190,15 @@ func importCmd(c *cli.Context) error {
 }
 
 func exportCmd(c *cli.Context) error {
-	if c.NArg() != 1 {
+	if c.NArg() > 1 {
 		return cliutils.PrintHelpAndReturnError("Wrong number of arguments.", c)
 	}
-	return commands.Export(c.Args()[0])
+	// If no server Id was given, export the default server.
+	serverId := ""
+	if c.NArg() == 1 {
+		serverId = c.Args()[0]
+	}
+	return commands.Export(serverId)
 }
 
 func useCmd(c *cli.Context) error {

--- a/docs/config/exportcmd/help.go
+++ b/docs/config/exportcmd/help.go
@@ -6,4 +6,4 @@ var Usage = []string{"jfrog config export [server ID]"}
 
 const Arguments string = `	server ID
 		The configured server ID.
-		If not supplied, the active server will be exported.`
+		If not specified, the active server will be exported.`

--- a/docs/config/exportcmd/help.go
+++ b/docs/config/exportcmd/help.go
@@ -2,7 +2,8 @@ package exportcmd
 
 const Description string = `Creates a server configuration token. The generated token can be imported by the "jfrog config import <Server token>" command.`
 
-var Usage = []string{"jfrog config export <server token>"}
+var Usage = []string{"jfrog config export [server ID]"}
 
 const Arguments string = `	server ID
-		The configured server ID.`
+		The configured server ID.
+		If not supplied, the active server will be exported.`


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
