### PR TITLE
Reduce output in Maven tests

### DIFF
--- a/maven_test.go
+++ b/maven_test.go
@@ -71,7 +71,7 @@ func TestMavenBuildWithServerIDAndDetailedSummary(t *testing.T) {
 	oldHomeDir := changeWD(t, pomDir)
 	defer clientTestUtils.ChangeDirAndAssert(t, oldHomeDir)
 	repoLocalSystemProp := localRepoSystemProperty + localRepoDir
-	filteredMavenArgs := []string{"clean", "install", repoLocalSystemProp}
+	filteredMavenArgs := []string{"clean", "install", "-B", repoLocalSystemProp}
 	mvnCmd := mvn.NewMvnCommand().SetConfiguration(new(utils.BuildConfiguration)).SetConfigPath(filepath.Join(destPath, tests.MavenConfig)).SetGoals(filteredMavenArgs).SetDetailedSummary(true)
 	assert.NoError(t, commands.Exec(mvnCmd))
 	// Validate
@@ -119,10 +119,10 @@ func TestInsecureTlsMavenBuild(t *testing.T) {
 	jfrogCli := tests.NewJfrogCli(execMain, "jfrog", "")
 
 	// First, try to run without the insecure-tls flag, failure is expected.
-	err = jfrogCli.Exec("mvn", "clean", "install", repoLocalSystemProp)
+	err = jfrogCli.Exec("mvn", "clean", "install", "-B", repoLocalSystemProp)
 	assert.Error(t, err)
 	// Run with the insecure-tls flag
-	err = jfrogCli.Exec("mvn", "clean", "install", repoLocalSystemProp, "--insecure-tls")
+	err = jfrogCli.Exec("mvn", "clean", "install", "-B", repoLocalSystemProp, "--insecure-tls")
 	assert.NoError(t, err)
 
 	// Validate Successful deployment
@@ -213,7 +213,7 @@ func runMavenCleanInstall(t *testing.T, createProjectFunction func(*testing.T) s
 	defer clientTestUtils.ChangeDirAndAssert(t, oldHomeDir)
 	repoLocalSystemProp := localRepoSystemProperty + localRepoDir
 
-	args := []string{"mvn", "clean", "install", repoLocalSystemProp}
+	args := []string{"mvn", "clean", "install", "-B", repoLocalSystemProp}
 	args = append(args, additionalArgs...)
 	runJfrogCli(t, args...)
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Add `-B` flag to Maven tests to remove thousands of progress reports:
![image](https://user-images.githubusercontent.com/11367982/150317042-5f436edf-39c6-4753-a9a7-e84e2a6c946a.png)

The number of lines of the tests reduced from ~24500 to ~9650