### PR TITLE
Undo Chocolatey release skip for jf

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,11 +42,11 @@ node("docker") {
             }
         }
 
-        stage('Release jf executables') {
+        stage('jf release phase') {
             runRelease(architectures)
         }
 
-        stage('Release jfrog executables') {
+        stage('jfrog release phase') {
             cliExecutableName = 'jfrog'
             identifier = 'v2'
             runRelease(architectures)
@@ -85,21 +85,18 @@ def runRelease(architectures) {
                 buildRpmAndDeb(version, architectures)
             }
 
-            // Skipping publishing jf choco package till it will be verified.
-            if (cliExecutableName == 'jfrog') {
-                // Download cert files, to be used for signing the Windows executable, packaged by Chocolatey.
-                downloadToolsCert()
-                stage('Build and publish Chocolatey') {
-                    publishChocoPackage(version, jfrogCliRepoDir, architectures)
-                }
-            }
-
             stage('Npm publish') {
                 publishNpmPackage(jfrogCliRepoDir)
             }
 
             stage('Build and publish docker images') {
                 buildPublishDockerImages(version, jfrogCliRepoDir)
+            }
+
+            // Download cert files, to be used for signing the Windows executable, packaged by Chocolatey.
+            downloadToolsCert()
+            stage('Build and publish Chocolatey') {
+                publishChocoPackage(version, jfrogCliRepoDir, architectures)
             }
         } else if ("$EXECUTION_MODE".toString().equals("Build CLI")) {
             downloadToolsCert()

--- a/build/chocolatey/v2-jf/jfrog-cli-v2-jf.nuspec
+++ b/build/chocolatey/v2-jf/jfrog-cli-v2-jf.nuspec
@@ -22,7 +22,7 @@ JFrog CLI is a compact and smart client that provides a simple interface that au
 * Wildcards and regular expressions give you an easy way to collect all the artifacts you wish to upload or download.
 * "Dry run" gives you a preview of file transfer operations before you actually run them
 ]]></description>
-    <releaseNotes>https://github.com/jfrog/jfrog-cli/commits/v2</releaseNotes>
+    <releaseNotes>https://github.com/jfrog/jfrog-cli/blob/v2/RELEASE.md</releaseNotes>
     <copyright> Copyright 2021 JFrog Ltd.</copyright>
   </metadata>
   <files>

--- a/build/chocolatey/v2/jfrog-cli.nuspec
+++ b/build/chocolatey/v2/jfrog-cli.nuspec
@@ -22,7 +22,7 @@ JFrog CLI is a compact and smart client that provides a simple interface that au
 * Wildcards and regular expressions give you an easy way to collect all the artifacts you wish to upload or download.
 * "Dry run" gives you a preview of file transfer operations before you actually run them
 ]]></description>
-    <releaseNotes>https://github.com/jfrog/jfrog-cli/commits/v2</releaseNotes>
+    <releaseNotes>https://github.com/jfrog/jfrog-cli/blob/v2/RELEASE.md</releaseNotes>
     <copyright> Copyright 2021 JFrog Ltd.</copyright>
   </metadata>
   <files>


### PR DESCRIPTION
Moved Chocolatey to release to be last to allow easier continuation in case of errors.
Fixed Chocolatey links to the CLI's release notes.