### PR TITLE
Spelling correction, environemt to environment

### DIFF
--- a/docs/artifactory/gradle/help.go
+++ b/docs/artifactory/gradle/help.go
@@ -4,7 +4,7 @@ var Usage = []string{"rt gradle <tasks and options> [command options]"}
 
 const EnvVar string = `	JFROG_CLI_EXTRACTORS_REMOTE
 		Configured Artifactory server ID and repository name from which to download the jar needed by the gradle command.
-		This environemt variable's value format should be <server ID>/<repo name>. The repository should proxy https://releases.jfrog.io/artifactory/oss-release-local.
+		This environment variable's value format should be <server ID>/<repo name>. The repository should proxy https://releases.jfrog.io/artifactory/oss-release-local.
 
 	JFROG_CLI_DEPENDENCIES_DIR
 		[Default: $JFROG_CLI_HOME_DIR/dependencies]

--- a/docs/artifactory/mvn/help.go
+++ b/docs/artifactory/mvn/help.go
@@ -4,7 +4,7 @@ var Usage = []string{"rt mvn <goals and options> [command options]"}
 
 const EnvVar string = `	JFROG_CLI_EXTRACTORS_REMOTE
 		Configured Artifactory server ID and repository name from which to download the jar needed by the mvn command.
-		This environemt variable's value format should be <server ID>/<repo name>. The repository should proxy https://releases.jfrog.io/artifactory/oss-release-local.
+		This environment variable's value format should be <server ID>/<repo name>. The repository should proxy https://releases.jfrog.io/artifactory/oss-release-local.
 
 	JFROG_CLI_DEPENDENCIES_DIR
 		[Default: $JFROG_CLI_HOME_DIR/dependencies]

--- a/docs/buildtools/mvn/help.go
+++ b/docs/buildtools/mvn/help.go
@@ -4,7 +4,7 @@ var Usage = []string{"mvn <goals and options> [command options]"}
 
 const EnvVar string = `	JFROG_CLI_EXTRACTORS_REMOTE
 		Configured Artifactory server ID and repository name from which to download the jar needed by the mvn command.
-		This environemt variable's value format should be <server ID>/<repo name>. The repository should proxy https://releases.jfrog.io/artifactory/oss-release-local.
+		This environment variable's value format should be <server ID>/<repo name>. The repository should proxy https://releases.jfrog.io/artifactory/oss-release-local.
 
 	JFROG_CLI_DEPENDENCIES_DIR
 		[Default: $JFROG_CLI_HOME_DIR/dependencies]

--- a/docs/common/help.go
+++ b/docs/common/help.go
@@ -59,7 +59,7 @@ func GetGlobalEnvVars() string {
 	
 	JFROG_CLI_EXTRACTORS_REMOTE
 		Configured Artifactory server ID and repository name from which to download the jar needed by the mvn/gradle command.
-		This environemt variable's value format should be <server ID>/<repo name>. The repository should proxy https://releases.jfrog.io/artifactory/oss-release-local.
+		This environment variable's value format should be <server ID>/<repo name>. The repository should proxy https://releases.jfrog.io/artifactory/oss-release-local.
 	
 	JFROG_CLI_DEPENDENCIES_DIR
 		[Default: $JFROG_CLI_HOME_DIR/dependencies]


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Hi there, just a small pr for a spelling error. That's all!

Thank you
