### PR TITLE
Add setup-cli script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,10 +102,14 @@ jobs:
         run: go test -v -timeout 0 --test.docker=true --jfrog.url=${{ secrets.PLATFORM_URL }} --jfrog.adminToken=${{ secrets.PLATFORM_ADMIN_TOKEN }} --rt.dockerRepoDomain=ecosysjfrog-docker-virtual.jfrog.io --rt.dockerVirtualRepo=docker-virtual --rt.DockerLocalRepo=docker-local --rt.dockerRemoteRepo=docker-remote
 
   Scripts-tests:
-    name: ${{ matrix.suite }} (${{ matrix.os }})
+    name: scripts (${{ matrix.os }})
+    defaults:
+      run:
+        shell: bash
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -113,10 +117,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Test install CLI - jf
-        run: ./build/installcli/jf.sh && jf --version
+        run: bash build/installcli/jf.sh && jf --version
       - name: Test install CLI - jfrog
-        run: ./build/installcli/jfrog.sh && jfrog --version
+        run: bash build/installcli/jfrog.sh && jfrog --version
       - name: Test get CLI - jf
-        run: ./build/getcli/jf.sh && ./jf --version
+        run: bash build/getcli/jf.sh && ./jf --version
       - name: Test get CLI - jfrog
-        run: ./build/getcli/jfrog.sh && ./jfrog --version
+        run: bash build/getcli/jfrog.sh && ./jfrog --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,3 +100,23 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Run Docker tests
         run: go test -v -timeout 0 --test.docker=true --jfrog.url=${{ secrets.PLATFORM_URL }} --jfrog.adminToken=${{ secrets.PLATFORM_ADMIN_TOKEN }} --rt.dockerRepoDomain=ecosysjfrog-docker-virtual.jfrog.io --rt.dockerVirtualRepo=docker-virtual --rt.DockerLocalRepo=docker-local --rt.dockerRemoteRepo=docker-remote
