### PR TITLE
Fix npm help

### DIFF
--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -348,8 +348,9 @@ func GetCommands() []cli.Command {
 func GetNpmSubcommands() []cli.Command {
 	return cliutils.GetSortedCommands(cli.CommandsByName{
 		{
-			Name:            "install",
-			Flags:           cliutils.GetCommandFlags(cliutils.NpmInstallCi),
+			Name:  "install",
+			Flags: cliutils.GetCommandFlags(cliutils.NpmInstallCi),
+			// Aliases accepted by npm.
 			Aliases:         []string{"i", "isntall", "add"},
 			Description:     npminstall.GetDescription(),
 			HelpName:        corecommon.CreateUsage("npm install", npminstall.GetDescription(), npminstall.Usage),

--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -795,7 +795,7 @@ func GetNpmConfigAndArgs(c *cli.Context) (configFilePath string, args []string, 
 	}
 
 	if !exists {
-		return "", nil, errors.New("no config file was found! Before running the npm command on a project for the first time, the project should be configured using the npm-config command")
+		return "", nil, errorutils.CheckError(errors.New("no config file was found! Before running the npm command on a project for the first time, the project should be configured using the npm-config command"))
 	}
 	args = cliutils.ExtractCommand(c)
 	return

--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -6,6 +6,9 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/terraform"
 	terraformdocs "github.com/jfrog/jfrog-cli/docs/artifactory/terraform"
 	"github.com/jfrog/jfrog-cli/docs/artifactory/terraformconfig"
+	"github.com/jfrog/jfrog-cli/docs/buildtools/npmci"
+	"github.com/jfrog/jfrog-cli/docs/buildtools/npminstall"
+	"github.com/jfrog/jfrog-cli/docs/buildtools/npmpublish"
 	"os"
 	"strconv"
 	"strings"
@@ -298,7 +301,6 @@ func GetCommands() []cli.Command {
 		},
 		{
 			Name:            "npm",
-			Flags:           cliutils.GetCommandFlags(cliutils.Npm),
 			Description:     npmcommand.GetDescription(),
 			HelpName:        corecommon.CreateUsage("npm", npmcommand.GetDescription(), npmcommand.Usage),
 			UsageText:       npmcommand.GetArguments(),
@@ -306,8 +308,9 @@ func GetCommands() []cli.Command {
 			SkipFlagParsing: true,
 			BashComplete:    corecommon.CreateBashCompletionFunc(),
 			Category:        buildToolsCategory,
+			Subcommands:     GetNpmSubcommands(),
 			Action: func(c *cli.Context) error {
-				return npmCmd(c)
+				return npmGenericCmd(c)
 			},
 		},
 		{
@@ -337,6 +340,51 @@ func GetCommands() []cli.Command {
 			Hidden:       true,
 			Action: func(c *cli.Context) error {
 				return terraformCmd(c)
+			},
+		},
+	})
+}
+
+func GetNpmSubcommands() []cli.Command {
+	return cliutils.GetSortedCommands(cli.CommandsByName{
+		{
+			Name:            "install",
+			Flags:           cliutils.GetCommandFlags(cliutils.NpmInstallCi),
+			Aliases:         []string{"i", "isntall", "add"},
+			Description:     npminstall.GetDescription(),
+			HelpName:        corecommon.CreateUsage("npm install", npminstall.GetDescription(), npminstall.Usage),
+			UsageText:       npminstall.GetArguments(),
+			ArgsUsage:       common.CreateEnvVars(),
+			SkipFlagParsing: true,
+			BashComplete:    corecommon.CreateBashCompletionFunc(),
+			Action: func(c *cli.Context) error {
+				return NpmInstallCmd(c)
+			},
+		},
+		{
+			Name:            "ci",
+			Flags:           cliutils.GetCommandFlags(cliutils.NpmInstallCi),
+			Description:     npmci.GetDescription(),
+			HelpName:        corecommon.CreateUsage("npm ci", npmci.GetDescription(), npmci.Usage),
+			UsageText:       npmci.GetArguments(),
+			ArgsUsage:       common.CreateEnvVars(),
+			SkipFlagParsing: true,
+			BashComplete:    corecommon.CreateBashCompletionFunc(),
+			Action: func(c *cli.Context) error {
+				return NpmCiCmd(c)
+			},
+		},
+		{
+			Name:            "publish",
+			Flags:           cliutils.GetCommandFlags(cliutils.NpmPublish),
+			Aliases:         []string{"p"},
+			Description:     npmpublish.GetDescription(),
+			HelpName:        corecommon.CreateUsage("npm publish", npmpublish.GetDescription(), npmpublish.Usage),
+			ArgsUsage:       common.CreateEnvVars(),
+			SkipFlagParsing: true,
+			BashComplete:    corecommon.CreateBashCompletionFunc(),
+			Action: func(c *cli.Context) error {
+				return NpmPublishCmd(c)
 			},
 		},
 	})
@@ -654,23 +702,23 @@ func CreateBuildConfigurationWithModule(c *cli.Context) (buildConfigConfiguratio
 	return
 }
 
-func npmCmd(c *cli.Context) error {
+func npmGenericCmd(c *cli.Context) error {
+	if show, err := cliutils.ShowCmdHelpIfNeeded(c, c.Args()); show || err != nil {
+		return err
+	}
+
 	configFilePath, orgArgs, err := GetNpmConfigAndArgs(c)
 	if err != nil {
 		return err
 	}
-	cmdName, filteredArgs := getCommandName(orgArgs)
-	switch cmdName {
-	// Aliases accepted by npm.
-	case "install", "i", "isntall", "add":
-		return npmInstallCmd(configFilePath, filteredArgs)
-	case "ci":
-		return npmCiCmd(configFilePath, filteredArgs)
-	case "publish", "p":
-		return npmPublishCmd(configFilePath, filteredArgs)
-	default:
-		return npmNativeCmd(cmdName, configFilePath, orgArgs)
+	cmdName, _ := getCommandName(orgArgs)
+	npmCmd := npm.NewNpmNativeCommand(cmdName)
+	npmCmd.SetConfigFilePath(configFilePath).SetNpmArgs(orgArgs)
+	err = npmCmd.Init()
+	if err != nil {
+		return err
 	}
+	return commands.Exec(npmCmd)
 }
 
 // Assuming command name is the first argument that isn't a flag.
@@ -686,58 +734,67 @@ func getCommandName(orgArgs []string) (string, []string) {
 	return "", cmdArgs
 }
 
-func npmInstallCmd(configFilePath string, args []string) error {
-	npmCmd := npm.NewNpmInstallCommand()
+func NpmInstallCmd(c *cli.Context) error {
+	return npmInstallCiCmd(c, npm.NewNpmInstallCommand())
+}
+
+func NpmCiCmd(c *cli.Context) error {
+	return npmInstallCiCmd(c, npm.NewNpmCiCommand())
+}
+
+func npmInstallCiCmd(c *cli.Context, npmCmd *npm.NpmInstallOrCiCommand) error {
+	if show, err := cliutils.ShowCmdHelpIfNeeded(c, c.Args()); show || err != nil {
+		return err
+	}
+
+	configFilePath, args, err := GetNpmConfigAndArgs(c)
+	if err != nil {
+		return err
+	}
+
 	npmCmd.SetConfigFilePath(configFilePath).SetArgs(args)
-	err := npmCmd.Init()
+	err = npmCmd.Init()
 	if err != nil {
 		return err
 	}
 	return commands.Exec(npmCmd)
 }
 
-func npmCiCmd(configFilePath string, args []string) error {
-	npmCmd := npm.NewNpmCiCommand()
-	npmCmd.SetConfigFilePath(configFilePath).SetArgs(args)
-	err := npmCmd.Init()
+func NpmPublishCmd(c *cli.Context) error {
+	if show, err := cliutils.ShowCmdHelpIfNeeded(c, c.Args()); show || err != nil {
+		return err
+	}
+
+	configFilePath, args, err := GetNpmConfigAndArgs(c)
 	if err != nil {
 		return err
 	}
-	return commands.Exec(npmCmd)
-}
 
-func npmPublishCmd(configFilePath string, args []string) error {
 	npmCmd := npm.NewNpmPublishCommand()
 	npmCmd.SetConfigFilePath(configFilePath).SetArgs(args)
-	err := npmCmd.Init()
+	err = npmCmd.Init()
 	if err != nil {
 		return err
 	}
-	return commands.Exec(npmCmd)
-}
-
-func npmNativeCmd(cmdName, configFilePath string, fullCmd []string) error {
-	npmCmd := npm.NewNpmNativeCommand(cmdName)
-	npmCmd.SetConfigFilePath(configFilePath).SetNpmArgs(fullCmd)
-	err := npmCmd.Init()
+	err = commands.Exec(npmCmd)
 	if err != nil {
 		return err
 	}
-	return commands.Exec(npmCmd)
+	if npmCmd.IsDetailedSummary() {
+		result := npmCmd.Result()
+		return cliutils.PrintDetailedSummaryReport(result.SuccessCount(), result.FailCount(), result.Reader(), true, false, err)
+	}
+	return nil
 }
 
 func GetNpmConfigAndArgs(c *cli.Context) (configFilePath string, args []string, err error) {
-	if show, err := cliutils.ShowCmdHelpIfNeeded(c, c.Args()); show || err != nil {
-		return "", nil, err
-	}
-
 	configFilePath, exists, err := utils.GetProjectConfFilePath(utils.Npm)
 	if err != nil {
 		return "", nil, err
 	}
 
 	if !exists {
-		return "", nil, errors.New("No config file was found! Before running the npm command on a project for the first time, the project should be configured using the npm-config command. ")
+		return "", nil, errors.New("no config file was found! Before running the npm command on a project for the first time, the project should be configured using the npm-config command")
 	}
 	args = cliutils.ExtractCommand(c)
 	return

--- a/docs/buildtools/npmci/help.go
+++ b/docs/buildtools/npmci/help.go
@@ -1,0 +1,12 @@
+package npmci
+
+var Usage = []string{"npm ci [npm ci args] [command options]"}
+
+func GetDescription() string {
+	return "Run npm ci."
+}
+
+func GetArguments() string {
+	return `	npm ci args
+		The npm ci args to run npm ci.`
+}

--- a/docs/buildtools/npmci/help.go
+++ b/docs/buildtools/npmci/help.go
@@ -1,9 +1,11 @@
 package npmci
 
+import "github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+
 var Usage = []string{"npm ci [npm ci args] [command options]"}
 
 func GetDescription() string {
-	return "Run npm ci."
+	return `Run npm ci, using the npm repository, configured by the '` + coreutils.GetCliExecutableName() + ` npmc' command.`
 }
 
 func GetArguments() string {

--- a/docs/buildtools/npminstall/help.go
+++ b/docs/buildtools/npminstall/help.go
@@ -1,0 +1,12 @@
+package npminstall
+
+var Usage = []string{"npm install [npm install args] [command options]"}
+
+func GetDescription() string {
+	return "Run npm install."
+}
+
+func GetArguments() string {
+	return `	npm install args
+		The npm install args to run npm install. For example, --global.`
+}

--- a/docs/buildtools/npminstall/help.go
+++ b/docs/buildtools/npminstall/help.go
@@ -1,9 +1,11 @@
 package npminstall
 
+import "github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+
 var Usage = []string{"npm install [npm install args] [command options]"}
 
 func GetDescription() string {
-	return "Run npm install."
+	return `Run npm install, using the npm repository, configured by the '` + coreutils.GetCliExecutableName() + ` npmc' command.`
 }
 
 func GetArguments() string {

--- a/docs/buildtools/npmpublish/help.go
+++ b/docs/buildtools/npmpublish/help.go
@@ -1,0 +1,7 @@
+package npmpublish
+
+var Usage = []string{"npm publish [command options]"}
+
+func GetDescription() string {
+	return "Packs and deploys the npm package to the designated npm repository."
+}

--- a/docs/buildtools/npmpublish/help.go
+++ b/docs/buildtools/npmpublish/help.go
@@ -1,7 +1,9 @@
 package npmpublish
 
+import "github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+
 var Usage = []string{"npm publish [command options]"}
 
 func GetDescription() string {
-	return "Packs and deploys the npm package to the designated npm repository."
+	return `Packs and deploys the npm package to the Artifactory npm repository, configured by the '` + coreutils.GetCliExecutableName() + ` npmc' command.`
 }

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ const subcommandHelpTemplate = `NAME:
    {{.HelpName}} - {{.Description}}
 
 USAGE:
-	{{if .Usage}}{{.Usage}}{{ "\n\t" }}{{end}}{{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}}[arguments...]
+	{{if .Usage}}{{.Usage}}{{ "\n\t" }}{{end}}{{.HelpName}} command{{if .VisibleFlags}} [command options]{{end}} [arguments...]
 
 COMMANDS:
    {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Description}}

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -37,8 +37,8 @@ const (
 	BuildDockerCreate      = "build-docker-create"
 	OcStartBuild           = "oc-start-build"
 	NpmConfig              = "npm-config"
-	Npm                    = "npm"
-	NpmPublish             = "npmPublish"
+	NpmInstallCi           = "npm-install-ci"
+	NpmPublish             = "npm-publish"
 	YarnConfig             = "yarn-config"
 	Yarn                   = "yarn"
 	NugetConfig            = "nuget-config"
@@ -1375,7 +1375,7 @@ var commandFlags = map[string][]string{
 	NpmConfig: {
 		global, serverIdResolve, serverIdDeploy, repoResolve, repoDeploy,
 	},
-	Npm: {
+	NpmInstallCi: {
 		buildName, buildNumber, module, npmThreads, project,
 	},
 	NpmPublish: {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
The help for npm command in the new syntax was broken:
1. Could not get the help of a specific cmd.
2. Returned error in some cases. 

This restructure fixes it.
The only problem remained is that the help of the generic npm command displays a help of a subcommands' namespace and cannot be modified:
```
 jf npm -h
NAME:
   jf npm - Run npm command.

USAGE:
  jf npm command [command options] [arguments...]

COMMANDS:
   ci                        Run npm ci.
   install, i, isntall, add  Run npm install.
   publish, p                Packs and deploys the npm package to the designated npm repository.
   help, h

OPTIONS:
   --help, -h  show help
