### PR TITLE
Bugfix - Docker images' size increase

### DIFF
--- a/build/docker/full/Dockerfile
+++ b/build/docker/full/Dockerfile
@@ -1,12 +1,14 @@
-ARG cli_executable_name
 ARG repo_name_21
-ARG image_name=jfrog-cli-full
 # Remove ${repo_name_21} to pull from Docker Hub.
 FROM ${repo_name_21}/jfrog-docker/golang:1.17.2 as builder
+ARG image_name=jfrog-cli-full
+ARG cli_executable_name
 WORKDIR /${image_name}
 COPY . /${image_name}
 RUN sh build/build.sh ${cli_executable_name}
 FROM releases-docker.jfrog.io/jfrog-ecosystem-integration-env:latest
+ARG image_name=jfrog-cli-full
+ARG cli_executable_name
 ENV CI true
 COPY --from=builder /${image_name}/${cli_executable_name} /usr/local/bin/${cli_executable_name}
 RUN chmod +x /usr/local/bin/${cli_executable_name}

--- a/build/docker/slim/Dockerfile
+++ b/build/docker/slim/Dockerfile
@@ -1,13 +1,15 @@
-ARG cli_executable_name
 ARG repo_name_21
-ARG image_name=jfrog-cli
 # Remove ${repo_name_21} to pull from Docker Hub.
 FROM ${repo_name_21}/jfrog-docker/golang:1.17.2-alpine as builder
+ARG image_name=jfrog-cli
+ARG cli_executable_name
 WORKDIR /${image_name}
 COPY . /${image_name}
 RUN apk add --update git && sh build/build.sh ${cli_executable_name}
 # Remove ${repo_name_21} to pull from Docker Hub.
 FROM ${repo_name_21}/jfrog-docker/alpine:3.12.0
+ARG image_name=jfrog-cli
+ARG cli_executable_name
 ENV CI true
 RUN apk add --no-cache bash tzdata ca-certificates curl
 COPY --from=builder /${image_name}/${cli_executable_name} /usr/local/bin/${cli_executable_name}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
An ARG instruction in the docker file goes out of scope at the end of the build stage where it was defined. As a result, any arg defined before the FROM is ignored (not including the From itself). This behavior caused to copy of the entire builder to the next stage every time.