### PR TITLE
Expose the terraform commands in JFrog CLI's embedded help

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -62,8 +62,8 @@ import (
 // https://jira.jfrog.org/browse/JA-2620
 const projectsTokenMinArtifactoryVersion = "7.41.0"
 
-// Expected terraform release in Artifactory.
-const terraformMinArtifactoryVersion = "7.41.0"
+// Minimum Artifactory version with Terraform support
+const terraformMinArtifactoryVersion = "7.38.4"
 
 // JFrog CLI for Artifactory sub-commands (jfrog rt ...)
 var artifactoryCli *tests.JfrogCli

--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -344,7 +344,6 @@ func GetCommands() []cli.Command {
 			ArgsUsage:    common.CreateEnvVars(),
 			BashComplete: corecommon.CreateBashCompletionFunc(),
 			Category:     buildToolsCategory,
-			Hidden:       true,
 			Action: func(c *cli.Context) error {
 				return cliutils.CreateConfigCmd(c, utils.Terraform)
 			},
@@ -359,7 +358,6 @@ func GetCommands() []cli.Command {
 			ArgsUsage:    common.CreateEnvVars(),
 			BashComplete: corecommon.CreateBashCompletionFunc(),
 			Category:     buildToolsCategory,
-			Hidden:       true,
 			Action: func(c *cli.Context) error {
 				return terraformCmd(c)
 			},


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Now that Artifactory supports managing Terraform modues, this PR:
* Exposes the terraform commands in the embedded help.
* Sets the minimum Artifactory version for Terraform testing.  