### PR TITLE
Bugfix - plugin install command with progress bar

### DIFF
--- a/plugins/commands/install.go
+++ b/plugins/commands/install.go
@@ -1,13 +1,14 @@
 package commands
 
 import (
-	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
-	commandsUtils "github.com/jfrog/jfrog-cli/plugins/commands/utils"
-	clientUtils "github.com/jfrog/jfrog-client-go/utils"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	commandsUtils "github.com/jfrog/jfrog-cli/plugins/commands/utils"
+	clientUtils "github.com/jfrog/jfrog-client-go/utils"
 
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli/utils/cliutils"
@@ -174,6 +175,7 @@ func downloadPlugin(pluginsDir, pluginName, downloadUrl string, httpDetails http
 		return err
 	}
 	if progressMgr != nil {
+		progressMgr.InitProgressReaders()
 		progressMgr.IncGeneralProgressTotalBy(1)
 		defer logUtils.CloseLogFile(logFile)
 		defer progressMgr.Quit()


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Our recent changes to the progress bar manager damaged the plugin install command.
This PR adds the missing (new) initialization.