+
+  Scripts-tests:
+    name: ${{ matrix.suite }} (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Test install CLI - jf
+        run: ./build/installcli/jf.sh && jf --version
+      - name: Test install CLI - jfrog
+        run: ./build/installcli/jfrog.sh && jfrog --version
+      - name: Test get CLI - jf
+        run: ./build/getcli/jf.sh && ./jf --version
+      - name: Test get CLI - jfrog
+        run: ./build/getcli/jfrog.sh && ./jfrog --version

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,10 +112,15 @@ def runRelease(architectures) {
                 withCredentials([string(credentialsId: 'jfrog-cli-automation', variable: 'JFROG_CLI_AUTOMATION_ACCESS_TOKEN')]) {
                     options = "--url https://releases.jfrog.io/artifactory --access-token=$JFROG_CLI_AUTOMATION_ACCESS_TOKEN"
                     sh """#!/bin/bash
-                        $builderPath rt cp jfrog-cli/$identifier/$version/scripts/ jfrog-cli/$identifier/scripts/ --flat $options
+                        $builderPath rt cp jfrog-cli/$identifier/$version/scripts/getCli.sh jfrog-cli/$identifier/scripts/ --flat $options
+                        $builderPath rt cp jfrog-cli/$identifier/$version/scripts/installCli.sh jfrog-cli/$identifier/scripts/ --flat $options
+                    """
+                    if (identifier == "v2-jf") {
+                        sh """#!/bin/bash
+                            $builderPath rt cp jfrog-cli/$identifier/$version/scripts/setupCli.sh jfrog-cli/setup/scripts/getCli.sh --flat $options
                         """
+                    }
                 }
-
             }
         }
     } finally {
@@ -208,6 +213,9 @@ def uploadCli(architectures) {
     stage("Publish scripts") {
         uploadGetCliToJfrogRepo21()
         uploadInstallCliToJfrogRepo21()
+        if (cliExecutableName == 'jf') {
+            uploadSetupCliToJfrogRepo21()
+        }
     }
     for (int i = 0; i < architectures.size(); i++) {
         def currentBuild = architectures[i]
@@ -275,6 +283,12 @@ def uploadGetCliToJfrogRepo21() {
 def uploadInstallCliToJfrogRepo21() {
     sh """#!/bin/bash
         $builderPath rt u $jfrogCliRepoDir/build/installcli/${cliExecutableName}.sh ecosys-jfrog-cli/$identifier/$version/scripts/install-cli.sh --flat
+    """
+}
+
+def uploadSetupCliToJfrogRepo21() {
+    sh """#!/bin/bash
+        $builderPath rt u $jfrogCliRepoDir/build/setupcli/${cliExecutableName}.sh ecosys-jfrog-cli/$identifier/$version/scripts/setup-cli.sh --flat
     """
 }
 
@@ -373,6 +387,6 @@ def dockerLogin(){
         usernamePassword(credentialsId: 'repo21', usernameVariable: 'REPO21_USER', passwordVariable: 'REPO21_PASSWORD'),
         string(credentialsId: 'repo21-url', variable: 'REPO21_URL')
     ]) {
-            sh "docker login $REPO_NAME_21 -u=$REPO21_USER -p=$REPO21_PASSWORD"
+            sh "echo $REPO21_PASSWORD | docker login $REPO_NAME_21 -u=$REPO21_USER --password-stdin"
        }
 }

--- a/build/installcli/jf.sh
+++ b/build/installcli/jf.sh
@@ -19,7 +19,6 @@ if $(echo "${OSTYPE}" | grep -q msys); then
     CLI_OS="windows"
     URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-windows-amd64/jf.exe"
     FILE_NAME="jf.exe"
-    DESTINATION_PATHS=("C:\\Program Files" "C:\\Program Files (x86)")
 elif $(echo "${OSTYPE}" | grep -q darwin); then
     CLI_OS="mac"
     URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-mac-386/jf"
@@ -62,13 +61,13 @@ curl -XGET "$URL" -L -k -g > $FILE_NAME
 chmod u+x $FILE_NAME
 
 # Move executable to a destination in path.
-for dest in ${DESTINATION_PATHS[@]}
+for dest in "${DESTINATION_PATHS[@]}"
 do
     pathenv="${PATH}"
     # Check if destination is in path.
     if test "${pathenv#*$dest}" != "$pathenv"; then
         mv $FILE_NAME $dest
-        echo "jf executable was installed at $dest"
+        echo "$FILE_NAME executable was installed at $dest"
         exit 0
     fi
 done

--- a/build/installcli/jfrog.sh
+++ b/build/installcli/jfrog.sh
@@ -19,7 +19,6 @@ if $(echo "${OSTYPE}" | grep -q msys); then
     CLI_OS="windows"
     URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-windows-amd64/jfrog.exe"
     FILE_NAME="jfrog.exe"
-    DESTINATION_PATHS=("C:\\Program Files" "C:\\Program Files (x86)")
 elif $(echo "${OSTYPE}" | grep -q darwin); then
     CLI_OS="mac"
     URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-mac-386/jfrog"
@@ -62,13 +61,13 @@ curl -XGET "$URL" -L -k -g > $FILE_NAME
 chmod u+x $FILE_NAME
 
 # Move executable to a destination in path.
-for dest in ${DESTINATION_PATHS[@]}
+for dest in "${DESTINATION_PATHS[@]}"
 do
     pathenv="${PATH}"
     # Check if destination is in path.
     if test "${pathenv#*$dest}" != "$pathenv"; then
         mv $FILE_NAME $dest
-        echo "jfrog executable was installed at $dest"
+        echo "$FILE_NAME executable was installed at $dest"
         exit 0
     fi
 done

--- a/build/installcli/jfrog.sh
+++ b/build/installcli/jfrog.sh
@@ -64,15 +64,14 @@ chmod u+x $FILE_NAME
 # Move executable to a destination in path.
 for dest in ${DESTINATION_PATHS[@]}
 do
-  pathenv="${PATH}"
-  # Check if destination is in path.
-  if test "${pathenv#*$dest}" != "$pathenv"
-  then
-  echo "jfrog executable was installed at $dest"
-  exit 0
-fi
+    pathenv="${PATH}"
+    # Check if destination is in path.
+    if test "${pathenv#*$dest}" != "$pathenv"; then
+        mv $FILE_NAME $dest
+        echo "jfrog executable was installed at $dest"
+        exit 0
+    fi
 done
 
 echo "could not find supported destination path in \$PATH"
 exit 1
-

--- a/build/setupcli/jf.sh
+++ b/build/setupcli/jf.sh
@@ -69,6 +69,8 @@ do
     if test "${pathenv#*$dest}" != "$pathenv"; then
         mv $FILE_NAME $dest
         echo "jf executable was installed at $dest"
+        echo "Executing 'jf ci-setup'..."
+        jf ci-setup
         exit 0
     fi
 done

--- a/build/setupcli/jf.sh
+++ b/build/setupcli/jf.sh
@@ -19,7 +19,6 @@ if $(echo "${OSTYPE}" | grep -q msys); then
     CLI_OS="windows"
     URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-windows-amd64/jf.exe"
     FILE_NAME="jf.exe"
-    DESTINATION_PATHS=("C:\\Program Files" "C:\\Program Files (x86)")
 elif $(echo "${OSTYPE}" | grep -q darwin); then
     CLI_OS="mac"
     URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-mac-386/jf"
@@ -68,7 +67,7 @@ do
     # Check if destination is in path.
     if test "${pathenv#*$dest}" != "$pathenv"; then
         mv $FILE_NAME $dest
-        echo "jf executable was installed at $dest"
+        echo "$FILE_NAME executable was installed at $dest"
         echo "Executing 'jf ci-setup'..."
         jf ci-setup
         exit 0


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

* Add new `getCli.sh` script that install and run `jf ci-setup`. This script eventually will be uploaded to `/jfrog-cli/setup/scripts/getCli.sh`.
* Fix an issue in the install-cli whereby `jf` or `jfrog` wasn't moved to the system path.
* Add tests for the install-cli and getCli scripts in GitHub actions.