### PR TITLE
Bug fix - Remove JFROG_CLI_OFFER_CONFIG from 'jf options'

### DIFF
--- a/docs/common/help.go
+++ b/docs/common/help.go
@@ -16,12 +16,6 @@ func GetGlobalEnvVars() string {
 		Controls the log messages timestamp format.
 		Possible values are: TIME, DATE_AND_TIME, and OFF.
 
-	JFROG_CLI_OFFER_CONFIG
-		[Default: true]
-		If true, JFrog CLI prompts for product server details and saves them in its config file.
-		To avoid having automation scripts interrupted, set this value to false, and instead,
-		provide product server details using the config command.
-
 	JFROG_CLI_HOME_DIR
 		[Default: ~/.jfrog]
 		Defines the JFrog CLI home directory path.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
The JFROG_CLI_OFFER_CONFIG environment variable was removed as part fo the changes in JFrog CLI V2. It shouldn't therefore be included in the output of the ```jf options``` command. This PR removes it.