### PR TITLE
Run go tests on the ecosys

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,6 @@ jobs:
             maven,
             gradle,
             nuget,
-            go,
           ]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -100,6 +99,27 @@ jobs:
       - name: Run Distribution / Xray tests
         run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.${{ matrix.suite }}=true --jfrog.url=${{ secrets.PLATFORM_URL }} --jfrog.adminToken=${{ secrets.PLATFORM_ADMIN_TOKEN }} --jfrog.user=${{ secrets.PLATFORM_USER }} --ci.runId=${{ runner.os }}-${{ matrix.suite }}
         if: ${{ matrix.suite == 'distribution' || matrix.suite == 'xray' }}
+
+  Go-Tests:
+    # Go modules doesn't allow passing credentials to a private registry using an HTTP URL. Therefore the Go tests run on a remote Artifactory server.
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
+    name: go (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run Docker tests
+        run: go test -v -timeout 0 --test.go --jfrog.url=${{ secrets.PLATFORM_URL }} --jfrog.adminToken=${{ secrets.PLATFORM_ADMIN_TOKEN }}
 
   Docker-tests:
     if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
         if: ${{ matrix.suite == 'distribution' || matrix.suite == 'xray' }}
 
   Go-Tests:
-    # Go modules doesn't allow passing credentials to a private registry using an HTTP URL. Therefore the Go tests run on a remote Artifactory server.
+    # Go modules doesn't allow passing credentials to a private registry using an HTTP URL. Therefore the Go tests run against a remote Artifactory server.
     if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
     name: go (${{ matrix.os }})
     strategy:


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Currently, TestGoPublishResolve fails with the following error:

> go: github.com/jfrog/dependency@v1.0.0: reading github.com/jfrog/dependency/go.mod at revision v1.0.0: git ls-remote -q origin in /tmp/jfrog.cli.temp.-1645700883-2330432947/pkg/mod/cache/vcs/b5e98ba27d5eefd271243a7db75bcb33be8626ec0901d9d6d85b776ca2732b4e: exit status 128:
	fatal: could not read Username for 'https://github.com/': terminal prompts disabled
Confirm the import path was entered correctly.
If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.

In that case, GOPROXY was configured as following:
GOPROXY=http://admin:xxxxx@localhost:8081/artifactory/api/go/cli-go-virtual-1645703089|direct

Running the same test without `|direct` in the GOPROXY returns the following error:

> refusing to pass credentials to insecure URL: http://admin:xxxxx@localhost:8081/artifactory/api/go/cli-go-virtual-1645703089/github.com/jfrog/dependency/@v/v1.0.0.mod

GOPROXY with credentials requires HTTPS server. Therefore, the Go tests running locally on `http://127.0.0.1` is expected to fail.

For now, let's use the ecosys server.

