### PR TITLE
New scan/audit pretty-json output format

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -528,7 +528,7 @@ func runDockerScan(t *testing.T, imageName, watchName string, minViolations, min
 		// Run docker scan on image
 		output := xrayCli.WithoutCredentials().RunCliCmdWithOutput(t, args...)
 		if assert.NotEmpty(t, output) {
-			verifyScanResults(t, output, 0, minVulnerabilities, minLicenses)
+			verifyJsonScanResults(t, output, 0, minVulnerabilities, minLicenses)
 		}
 
 		// Run docker scan on image with watch
@@ -536,7 +536,7 @@ func runDockerScan(t *testing.T, imageName, watchName string, minViolations, min
 			args = append(args, "--watches="+watchName)
 			output = xrayCli.WithoutCredentials().RunCliCmdWithOutput(t, args...)
 			if assert.NotEmpty(t, output) {
-				verifyScanResults(t, output, minViolations, 0, 0)
+				verifyJsonScanResults(t, output, minViolations, 0, 0)
 			}
 		}
 	}

--- a/general/cisetup/cisetup.go
+++ b/general/cisetup/cisetup.go
@@ -636,15 +636,7 @@ func (cc *CiSetupCommand) printDetectedTechs() error {
 	if len(techs) == 0 {
 		return errorutils.CheckErrorf("no supported technology was found in the project")
 	}
-	return writeToScreen("The next step is to provide the commands to build your code. It looks like the code is built with " + getExplicitTechsListByNumber(techs) + ".\n")
-}
-
-// Get the explicit list of technologies, for ex: "maven, gradle and npm"
-func getExplicitTechsListByNumber(techs []string) string {
-	if len(techs) == 1 {
-		return techs[0]
-	}
-	return strings.Join(techs[0:len(techs)-1], ", ") + " and " + techs[len(techs)-1]
+	return writeToScreen("The next step is to provide the commands to build your code. It looks like the code is built with " + coreutils.GetExplicitListByNumber(techs) + ".\n")
 }
 
 func (cc *CiSetupCommand) getBuildCmd() {

--- a/general/cisetup/cisetup.go
+++ b/general/cisetup/cisetup.go
@@ -636,7 +636,7 @@ func (cc *CiSetupCommand) printDetectedTechs() error {
 	if len(techs) == 0 {
 		return errorutils.CheckErrorf("no supported technology was found in the project")
 	}
-	return writeToScreen("The next step is to provide the commands to build your code. It looks like the code is built with " + coreutils.GetExplicitListByNumber(techs) + ".\n")
+	return writeToScreen("The next step is to provide the commands to build your code. It looks like the code is built with " + coreutils.ListToText(techs) + ".\n")
 }
 
 func (cc *CiSetupCommand) getBuildCmd() {

--- a/general/cisetup/cisetup_test.go
+++ b/general/cisetup/cisetup_test.go
@@ -44,23 +44,3 @@ func TestExtractRepositoryName(t *testing.T) {
 		})
 	}
 }
-
-func TestGetExplicitTechsListByNumber(t *testing.T) {
-	tests := []struct {
-		name     string
-		techs    []string
-		expected string
-	}{
-		{"one tech", []string{"maven"}, "maven"},
-		{"two techs", []string{"maven", "gradle"}, "maven and gradle"},
-		{"three techs", []string{"maven", "gradle", "npm"}, "maven, gradle and npm"},
-		{"four techs", []string{"maven", "gradle", "npm", "something"}, "maven, gradle, npm and something"},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			output := getExplicitTechsListByNumber(test.techs)
-			assert.Equal(t, test.expected, output)
-		})
-	}
-}

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.10.1-0.20220307134618-940f00d5517b
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220327074733-440fa971a5ae
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.11.3-0.20220327080113-6ea66628698c
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.1.2-0.20220320172359-114c9ce2e4b4
 

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.10.1-0.20220307134618-940f00d5517b
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220324103930-956e4abf6ae5
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220327074733-440fa971a5ae
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.1.2-0.20220320172359-114c9ce2e4b4
 

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.10.1-0.20220307134618-940f00d5517b
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.11.2-0.20220321101620-2ee6ece56d97
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220324103930-956e4abf6ae5
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.1.2-0.20220320172359-114c9ce2e4b4
 

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,6 @@ github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXG
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220327074733-440fa971a5ae h1:JA84z2VBqD8zY+RdD0rSnS04D0j+q+H9yVY/AH41sTc=
-github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220327074733-440fa971a5ae/go.mod h1:VHm3v5BT0xxlXPkz7hN9SQZw0xqh5M4cdA9Fc+O9iDQ=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
@@ -239,6 +237,8 @@ github.com/jfrog/build-info-go v1.2.0 h1:xs+SpWqyYZNfXIK2npQyMbHPrLduagY750HSra2
 github.com/jfrog/build-info-go v1.2.0/go.mod h1:gdCtJXDZhHotlr+Bfep9NYyo/67PrFhJ65dhwQIpUoI=
 github.com/jfrog/gofrog v1.1.1 h1:uRjeZWidQl4FmKP4Zpj5hSKJp3gSIWW9VUwbQdVEVRU=
 github.com/jfrog/gofrog v1.1.1/go.mod h1:9YN5v4LlsCfLIXpwQnzSf1wVtgjdHM20FzuIu58RMI4=
