### PR TITLE
Audit tests improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.11.4-0.20220330080802-5386ccb93d01
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.12.2-0.20220405074650-f36f642a1beb
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/talarian1/jfrog-cli-core/v2 v2.0.0-20220405114031-999e95a06396
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.1.2-0.20220320172359-114c9ce2e4b4
 

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.11.4-0.20220330080802-5386ccb93d01
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/talarian1/jfrog-cli-core/v2 v2.0.0-20220405114031-999e95a06396
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.12.2-0.20220405151147-fc8999d40ff1
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.1.2-0.20220320172359-114c9ce2e4b4
 

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,8 @@ github.com/jfrog/build-info-go v1.2.2 h1:Urs24FSQNvu2oO+aZVUCGLeF3UQUojPxWDkoSfx
 github.com/jfrog/build-info-go v1.2.2/go.mod h1:gdCtJXDZhHotlr+Bfep9NYyo/67PrFhJ65dhwQIpUoI=
 github.com/jfrog/gofrog v1.1.1 h1:uRjeZWidQl4FmKP4Zpj5hSKJp3gSIWW9VUwbQdVEVRU=
 github.com/jfrog/gofrog v1.1.1/go.mod h1:9YN5v4LlsCfLIXpwQnzSf1wVtgjdHM20FzuIu58RMI4=
+github.com/jfrog/jfrog-cli-core/v2 v2.12.2-0.20220405151147-fc8999d40ff1 h1:cD63WzTLWgK671DC5R75eynrw00WejGMHfXJgW5cdWs=
+github.com/jfrog/jfrog-cli-core/v2 v2.12.2-0.20220405151147-fc8999d40ff1/go.mod h1:doIcN1tDhvpE/M9SmVui766iYnUmBoK5Rpt9d1Dmok0=
 github.com/jfrog/jfrog-client-go v1.11.4 h1:6aZODS7wKc1YR0/9+wDLibJM9tiws6OwsTOu0rGWiaw=
 github.com/jfrog/jfrog-client-go v1.11.4/go.mod h1:y64OpQk/gR+5OE5WQBNqctJCAYb+jAJfXbJMbuw59Fc=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -455,8 +457,6 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/talarian1/jfrog-cli-core/v2 v2.0.0-20220405114031-999e95a06396 h1:MguaOauNlxhEr5kcwuyRb45fz8rk5MXI8KdH7ssK1E0=
-github.com/talarian1/jfrog-cli-core/v2 v2.0.0-20220405114031-999e95a06396/go.mod h1:doIcN1tDhvpE/M9SmVui766iYnUmBoK5Rpt9d1Dmok0=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.9 h1:RsKRIA2MO8x56wkkcd3LbtcE/uMszhb6DpRf+3uwa3I=

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,6 @@ github.com/jfrog/build-info-go v1.2.2 h1:Urs24FSQNvu2oO+aZVUCGLeF3UQUojPxWDkoSfx
 github.com/jfrog/build-info-go v1.2.2/go.mod h1:gdCtJXDZhHotlr+Bfep9NYyo/67PrFhJ65dhwQIpUoI=
 github.com/jfrog/gofrog v1.1.1 h1:uRjeZWidQl4FmKP4Zpj5hSKJp3gSIWW9VUwbQdVEVRU=
 github.com/jfrog/gofrog v1.1.1/go.mod h1:9YN5v4LlsCfLIXpwQnzSf1wVtgjdHM20FzuIu58RMI4=
-github.com/jfrog/jfrog-cli-core/v2 v2.12.2-0.20220405074650-f36f642a1beb h1:INu/JasTPH0/CwLrKpfDDyIfiLF6zYleeWDXvEvBZGc=
-github.com/jfrog/jfrog-cli-core/v2 v2.12.2-0.20220405074650-f36f642a1beb/go.mod h1:doIcN1tDhvpE/M9SmVui766iYnUmBoK5Rpt9d1Dmok0=
 github.com/jfrog/jfrog-client-go v1.11.4 h1:6aZODS7wKc1YR0/9+wDLibJM9tiws6OwsTOu0rGWiaw=
 github.com/jfrog/jfrog-client-go v1.11.4/go.mod h1:y64OpQk/gR+5OE5WQBNqctJCAYb+jAJfXbJMbuw59Fc=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -457,6 +455,8 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/talarian1/jfrog-cli-core/v2 v2.0.0-20220405114031-999e95a06396 h1:MguaOauNlxhEr5kcwuyRb45fz8rk5MXI8KdH7ssK1E0=
+github.com/talarian1/jfrog-cli-core/v2 v2.0.0-20220405114031-999e95a06396/go.mod h1:doIcN1tDhvpE/M9SmVui766iYnUmBoK5Rpt9d1Dmok0=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.9 h1:RsKRIA2MO8x56wkkcd3LbtcE/uMszhb6DpRf+3uwa3I=

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -1189,31 +1189,31 @@ var flagsMap = map[string]cli.Flag{
 		Name:  xrOutput,
 		Usage: "[Default: table] Defines the output format of the command. Acceptable values are: table and json.` `",
 	},
-	Mvn: cli.StringFlag{
+	Mvn: cli.BoolFlag{
 		Name:  Mvn,
 		Usage: "[Optional] Request audit for a Maven project.` `",
 	},
-	Gradle: cli.StringFlag{
+	Gradle: cli.BoolFlag{
 		Name:  Gradle,
 		Usage: "[Optional] Request audit for a Gradle project.` `",
 	},
-	Npm: cli.StringFlag{
+	Npm: cli.BoolFlag{
 		Name:  Npm,
 		Usage: "[Optional] Request audit for a npm project.` `",
 	},
-	Nuget: cli.StringFlag{
+	Nuget: cli.BoolFlag{
 		Name:  Nuget,
 		Usage: "[Optional] Request audit for a .Net project.` `",
 	},
-	Pip: cli.StringFlag{
+	Pip: cli.BoolFlag{
 		Name:  Pip,
 		Usage: "[Optional] Request audit for a Pip project.` `",
 	},
-	Pipenv: cli.StringFlag{
+	Pipenv: cli.BoolFlag{
 		Name:  Pipenv,
 		Usage: "[Optional] Request audit for a Pipenv project.` `",
 	},
-	Go: cli.StringFlag{
+	Go: cli.BoolFlag{
 		Name:  Go,
 		Usage: "[Optional] Request audit for a Go project.` `",
 	},


### PR DESCRIPTION
Replace deprecated audit use with the new syntax.
Add new 2 tests for the generic audit command.

- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
