### PR TITLE
Fix TestGitLfsCleanup on windows

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/jfrog/gofrog/version"
 	"io"
 	"io/ioutil"
 	"net"
@@ -23,6 +22,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jfrog/gofrog/version"
 
 	"github.com/jfrog/jfrog-client-go/access"
 	"github.com/jfrog/jfrog-client-go/utils/io/content"
@@ -3835,7 +3836,7 @@ func TestGitLfsCleanup(t *testing.T) {
 	var filePath = "testdata/gitlfs/(4b)(*)"
 	runRt(t, "upload", filePath, tests.RtLfsRepo+"/objects/4b/f4/{2}{1}", "--flat=true")
 	runRt(t, "upload", filePath, tests.RtLfsRepo+"/objects/4b/f4/", "--flat=true")
-	refs := filepath.Join("refs", "remotes", "*")
+	refs := path.Join("refs", "remotes", "*")
 	dotGitPath := getCliDotGitPath(t)
 	runRt(t, "glc", dotGitPath, "--repo="+tests.RtLfsRepo, "--refs=HEAD,"+refs)
 	gitlfsSpecFile, err := tests.CreateSpec(tests.GitLfsAssertSpec)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
In Windows It does:
--refs=HEAD,refs\remotes\*
Instead of:
--refs=HEAD,refs/remotes/*