### PR TITLE
Warn about no servers configured in cURL commands

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1851,6 +1851,9 @@ func newRtCurlCommand(c *cli.Context) (*curl.RtCurlCommand, error) {
 	if err != nil {
 		return nil, err
 	}
+	if rtDetails.ArtifactoryUrl == "" {
+		return nil, errorutils.CheckErrorf("No Artifactory servers configured. Use the 'jf c add' command to set the Artifactory server details.")
+	}
 	rtCurlCommand.SetServerDetails(rtDetails)
 	rtCurlCommand.SetUrl(rtDetails.ArtifactoryUrl)
 	return rtCurlCommand, err

--- a/xray/cli.go
+++ b/xray/cli.go
@@ -183,6 +183,9 @@ func newXrCurlCommand(c *cli.Context) (*curl.XrCurlCommand, error) {
 	if err != nil {
 		return nil, err
 	}
+	if xrDetails.XrayUrl == "" {
+		return nil, errorutils.CheckErrorf("No Xray servers configured. Use the 'jf c add' command to set the Xray server details.")
+	}
 	xrCurlCommand.SetServerDetails(xrDetails)
 	xrCurlCommand.SetUrl(xrDetails.XrayUrl)
 	return xrCurlCommand, err


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Resolves #1538 