### PR TITLE
Use 'sudo' during jfrog-cli installation if needed

### DIFF
--- a/build/installcli/jf.sh
+++ b/build/installcli/jf.sh
@@ -14,6 +14,7 @@ then
 else
     echo "Downloading the latest version of JFrog CLI..."
 fi
+echo ""
 
 if $(echo "${OSTYPE}" | grep -q msys); then
     CLI_OS="windows"
@@ -66,8 +67,22 @@ while [ -n "$1" ]; do
     # Check if destination is in path.
     if echo $PATH|grep "$1" -> /dev/null ; then
         mv $FILE_NAME $1
-        echo "$FILE_NAME executable was installed at $1"
-        exit 0
+        if [ "$?" -eq "0" ]
+        then
+            echo ""
+            echo "The $FILE_NAME executable was installed in $1"
+            exit 0
+        else
+            echo ""
+            echo "We'd like to install the JFrog CLI executable in $1. Please approve this installation by entering your password."
+            sudo mv $FILE_NAME $1
+            if [ "$?" -eq "0" ]
+            then
+                echo ""
+                echo "The $FILE_NAME executable was installed in $1"
+                exit 0
+            fi
+        fi
     fi
     shift
 done

--- a/build/installcli/jfrog.sh
+++ b/build/installcli/jfrog.sh
@@ -14,6 +14,7 @@ then
 else
     echo "Downloading the latest version of JFrog CLI..."
 fi
+echo ""
 
 if $(echo "${OSTYPE}" | grep -q msys); then
     CLI_OS="windows"
@@ -66,8 +67,22 @@ while [ -n "$1" ]; do
     # Check if destination is in path.
     if echo $PATH|grep "$1" -> /dev/null ; then
         mv $FILE_NAME $1
-        echo "$FILE_NAME executable was installed at $1"
-        exit 0
+        if [ "$?" -eq "0" ]
+        then
+            echo ""
+            echo "The $FILE_NAME executable was installed in $1"
+            exit 0
+        else
+            echo ""
+            echo "We'd like to install the JFrog CLI executable in $1. Please approve this installation by entering your password."
+            sudo mv $FILE_NAME $1
+            if [ "$?" -eq "0" ]
+            then
+                echo ""
+                echo "The $FILE_NAME executable was installed in $1"
+                exit 0
+            fi
+        fi
     fi
     shift
 done

--- a/build/setupcli/jf.sh
+++ b/build/setupcli/jf.sh
@@ -66,7 +66,7 @@ set -- $DESTINATION_PATHS
 while [ -n "$1" ]; do
     # Check if destination is in path.
     if echo $PATH|grep "$1" -> /dev/null ; then
-        mv $FILE_NAME1 $1
+        mv $FILE_NAME $1
         if [ "$?" -eq "0" ]
         then
             echo ""

--- a/build/setupcli/jf.sh
+++ b/build/setupcli/jf.sh
@@ -6,6 +6,7 @@ CLI_MAJOR_VER="v2-jf"
 VERSION="[RELEASE]"
 # Order is by destination priority.
 DESTINATION_PATHS="/usr/local/bin /usr/bin /opt/bin"
+SETUP_COMMAND="jf setup"
 
 if [ $# -eq 1 ]
 then
@@ -65,10 +66,25 @@ set -- $DESTINATION_PATHS
 while [ -n "$1" ]; do
     # Check if destination is in path.
     if echo $PATH|grep "$1" -> /dev/null ; then
-        mv $FILE_NAME $1
-        echo "$FILE_NAME executable was installed at $1"
-        jf setup
-        exit 0
+        mv $FILE_NAME1 $1
+        if [ "$?" -eq "0" ]
+        then
+            echo ""
+            echo "The $FILE_NAME executable was installed in $1"
+            $SETUP_COMMAND
+            exit 0
+        else
+            echo ""
+            echo "We'd like to install the JFrog CLI executable in $1. Please approve this installation by entering your password."
+            sudo mv $FILE_NAME $1
+            if [ "$?" -eq "0" ]
+            then
+                echo ""
+                echo "The $FILE_NAME executable was installed in $1"
+                $SETUP_COMMAND
+                exit 0
+            fi
+        fi
     fi
     shift
 done


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Modify jfrog-cli's curl installation as follows - 
In case the move (mv command) of the executable to the dire in PATH fails (probably because of lack of permissions), the setup script will run the move command again, but this time with sudo.

Here's the flow - 
1. Try to move the exe to a dir in the PATH
2. If move is successful, exit 0
3. If not successful, try to move again with sudo
4. If move is successful, exit 0
5. If not successful, exit 1
