### PR TITLE
Remove progress width limit & improve 'jf setup' message

### DIFF
--- a/general/envsetup/envsetup.go
+++ b/general/envsetup/envsetup.go
@@ -16,7 +16,7 @@ func RunEnvSetupCmd() error {
 	fmt.Println()
 	fmt.Println()
 	fmt.Println(coreutils.PrintTitle("Thank you for installing JFrog CLI! 🐸"))
-	fmt.Println(coreutils.PrintTitle("We'll now set up a FREE JFrog environment in the cloud for you, and configure you local machine to use it"))
+	fmt.Println(coreutils.PrintTitle("We'll now set up a FREE JFrog environment in the cloud for you, and configure your local machine to use it."))
 	fmt.Println("Your environment will be ready in less than a minute.")
 	setupCmd := envsetup.NewEnvSetupCommand(registrationPageURL)
 	return progressbar.ExecWithProgress(setupCmd, false)

--- a/general/envsetup/envsetup.go
+++ b/general/envsetup/envsetup.go
@@ -17,6 +17,7 @@ func RunEnvSetupCmd() error {
 	fmt.Println()
 	fmt.Println(coreutils.PrintTitle("Thank you for installing JFrog CLI! 🐸"))
 	fmt.Println(coreutils.PrintTitle("We'll now set up a FREE JFrog environment in the cloud for you, and configure you local machine to use it"))
+	fmt.Println("Your environment will be ready in less than a minute.")
 	setupCmd := envsetup.NewEnvSetupCommand(registrationPageURL)
 	return progressbar.ExecWithProgress(setupCmd, false)
 }

--- a/general/envsetup/envsetup.go
+++ b/general/envsetup/envsetup.go
@@ -2,6 +2,7 @@ package envsetup
 
 import (
 	"fmt"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 
 	"github.com/jfrog/jfrog-cli-core/v2/general/envsetup"
 	"github.com/jfrog/jfrog-cli/utils/progressbar"
@@ -12,7 +13,10 @@ const (
 )
 
 func RunEnvSetupCmd() error {
-	fmt.Println("Thank you for installing JFrog CLI! 🐸")
+	fmt.Println()
+	fmt.Println()
+	fmt.Println(coreutils.PrintTitle("Thank you for installing JFrog CLI! 🐸"))
+	fmt.Println(coreutils.PrintTitle("We'll now set up a FREE JFrog environment in the cloud for you, and configure you local machine to use it"))
 	setupCmd := envsetup.NewEnvSetupCommand(registrationPageURL)
 	return progressbar.ExecWithProgress(setupCmd, false)
 }

--- a/utils/progressbar/progressbar.go
+++ b/utils/progressbar/progressbar.go
@@ -23,7 +23,6 @@ import (
 var terminalWidth int
 
 const progressBarWidth = 20
-const minTerminalWidth = 70
 const progressRefreshRate = 200 * time.Millisecond
 
 type progressBarManager struct {

--- a/utils/progressbar/progressbar.go
+++ b/utils/progressbar/progressbar.go
@@ -265,7 +265,7 @@ func shouldInitProgressBar() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return terminalWidth >= minTerminalWidth, nil
+	return true, nil
 }
 
 // Check if Stderr is a terminal

--- a/utils/progressbar/progressbar.go
+++ b/utils/progressbar/progressbar.go
@@ -250,8 +250,8 @@ func InitProgressBarIfPossible(printLogPath bool) (ioUtils.ProgressMgr, *os.File
 	return newProgressBar, logFile, nil
 }
 
-// Init progress bar if all required conditions are met:
-// CI == false (or unset), Stderr is a terminal, and terminal width is large enough
+// Init the progress bar, if the required conditions are met:
+// CI == false (or unset) and Stderr is a terminal.
 func shouldInitProgressBar() (bool, error) {
 	ci, err := utils.GetBoolEnvValue(coreutils.CI, false)
 	if ci || err != nil {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is obeucase n the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
**Change 1**
I found a critical bug, which causes the 'jf setup' command to fail with the following nil panic, if the terminal width is too small. This happens progress bar isn't created, and is nil, if the terminal width is too small.
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x18024ee]

goroutine 1 [running]:
github.com/jfrog/jfrog-cli-core/v2/general/envsetup.(*EnvSetupCommand).Run(0xc000338b40)
	/Users/eyalb/dev/forks/jfrog-cli-core/general/envsetup/envsetup.go:54 +0x6e
github.com/jfrog/jfrog-cli-core/v2/common/commands.Exec({0x61110b8, 0xc000338b40})
	/Users/eyalb/dev/forks/jfrog-cli-core/common/commands/command.go:26 +0xad
github.com/jfrog/jfrog-cli/utils/progressbar.ExecWithProgress({0x1be5b98, 0xc000338b40}, 0x30)
	/Users/eyalb/dev/forks/jfrog-cli/utils/progressbar/progressbar.go:375 +0x10e
github.com/jfrog/jfrog-cli/general/envsetup.RunEnvSetupCmd()
	/Users/eyalb/dev/forks/jfrog-cli/general/envsetup/envsetup.go:20 +0xfe
main.getCommands.func2(0x1ab3c01)
	/Users/eyalb/dev/forks/jfrog-cli/main.go:212 +0x17
github.com/urfave/cli.HandleAction({0x19227a0, 0x1ab3cf8}, 0x5)
	/Users/eyalb/go/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:524 +0xa8
github.com/urfave/cli.Command.Run({{0x1a5c04c, 0x5}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x0, 0x0}, {0x0, ...}, ...}, ...)
	/Users/eyalb/go/pkg/mod/github.com/urfave/cli@v1.22.5/command.go:173 +0x652
github.com/urfave/cli.(*App).Run(0xc0000eaa80, {0xc000096020, 0x2, 0x2})
	/Users/eyalb/go/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:277 +0x705
main.execMain()
	/Users/eyalb/dev/forks/jfrog-cli/main.go:104 +0x307
main.main()
	/Users/eyalb/dev/forks/jfrog-cli/main.go:68 +0x25
```
Following my tests, this width limit is no longer needed. The progress bar (in its two forms) functions well with all terminal widths.
I therefore removed this limitation, which resolves the issue.

**Change 2**
I improved the initial intro message, displayed after running 'jf setup'.