### PR TITLE
Fix transitive flag in download command

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -2482,8 +2482,8 @@ func setTransitiveInDownloadSpec(downloadSpec *spec.SpecFiles) {
 	if transitive == "" {
 		return
 	}
-	for _, file := range downloadSpec.Files {
-		file.Transitive = transitive
+	for fileIndex := 0; fileIndex < len(downloadSpec.Files); fileIndex++ {
+		downloadSpec.Files[fileIndex].Transitive = transitive
 	}
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fixed the setting of JFROG_CLI_TRANSITIVE_DOWNLOAD_EXPERIMENTAL env var in spec files of the download command.