### PR TITLE
Fix: plugins test fails for windows

### DIFF
--- a/plugins_test.go
+++ b/plugins_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -305,7 +306,7 @@ func verifyPluginExistsInRegistry(t *testing.T, checkResources bool) error {
 		assert.NoError(t, err)
 		return err
 	}
-	expectedPath := filepath.Join(utils.GetPluginDirPath(customPluginName, cliutils.GetVersion(), localArc), pluginsutils.GetLocalPluginExecutableName(customPluginName))
+	expectedPath := path.Join(utils.GetPluginDirPath(customPluginName, cliutils.GetVersion(), localArc), pluginsutils.GetLocalPluginExecutableName(customPluginName))
 	// Expected to find the plugin in the version and latest dir.
 	expected := []string{
 		expectedPath,
@@ -313,7 +314,7 @@ func verifyPluginExistsInRegistry(t *testing.T, checkResources bool) error {
 	}
 	// Add resources to expected paths if needed
 	if checkResources {
-		expectedPath = filepath.Join(utils.GetPluginDirPath(customPluginName, cliutils.GetVersion(), localArc), coreutils.PluginsResourcesDirName+".zip")
+		expectedPath = path.Join(utils.GetPluginDirPath(customPluginName, cliutils.GetVersion(), localArc), coreutils.PluginsResourcesDirName+".zip")
 		expected = append(expected, expectedPath, strings.Replace(expectedPath, cliutils.GetVersion(), utils.LatestVersionName, 1))
 	}
 	verifyExistInArtifactory(expected, searchFilePath, t)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Fix test "TestPublishInstallCustomServer".
Change backslash to slash for path comparison.