### PR TITLE
Fix npm tests on CI

### DIFF
--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -74,7 +74,7 @@ var (
 )
 
 func init() {
-	JfrogUrl = flag.String("jfrog.url", "http://127.0.0.1:8081/", "JFrog platform url")
+	JfrogUrl = flag.String("jfrog.url", "http://localhost:8081/", "JFrog platform url")
 	JfrogUser = flag.String("jfrog.user", "admin", "JFrog platform  username")
 	JfrogPassword = flag.String("jfrog.password", "password", "JFrog platform password")
 	JfrogSshKeyPath = flag.String("jfrog.sshKeyPath", "", "Ssh key file path")


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Apparently, npm does not support authenticating with registries started with 127.0.0.1.

The change from `localhost` to `127.0.0.1` happened at https://github.com/jfrog/jfrog-cli/commit./cd16db7dae5cfa71088bd0ba55b3c3808018adb2. This commit introduced 2 new tests: TestArtifactoryProxy and TestArtifactorySelfSignedCert. These tests passed for me with localhost.