### PR TITLE
Fix jf setup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,12 +112,12 @@ def runRelease(architectures) {
                 withCredentials([string(credentialsId: 'jfrog-cli-automation', variable: 'JFROG_CLI_AUTOMATION_ACCESS_TOKEN')]) {
                     options = "--url https://releases.jfrog.io/artifactory --access-token=$JFROG_CLI_AUTOMATION_ACCESS_TOKEN"
                     sh """#!/bin/bash
-                        $builderPath rt cp jfrog-cli/$identifier/$version/scripts/getCli.sh jfrog-cli/$identifier/scripts/ --flat $options
-                        $builderPath rt cp jfrog-cli/$identifier/$version/scripts/install-cli.sh jfrog-cli/$identifier/scripts/ --flat $options
+                        $builderPath rt cp jfrog-cli/$identifier/$version/scripts/getCli.sh jfrog-cli/$identifier/scripts/ --flat $options --fail-no-op
+                        $builderPath rt cp jfrog-cli/$identifier/$version/scripts/install-cli.sh jfrog-cli/$identifier/scripts/ --flat $options --fail-no-op
                     """
                     if (identifier == "v2-jf") {
                         sh """#!/bin/bash
-                            $builderPath rt cp jfrog-cli/$identifier/$version/scripts/setupCli.sh jfrog-cli/setup/scripts/getCli.sh --flat $options
+                            $builderPath rt cp jfrog-cli/$identifier/$version/scripts/setup-cli.sh jfrog-cli/setup/scripts/getCli.sh --flat $options --fail-no-op
                         """
                     }
                 }

--- a/build/setupcli/jf.sh
+++ b/build/setupcli/jf.sh
@@ -67,8 +67,7 @@ while [ -n "$1" ]; do
     if echo $PATH|grep "$1" -> /dev/null ; then
         mv $FILE_NAME $1
         echo "$FILE_NAME executable was installed at $1"
-        echo "Executing 'jf ci-setup'..."
-        jf ci-setup
+        jf setup
         exit 0
     fi
     shift


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

* getCli.sh of the setup should run `jf setup` instead of `jf ci-setup`.
* Fix copy command.
* Add fail-no-op to the copy commands to avoid future mistakes.