+github.com/jfrog/jfrog-cli-core/v2 v2.11.3-0.20220327080113-6ea66628698c h1:0JxOk4QcGsATQKtVEUouFHnD1V6lajWFwJvpvhisA0U=
+github.com/jfrog/jfrog-cli-core/v2 v2.11.3-0.20220327080113-6ea66628698c/go.mod h1:VHm3v5BT0xxlXPkz7hN9SQZw0xqh5M4cdA9Fc+O9iDQ=
 github.com/jfrog/jfrog-client-go v1.11.1 h1:/E8fS3hTpaQxP5cMWq14zeya0hDCDtgEGYB2mx8s32E=
 github.com/jfrog/jfrog-client-go v1.11.1/go.mod h1:/d/Eki45fyk97ziLETT2suzuP1f0pUNRbgldSJ8FZdg=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXG
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220324103930-956e4abf6ae5 h1:dDWMT4TDoSoadXbQQsGLhm/8wYUUrh0lNCvH0zaWBJ0=
-github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220324103930-956e4abf6ae5/go.mod h1:VHm3v5BT0xxlXPkz7hN9SQZw0xqh5M4cdA9Fc+O9iDQ=
+github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220327074733-440fa971a5ae h1:JA84z2VBqD8zY+RdD0rSnS04D0j+q+H9yVY/AH41sTc=
+github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220327074733-440fa971a5ae/go.mod h1:VHm3v5BT0xxlXPkz7hN9SQZw0xqh5M4cdA9Fc+O9iDQ=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXG
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
+github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220324103930-956e4abf6ae5 h1:dDWMT4TDoSoadXbQQsGLhm/8wYUUrh0lNCvH0zaWBJ0=
+github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20220324103930-956e4abf6ae5/go.mod h1:VHm3v5BT0xxlXPkz7hN9SQZw0xqh5M4cdA9Fc+O9iDQ=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
@@ -237,8 +239,6 @@ github.com/jfrog/build-info-go v1.2.0 h1:xs+SpWqyYZNfXIK2npQyMbHPrLduagY750HSra2
 github.com/jfrog/build-info-go v1.2.0/go.mod h1:gdCtJXDZhHotlr+Bfep9NYyo/67PrFhJ65dhwQIpUoI=
 github.com/jfrog/gofrog v1.1.1 h1:uRjeZWidQl4FmKP4Zpj5hSKJp3gSIWW9VUwbQdVEVRU=
 github.com/jfrog/gofrog v1.1.1/go.mod h1:9YN5v4LlsCfLIXpwQnzSf1wVtgjdHM20FzuIu58RMI4=
-github.com/jfrog/jfrog-cli-core/v2 v2.11.2 h1:QEUwagK0RVrH+vLQiJ9oqrsd5HzYDJgPJREWKDRlu/E=
-github.com/jfrog/jfrog-cli-core/v2 v2.11.2/go.mod h1:VHm3v5BT0xxlXPkz7hN9SQZw0xqh5M4cdA9Fc+O9iDQ=
 github.com/jfrog/jfrog-client-go v1.11.1 h1:/E8fS3hTpaQxP5cMWq14zeya0hDCDtgEGYB2mx8s32E=
 github.com/jfrog/jfrog-client-go v1.11.1/go.mod h1:/d/Eki45fyk97ziLETT2suzuP1f0pUNRbgldSJ8FZdg=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/scan/cli.go
+++ b/scan/cli.go
@@ -299,6 +299,9 @@ func createGenericAuditCmd(c *cli.Context) (*audit.AuditCommand, error) {
 }
 
 func ScanCmd(c *cli.Context) error {
+	if c.NArg() == 0 && !c.IsSet("spec") {
+		return cliutils.PrintHelpAndReturnError("providing either a <source pattern> argument or the 'spec' option is mandatory", c)
+	}
 	err := validateXrayContext(c)
 	if err != nil {
 		return err

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -1,8 +1,6 @@
 package cliutils
 
 import (
-	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
-	"github.com/jfrog/jfrog-cli-core/v2/xray/utils"
 	"sort"
 	"strconv"
 
@@ -1186,7 +1184,7 @@ var flagsMap = map[string]cli.Flag{
 	},
 	xrOutput: cli.StringFlag{
 		Name:  xrOutput,
-		Usage: "[Default: table] Defines the output format of the command. Acceptable values are: " + coreutils.GetExplicitListByNumber(utils.OutputFormats) + ".` `",
+		Usage: "[Default: table] Defines the output format of the command. Acceptable values are: table and json.` `",
 	},
 
 	// Mission Control's commands Flags

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -1,6 +1,8 @@
 package cliutils
 
 import (
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/jfrog/jfrog-cli-core/v2/xray/utils"
 	"sort"
 	"strconv"
 
@@ -1184,7 +1186,7 @@ var flagsMap = map[string]cli.Flag{
 	},
 	xrOutput: cli.StringFlag{
 		Name:  xrOutput,
-		Usage: "[Default: table] Defines the output format of the command. Acceptable values are: table and json.` `",
+		Usage: "[Default: table] Defines the output format of the command. Acceptable values are: " + coreutils.GetExplicitListByNumber(utils.OutputFormats) + ".` `",
 	},
 
 	// Mission Control's commands Flags

--- a/xray_test.go
+++ b/xray_test.go
@@ -108,7 +108,7 @@ func testXrayAuditNpm(t *testing.T, format string) string {
 	// Run npm install before executing jfrog xr npm-audit
 	assert.NoError(t, exec.Command("npm", "install").Run())
 
-	return xrayCli.RunCliCmdWithOutput(t, "audit-npm", "--licenses", "--format=json")
+	return xrayCli.RunCliCmdWithOutput(t, "audit-npm", "--licenses", "--format="+format)
 }
 
 // Tests NuGet audit by providing simple NuGet project and asserts any error.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
The new format transforms the raw scan results into a "table like" json.
```
{
  "Vulnerabilities": [],
  "SecurityViolations": [],
  "LicensesViolations": [],
  "Licenses": []
}
```
Each table is an array of key:value objects, with the keys corresponding to the column names in the `table` format.

Depends on jfrog/jfrog-cli-core#359