### PR TITLE
Add log timestamp prefix

### DIFF
--- a/docs/common/help.go
+++ b/docs/common/help.go
@@ -11,9 +11,9 @@ func GetGlobalEnvVars() string {
 		If set to ERROR, JFrog CLI logs error messages only.
 		It is useful when you wish to read or parse the JFrog CLI output and do not want any other information logged.
 
-	JFROG_CLI_TIMESTAMP
+	JFROG_CLI_LOG_TIMESTAMP
 		[Default: TIME]
-		This variable determines the timestamp prefix appearance of JFrog CLI's logs.
+		Controls the log messages timestamp format.
 		Possible values are: TIME, DATE_AND_TIME, and OFF.
 
 	JFROG_CLI_OFFER_CONFIG

--- a/docs/common/help.go
+++ b/docs/common/help.go
@@ -11,6 +11,11 @@ func GetGlobalEnvVars() string {
 		If set to ERROR, JFrog CLI logs error messages only.
 		It is useful when you wish to read or parse the JFrog CLI output and do not want any other information logged.
 
+	JFROG_CLI_TIMESTAMP
+		[Default: TIME]
+		This variable determines the timestamp prefix appearance of JFrog CLI's logs.
+		Possible values are: TIME, DATE_AND_TIME, and OFF.
+
 	JFROG_CLI_OFFER_CONFIG
 		[Default: true]
 		If true, JFrog CLI prompts for product server details and saves them in its config file.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gookit/color v1.4.2
 	github.com/jfrog/build-info-go v1.0.0
 	github.com/jfrog/gofrog v1.1.1
-	github.com/jfrog/jfrog-cli-core/v2 v2.8.2
+	github.com/jfrog/jfrog-cli-core/v2 v2.8.3
 	github.com/jfrog/jfrog-client-go v1.7.0
 	github.com/jszwec/csvutil v1.4.0
 	github.com/mholt/archiver v2.1.0+incompatible
@@ -23,10 +23,10 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/RobiNino/jfrog-client-go v0.0.0-20220113162342-2b4ef023cdaa
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.7.2-0.20220126084028-970e7f26e2c2
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220113163852-22a484978059
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.8.4-0.20220126084408-2b20691a10da
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.0.7-0.20211128152632-e218c460d703
 
-replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.0.1-0.20220112152743-8c04d862d822
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.0.1-0.20220118114459-b944fdc6a593

--- a/go.mod
+++ b/go.mod
@@ -23,9 +23,9 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.7.2-0.20220113071425-92104764c0e1
+replace github.com/jfrog/jfrog-client-go => github.com/RobiNino/jfrog-client-go v0.0.0-20220113162342-2b4ef023cdaa
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.8.2-0.20220113114723-425dd3ac0576
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220113163852-22a484978059
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.0.7-0.20211128152632-e218c460d703
 

--- a/go.sum
+++ b/go.sum
@@ -46,10 +46,6 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220113163852-22a484978059 h1:NXUcWX5SUDsDHHbaOJfKXx9Xuaj+8YL9vpTasRq57UE=
-github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220113163852-22a484978059/go.mod h1:DGbHP21AJFCouWD9d1wwfJZxAWRSz9YZSz4rf1zh65A=
-github.com/RobiNino/jfrog-client-go v0.0.0-20220113162342-2b4ef023cdaa h1:OQfRI0nAWVwjk6ToB4gD0kxF8oJkaXVX1fmT/C2FX+o=
-github.com/RobiNino/jfrog-client-go v0.0.0-20220113162342-2b4ef023cdaa/go.mod h1:LjMyvNTaSn8aMqgqCga1Ii5stlX+TBZyt/RD+K+hC7w=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
@@ -234,10 +230,14 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jedib0t/go-pretty/v6 v6.2.2 h1:o3McN0rQ4X+IU+HduppSp9TwRdGLRW2rhJXy9CJaCRw=
 github.com/jedib0t/go-pretty/v6 v6.2.2/go.mod h1:+nE9fyyHGil+PuISTCrp7avEdo6bqoMwqZnuiK2r2a0=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/build-info-go v1.0.1-0.20220112152743-8c04d862d822 h1:fmqLUs99Vbu/nUk2H17wNP1zNZXxgE3S85KZ2ob9+tI=
-github.com/jfrog/build-info-go v1.0.1-0.20220112152743-8c04d862d822/go.mod h1:QyeMfNGt4W0eWazrd7j6uZVN5KTpB05nxF/MwvGnTqs=
+github.com/jfrog/build-info-go v1.0.1-0.20220118114459-b944fdc6a593 h1:QF8ZHXbXXV7CoidKpZuc7gqp6AjxUbVVMSTO9vf3X1I=
+github.com/jfrog/build-info-go v1.0.1-0.20220118114459-b944fdc6a593/go.mod h1:QyeMfNGt4W0eWazrd7j6uZVN5KTpB05nxF/MwvGnTqs=
 github.com/jfrog/gofrog v1.1.1 h1:uRjeZWidQl4FmKP4Zpj5hSKJp3gSIWW9VUwbQdVEVRU=
 github.com/jfrog/gofrog v1.1.1/go.mod h1:9YN5v4LlsCfLIXpwQnzSf1wVtgjdHM20FzuIu58RMI4=
+github.com/jfrog/jfrog-cli-core/v2 v2.8.4-0.20220126084408-2b20691a10da h1:MVq9Dxgg42Km/U2BPunS5vIS/eitQiizMeZxVKHG1sc=
+github.com/jfrog/jfrog-cli-core/v2 v2.8.4-0.20220126084408-2b20691a10da/go.mod h1:kkDrPqjXeQcg4HyDNJn9z7CuhqvtdcNI044LXrZZaoc=
+github.com/jfrog/jfrog-client-go v1.7.2-0.20220126084028-970e7f26e2c2 h1:ZWWeYdeEaWhnQ4qFUY04oNt37PF/wQJYhDmWXquqdSc=
+github.com/jfrog/jfrog-client-go v1.7.2-0.20220126084028-970e7f26e2c2/go.mod h1:LjMyvNTaSn8aMqgqCga1Ii5stlX+TBZyt/RD+K+hC7w=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,10 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
+github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220113163852-22a484978059 h1:NXUcWX5SUDsDHHbaOJfKXx9Xuaj+8YL9vpTasRq57UE=
+github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220113163852-22a484978059/go.mod h1:DGbHP21AJFCouWD9d1wwfJZxAWRSz9YZSz4rf1zh65A=
+github.com/RobiNino/jfrog-client-go v0.0.0-20220113162342-2b4ef023cdaa h1:OQfRI0nAWVwjk6ToB4gD0kxF8oJkaXVX1fmT/C2FX+o=
+github.com/RobiNino/jfrog-client-go v0.0.0-20220113162342-2b4ef023cdaa/go.mod h1:LjMyvNTaSn8aMqgqCga1Ii5stlX+TBZyt/RD+K+hC7w=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
@@ -234,10 +238,6 @@ github.com/jfrog/build-info-go v1.0.1-0.20220112152743-8c04d862d822 h1:fmqLUs99V
 github.com/jfrog/build-info-go v1.0.1-0.20220112152743-8c04d862d822/go.mod h1:QyeMfNGt4W0eWazrd7j6uZVN5KTpB05nxF/MwvGnTqs=
 github.com/jfrog/gofrog v1.1.1 h1:uRjeZWidQl4FmKP4Zpj5hSKJp3gSIWW9VUwbQdVEVRU=
 github.com/jfrog/gofrog v1.1.1/go.mod h1:9YN5v4LlsCfLIXpwQnzSf1wVtgjdHM20FzuIu58RMI4=
-github.com/jfrog/jfrog-cli-core/v2 v2.8.2-0.20220113114723-425dd3ac0576 h1:TvtzgVkAz3jPs6/MJeAJ8fNszbnw8sDy0wBSMhPnvEo=
-github.com/jfrog/jfrog-cli-core/v2 v2.8.2-0.20220113114723-425dd3ac0576/go.mod h1:F06gn+R0DL5QyxeCEI+XSEDVD9yljWEKGNDIc5Lyh/c=
-github.com/jfrog/jfrog-client-go v1.7.2-0.20220113071425-92104764c0e1 h1:oMp2cQsJPeZQdyNwe2pza89hrhmbGTNnQDBte8PmWzo=
-github.com/jfrog/jfrog-client-go v1.7.2-0.20220113071425-92104764c0e1/go.mod h1:LjMyvNTaSn8aMqgqCga1Ii5stlX+TBZyt/RD+K+hC7w=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -695,7 +695,7 @@ func RedirectLogOutputToNil() (previousLog log.Log) {
 	previousLog = log.Logger
 	newLog := log.NewLogger(corelog.GetCliLogLevel(), nil)
 	newLog.SetOutputWriter(ioutil.Discard)
-	newLog.SetLogsWriter(ioutil.Discard)
+	newLog.SetLogsWriter(ioutil.Discard, 0)
 	log.SetLogger(newLog)
 	return previousLog
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Following #698 
Depends on [jfrog/jfrog-cli-core#309](https://github.com/jfrog/jfrog-cli-core/pull/309)

Preview:
```
$ JFROG_CLI_TIMESTAMP=TIME jf rt ping
18:50:36 [Debug] Sending HTTP GET request to...

$ JFROG_CLI_TIMESTAMP=DATE_AND_TIME jf rt ping
2022/01/13 18:51:04 [Debug] Sending HTTP GET request to...

$ JFROG_CLI_TIMESTAMP=OFF jf rt ping
[Debug] Sending HTTP GET request to...