### PR TITLE
Add test for resolving project key from environment variables

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -3084,14 +3084,15 @@ func TestArtifactoryDownloadByBuildUsingSimpleDownloadWithProject(t *testing.T) 
 	initArtifactoryProjectTest(t)
 	accessManager, err := utils.CreateAccessServiceManager(serverDetails, false)
 	assert.NoError(t, err)
-	projectKey := "tstprj"
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)[:3]
+	projectKey := "prj" + timestamp[len(timestamp)-3:]
 	// Delete the project if already exists
 	accessManager.DeleteProject(projectKey)
 
 	// Create new project
 	projectParams := accessServices.ProjectParams{
 		ProjectDetails: accessServices.Project{
-			DisplayName: "testProject",
+			DisplayName: "testProject " + projectKey,
 			ProjectKey:  projectKey,
 		},
 	}
@@ -3137,14 +3138,15 @@ func TestArtifactoryDownloadWithEnvProject(t *testing.T) {
 	initArtifactoryProjectTest(t)
 	accessManager, err := utils.CreateAccessServiceManager(serverDetails, false)
 	assert.NoError(t, err)
-	projectKey := "tstprj"
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)[:3]
+	projectKey := "prj" + timestamp[len(timestamp)-3:]
 	// Delete the project if already exists
 	accessManager.DeleteProject(projectKey)
 
 	// Create new project
 	projectParams := accessServices.ProjectParams{
 		ProjectDetails: accessServices.Project{
-			DisplayName: "testProject",
+			DisplayName: "testProject " + projectKey,
 			ProjectKey:  projectKey,
 		},
 	}

