### PR TITLE
Skip terraform and projects tests

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -63,10 +63,10 @@ import (
 
 // Access does not support creating an admin token without UI. Skipping projects tests till this functionality will be implemented.
 // https://jira.jfrog.org/browse/JA-2620
-const projectsTokenMinArtifactoryVersion = "7.33.0"
+const projectsTokenMinArtifactoryVersion = "7.37.0"
 
 // Expected terraform release in Artifactory.
-const terraformMinArtifactoryVersion = "7.32.0"
+const terraformMinArtifactoryVersion = "7.37.0"
 
 // JFrog CLI for Artifactory sub-commands (jfrog rt ...)
 var artifactoryCli *tests.JfrogCli


### PR DESCRIPTION
Terraform and UI-less access token for projects were not released yet.
