### PR TITLE
Allow Go tests running on VS-Code

### DIFF
--- a/go_test.go
+++ b/go_test.go
@@ -225,6 +225,7 @@ func initGoTest(t *testing.T) (tempGoPath string, cleanUp func()) {
 		t.Skip("Skipping go test. To run go test add the '-test.go=true' option.")
 	}
 	clientTestUtils.SetEnvAndAssert(t, "GONOSUMDB", "github.com/jfrog")
+	clientTestUtils.UnSetEnvAndAssert(t, "GOMODCACHE")
 	createJfrogHomeConfig(t, true)
 	tempGoPath, cleanUpGoPath := createTempGoPath(t)
 	return tempGoPath, func() {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

The VS-Code Go extension sets the `GOMODCACHE` to be the original Go cache directory. This behavior causes the Go tests the not download dependencies.