### PR TITLE
Make Zsh completion autoloadable

### DIFF
--- a/completion/shells/zsh/zsh.go
+++ b/completion/shells/zsh/zsh.go
@@ -10,7 +10,9 @@ import (
 	"path/filepath"
 )
 
-const ZshAutocomplete = `_jfrog() {
+const ZshAutocomplete = `#compdef _jf jf _jfrog jfrog
+
+_jfrog() {
 	local -a opts
 	opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
 	_describe 'values' opts


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

In order to make the Zsh script autoloadable by tools such as Homebrew, we should add the `#compdef` header.
This should resolve the issue raised here: https://github.com/Homebrew/homebrew-core/pull/94550#discussion_r800069036