### PR TITLE
V1 - Update the CentOS image used for creating jfrog-cli's rpm package

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ node("docker") {
     def architectures = [
             [pkg: 'jfrog-cli-windows-amd64', goos: 'windows', goarch: 'amd64', fileExtention: '.exe', chocoImage: 'linuturk/mono-choco'],
             [pkg: 'jfrog-cli-linux-386', goos: 'linux', goarch: '386', fileExtention: '', debianImage: 'i386/ubuntu:16.04', debianArch: 'i386'],
-            [pkg: 'jfrog-cli-linux-amd64', goos: 'linux', goarch: 'amd64', fileExtention: '', debianImage: 'ubuntu:16.04', debianArch: 'x86_64', rpmImage: 'tgagor/centos:stream9'],
+            [pkg: 'jfrog-cli-linux-amd64', goos: 'linux', goarch: 'amd64', fileExtention: '', debianImage: 'ubuntu:16.04', debianArch: 'x86_64', rpmImage: 'tgagor/centos:stream8'],
             [pkg: 'jfrog-cli-linux-arm64', goos: 'linux', goarch: 'arm64', fileExtention: ''],
             [pkg: 'jfrog-cli-linux-arm', goos: 'linux', goarch: 'arm', fileExtention: ''],
             [pkg: 'jfrog-cli-mac-386', goos: 'darwin', goarch: 'amd64', fileExtention: ''],
@@ -97,15 +97,15 @@ def buildRpmAndDeb(version, architectures) {
 
         for (int i = 0; i < architectures.size(); i++) {
             def currentBuild = architectures[i]
-            // if (currentBuild.debianImage) {
-            //     stage("Build debian ${currentBuild.pkg}") {
-            //         build(currentBuild.goos, currentBuild.goarch, currentBuild.pkg, 'jfrog')
-            //         dir("$jfrogCliRepoDir") {
-            //             sh "build/deb_rpm/build-scripts/pack.sh -b jfrog -v $version -f deb --deb-arch $currentBuild.debianArch --deb-build-image $currentBuild.debianImage -t --deb-test-image $currentBuild.debianImage"
-            //             built = true
-            //         }
-            //     }
-            // }
+            if (currentBuild.debianImage) {
+                stage("Build debian ${currentBuild.pkg}") {
+                    build(currentBuild.goos, currentBuild.goarch, currentBuild.pkg, 'jfrog')
+                    dir("$jfrogCliRepoDir") {
+                        sh "build/deb_rpm/build-scripts/pack.sh -b jfrog -v $version -f deb --deb-arch $currentBuild.debianArch --deb-build-image $currentBuild.debianImage -t --deb-test-image $currentBuild.debianImage"
+                        built = true
+                    }
+                }
+            }
             if (currentBuild.rpmImage) {
                 stage("Build rpm ${currentBuild.pkg}") {
                     build(currentBuild.goos, currentBuild.goarch, currentBuild.pkg, 'jfrog')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ node("docker") {
     def architectures = [
             [pkg: 'jfrog-cli-windows-amd64', goos: 'windows', goarch: 'amd64', fileExtention: '.exe', chocoImage: 'linuturk/mono-choco'],
             [pkg: 'jfrog-cli-linux-386', goos: 'linux', goarch: '386', fileExtention: '', debianImage: 'i386/ubuntu:16.04', debianArch: 'i386'],
-            [pkg: 'jfrog-cli-linux-amd64', goos: 'linux', goarch: 'amd64', fileExtention: '', debianImage: 'ubuntu:16.04', debianArch: 'x86_64', rpmImage: 'centos:8'],
+            [pkg: 'jfrog-cli-linux-amd64', goos: 'linux', goarch: 'amd64', fileExtention: '', debianImage: 'ubuntu:16.04', debianArch: 'x86_64', rpmImage: 'tgagor/centos:stream9'],
             [pkg: 'jfrog-cli-linux-arm64', goos: 'linux', goarch: 'arm64', fileExtention: ''],
             [pkg: 'jfrog-cli-linux-arm', goos: 'linux', goarch: 'arm', fileExtention: ''],
             [pkg: 'jfrog-cli-mac-386', goos: 'darwin', goarch: 'amd64', fileExtention: ''],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,15 +97,15 @@ def buildRpmAndDeb(version, architectures) {
 
         for (int i = 0; i < architectures.size(); i++) {
             def currentBuild = architectures[i]
-            if (currentBuild.debianImage) {
-                stage("Build debian ${currentBuild.pkg}") {
-                    build(currentBuild.goos, currentBuild.goarch, currentBuild.pkg, 'jfrog')
-                    dir("$jfrogCliRepoDir") {
-                        sh "build/deb_rpm/build-scripts/pack.sh -b jfrog -v $version -f deb --deb-arch $currentBuild.debianArch --deb-build-image $currentBuild.debianImage -t --deb-test-image $currentBuild.debianImage"
-                        built = true
-                    }
-                }
-            }
+            // if (currentBuild.debianImage) {
+            //     stage("Build debian ${currentBuild.pkg}") {
+            //         build(currentBuild.goos, currentBuild.goarch, currentBuild.pkg, 'jfrog')
+            //         dir("$jfrogCliRepoDir") {
+            //             sh "build/deb_rpm/build-scripts/pack.sh -b jfrog -v $version -f deb --deb-arch $currentBuild.debianArch --deb-build-image $currentBuild.debianImage -t --deb-test-image $currentBuild.debianImage"
+            //             built = true
+            //         }
+            //     }
+            // }
             if (currentBuild.rpmImage) {
                 stage("Build rpm ${currentBuild.pkg}") {
                     build(currentBuild.goos, currentBuild.goarch, currentBuild.pkg, 'jfrog')


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Since CentOS 8 seem to have reached its end of life and its no longer possible to update or install packages on it, this PR replaces the images to use CentOS steam8.