--- a/docker_test.go
+++ b/docker_test.go
@@ -142,11 +142,12 @@ func TestContainerPushBuildNameNumberFromEnv(t *testing.T) {
 	for _, containerManager := range containerManagers {
 		imageTag := inttestutils.BuildTestContainerImage(t, tests.DockerImageName, containerManager)
 		buildNumber := "1"
-		os.Setenv(coreutils.BuildName, tests.DockerBuildName)
-		os.Setenv(coreutils.BuildNumber, buildNumber)
-		defer os.Unsetenv(coreutils.BuildName)
-		defer os.Unsetenv(coreutils.BuildNumber)
-
+		assert.NoError(t, os.Setenv(coreutils.BuildName, tests.DockerBuildName))
+		assert.NoError(t, os.Setenv(coreutils.BuildNumber, buildNumber))
+		defer func() {
+			assert.NoError(t, os.Unsetenv(coreutils.BuildName))
+			assert.NoError(t, os.Unsetenv(coreutils.BuildNumber))
+		}()
 		// Push container image
 		assert.NoError(t, artifactoryCli.Exec(containerManager.String()+"-push", imageTag, *tests.DockerLocalRepo))
 		assert.NoError(t, artifactoryCli.Exec("build-publish"))
@@ -156,6 +157,7 @@ func TestContainerPushBuildNameNumberFromEnv(t *testing.T) {
 
 		inttestutils.ContainerTestCleanup(t, serverDetails, artHttpDetails, tests.DockerImageName, tests.DockerBuildName, *tests.DockerLocalRepo)
 	}
+
 }
 
 func TestContainerPull(t *testing.T) {

--- a/gradle_test.go
+++ b/gradle_test.go
@@ -25,8 +25,8 @@ const (
 	gradleModuleId = ":minimal-example:1.0"
 )
 
-func cleanGradleTest() {
-	os.Unsetenv(coreutils.HomeDir)
+func cleanGradleTest(t *testing.T) {
+	assert.NoError(t, os.Unsetenv(coreutils.HomeDir))
 	deleteSpec := spec.NewBuilder().Pattern(tests.GradleRepo).BuildSpec()
 	tests.DeleteFiles(deleteSpec, serverDetails)
 	tests.CleanFileSystem()
@@ -47,7 +47,7 @@ func TestGradleBuildConditionalUpload(t *testing.T) {
 	searchSpec, err := tests.CreateSpec(tests.SearchAllGradle)
 	assert.NoError(t, err)
 	verifyExistInArtifactory(tests.GetGradleDeployedArtifacts(), searchSpec, t)
-	cleanGradleTest()
+	cleanGradleTest(t)
 }
 
 func TestGradleBuildWithServerID(t *testing.T) {
@@ -80,7 +80,7 @@ func TestGradleBuildWithServerID(t *testing.T) {
 	}
 	buildInfo := publishedBuildInfo.BuildInfo
 	validateBuildInfo(buildInfo, t, 0, 1, gradleModuleId, buildinfo.Gradle)
-	cleanGradleTest()
+	cleanGradleTest(t)
 }
 
 func TestGradleBuildWithServerIDAndDetailedSummary(t *testing.T) {
@@ -129,7 +129,7 @@ func TestGradleBuildWithServerIDAndDetailedSummary(t *testing.T) {
 	}
 	buildInfo := publishedBuildInfo.BuildInfo
 	validateBuildInfo(buildInfo, t, 0, 1, gradleModuleId, buildinfo.Gradle)
-	cleanGradleTest()
+	cleanGradleTest(t)
 }
 
 func TestGradleBuildWithServerIDWithUsesPlugin(t *testing.T) {
@@ -165,7 +165,7 @@ func TestGradleBuildWithServerIDWithUsesPlugin(t *testing.T) {
 	}
 	buildInfo := publishedBuildInfo.BuildInfo
 	validateBuildInfo(buildInfo, t, 0, 1, gradleModuleId, buildinfo.Gradle)
-	cleanGradleTest()
+	cleanGradleTest(t)
 }
 
 func createGradleProject(t *testing.T, projectName string) string {

--- a/npm_test.go
+++ b/npm_test.go
@@ -42,8 +42,8 @@ type npmTestParams struct {
 	validationFunc func(*testing.T, npmTestParams, bool)
 }
 
-func cleanNpmTest() {
-	os.Unsetenv(coreutils.HomeDir)
+func cleanNpmTest(t *testing.T) {
+	assert.NoError(t, os.Unsetenv(coreutils.HomeDir))
 	deleteSpec := spec.NewBuilder().Pattern(tests.NpmRepo).BuildSpec()
 	tests.DeleteFiles(deleteSpec, serverDetails)
 	tests.CleanFileSystem()
@@ -60,7 +60,7 @@ func TestNpmLegacy(t *testing.T) {
 
 func testNpm(t *testing.T, isLegacy bool) {
 	initNpmTest(t)
-	defer cleanNpmTest()
+	defer cleanNpmTest(t)
 	wd, err := os.Getwd()
 	assert.NoError(t, err)
 	defer os.Chdir(wd)
@@ -140,7 +140,7 @@ func readModuleId(t *testing.T, wd string, npmVersion *version.Version) string {
 
 func TestNpmWithGlobalConfig(t *testing.T) {
 	initNpmTest(t)
-	defer cleanNpmTest()
+	defer cleanNpmTest(t)
 	wd, err := os.Getwd()
 	assert.NoError(t, err)
 	defer os.Chdir(wd)
@@ -354,7 +354,7 @@ func runNpm(t *testing.T, args ...string) {
 
 func TestNpmPublishDetailedSummary(t *testing.T) {
 	initNpmTest(t)
-	defer cleanNpmTest()
+	defer cleanNpmTest(t)
 	wd, err := os.Getwd()
 	assert.NoError(t, err)
 	defer os.Chdir(wd)
@@ -412,7 +412,7 @@ func TestYarn(t *testing.T) {
 	testDataTarget := filepath.Join(tests.Out, "yarn")
 	err := fileutils.CopyDir(testDataSource, testDataTarget, true, nil)
 	assert.NoError(t, err)
-	defer cleanNpmTest()
+	defer cleanNpmTest(t)
 
 	yarnProjectPath := filepath.Join(testDataTarget, "yarnproject")
 	err = createConfigFileForTest([]string{yarnProjectPath}, tests.NpmRemoteRepo, "", t, utils.Yarn, false)

--- a/pip_test.go
+++ b/pip_test.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
-	buildinfo "github.com/jfrog/build-info-go/entities"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"testing"
+
+	buildinfo "github.com/jfrog/build-info-go/entities"
 
 	gofrogcmd "github.com/jfrog/gofrog/io"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
@@ -42,15 +43,17 @@ func testPipInstall(t *testing.T, isLegacy bool) {
 	if t.Failed() {
 		t.FailNow()
 	}
-	defer os.Setenv("PATH", pathValue)
+	defer func() { assert.NoError(t, os.Setenv("PATH", pathValue)) }()
 
 	// Check pip env is clean.
 	validateEmptyPipEnv(t)
 
 	// Populate cli config with 'default' server.
 	oldHomeDir, newHomeDir := prepareHomeDir(t)
-	defer os.Setenv(coreutils.HomeDir, oldHomeDir)
-	defer os.RemoveAll(newHomeDir)
+	defer func() {
+		assert.NoError(t, os.Setenv(coreutils.HomeDir, oldHomeDir))
+		assert.NoError(t, os.RemoveAll(newHomeDir))
+	}()
 
 	// Create test cases.
 	allTests := []struct {

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -33,12 +33,15 @@ func TestPluginInstallUninstallOfficialRegistry(t *testing.T) {
 
 	// Set empty plugins server to run against official registry.
 	oldServer := os.Getenv(utils.PluginsServerEnv)
-	defer os.Setenv(utils.PluginsServerEnv, oldServer)
+	defer func() {
+		assert.NoError(t, os.Setenv(utils.PluginsServerEnv, oldServer))
+	}()
 	assert.NoError(t, os.Setenv(utils.PluginsServerEnv, ""))
 	oldRepo := os.Getenv(utils.PluginsRepoEnv)
-	defer os.Setenv(utils.PluginsRepoEnv, oldRepo)
+	defer func() {
+		assert.NoError(t, os.Setenv(utils.PluginsRepoEnv, oldRepo))
+	}()
 	assert.NoError(t, os.Setenv(utils.PluginsRepoEnv, ""))
-
 	jfrogCli := tests.NewJfrogCli(execMain, "jfrog", "")
 
 	// Try installing a plugin with specific version.
@@ -203,10 +206,14 @@ func TestPublishInstallCustomServer(t *testing.T) {
 
 	// Set plugins server to run against the configured server.
 	oldServer := os.Getenv(utils.PluginsServerEnv)
-	defer os.Setenv(utils.PluginsServerEnv, oldServer)
+	defer func() {
+		assert.NoError(t, os.Setenv(utils.PluginsServerEnv, oldServer))
+	}()
 	assert.NoError(t, os.Setenv(utils.PluginsServerEnv, tests.ServerId))
 	oldRepo := os.Getenv(utils.PluginsRepoEnv)
-	defer os.Setenv(utils.PluginsRepoEnv, oldRepo)
+	defer func() {
+		assert.NoError(t, os.Setenv(utils.PluginsRepoEnv, oldRepo))
+	}()
 	assert.NoError(t, os.Setenv(utils.PluginsRepoEnv, tests.RtRepo1))
 
 	err = setOnlyLocalArc(t)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Test that JFrog CLI resolves project key from environment variables.