### PR TITLE
Duplicate build-info's artifacts are counted by their paths instead of their names

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -1790,6 +1790,26 @@ func TestArtifactoryDeletePropertiesWithExclusions(t *testing.T) {
 	cleanArtifactoryTest()
 }
 
+func TestArtifactoryUploadOneArtifactToMultipleLocation(t *testing.T) {
+	initArtifactoryTest(t, "")
+	buildNumber := "333"
+	runRt(t, "upload", "testdata/a/a1.in", tests.RtRepo1, "--build-name="+tests.RtBuildName1, "--build-number="+buildNumber)
+	runRt(t, "upload", "testdata/a/a1.in", tests.RtRepo1+"/root/", "--build-name="+tests.RtBuildName1, "--build-number="+buildNumber)
+	// Publish buildInfo
+	runRt(t, "build-publish", tests.RtBuildName1, buildNumber)
+	publishedBuildInfo, found, err := tests.GetBuildInfo(serverDetails, tests.RtBuildName1, buildNumber)
+	if err != nil {
+		assert.NoError(t, err)
+		return
+	}
+	if !found {
+		assert.True(t, found, "build info was expected to be found")
+		return
+	}
+	assert.Equal(t, 2, len(publishedBuildInfo.BuildInfo.Modules[0].Artifacts))
+	cleanArtifactoryTest()
+}
+
 func TestArtifactoryUploadFromHomeDir(t *testing.T) {
 	initArtifactoryTest(t, "")
 	testFileRel, testFileAbs := createFileInHomeDir(t, "cliTestFile.txt")

--- a/go.mod
+++ b/go.mod
@@ -91,8 +91,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
 
-// replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.2.7-0.20220524180534-919432fc5785
+replace github.com/jfrog/jfrog-client-go => github.com/Or-Geva/jfrog-client-go v0.5.1-0.20220606060109-827e009fefd9
 
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.13.2-0.20220526210458-b2f3881d8e25
+replace github.com/jfrog/build-info-go => github.com/Or-Geva/build-info-go v0.1.7-0.20220601133811-f65f58cd8e91
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => /Users/eyalb/dev/forks/jfrog-cli-core
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/Or-Geva/jfrog-cli-core/v2 v2.0.0-20220606060434-edcb477fbcb0

--- a/go.mod
+++ b/go.mod
@@ -91,8 +91,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/Or-Geva/jfrog-client-go v0.5.1-0.20220606060109-827e009fefd9
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.13.2-0.20220606063419-74332a39e430
 
-replace github.com/jfrog/build-info-go => github.com/Or-Geva/build-info-go v0.1.7-0.20220601133811-f65f58cd8e91
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.2.7-0.20220606063153-46b4aaf4d455
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/Or-Geva/jfrog-cli-core/v2 v2.0.0-20220606060434-edcb477fbcb0
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.15.3-0.20220606064015-b5073f9a4db9

--- a/go.sum
+++ b/go.sum
@@ -55,12 +55,6 @@ github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugX
 github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXGjwU=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Or-Geva/build-info-go v0.1.7-0.20220601133811-f65f58cd8e91 h1:fNcbY4X2EX1xXvjfx36ZtDkT4z2rHNEQsFsauMT++X4=
-github.com/Or-Geva/build-info-go v0.1.7-0.20220601133811-f65f58cd8e91/go.mod h1:/o44xAZfSGbMRWSG1SwmtqcZ9g4a5H8wQMsgjahFiSs=
-github.com/Or-Geva/jfrog-cli-core/v2 v2.0.0-20220606060434-edcb477fbcb0 h1:PgRiJjTYkOWHW1BWs1gMOd4VL/cNlMTffGqEI5gsZcw=
-github.com/Or-Geva/jfrog-cli-core/v2 v2.0.0-20220606060434-edcb477fbcb0/go.mod h1:Eia3HlDjMjWW0UzeArFlyvN5oo+CMlaGnxFnHA2Gxbg=
-github.com/Or-Geva/jfrog-client-go v0.5.1-0.20220606060109-827e009fefd9 h1:XX9ce3NqircPUoiWh+tvveFXDbb9s6WiklhUSpXXhYY=
-github.com/Or-Geva/jfrog-client-go v0.5.1-0.20220606060109-827e009fefd9/go.mod h1:gjVBz+ARIJ0OaveFeT5ZYShVnY4rXaR1N6p4R6AXE7A=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
@@ -298,8 +292,14 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jedib0t/go-pretty/v6 v6.3.0 h1:QQ5yZPDUMEjbZRXDJtZlvwfDQqCYFaxV3yEzTkogUgk=
 github.com/jedib0t/go-pretty/v6 v6.3.0/go.mod h1:FMkOpgGD3EZ91cW8g/96RfxoV7bdeJyzXPYgz1L1ln0=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jfrog/build-info-go v1.2.7-0.20220606063153-46b4aaf4d455 h1:lFljvDsHgkaoQ35ZOGAjH6Q1ywCIccwMelrm5QvtloU=
+github.com/jfrog/build-info-go v1.2.7-0.20220606063153-46b4aaf4d455/go.mod h1:/o44xAZfSGbMRWSG1SwmtqcZ9g4a5H8wQMsgjahFiSs=
 github.com/jfrog/gofrog v1.1.1 h1:uRjeZWidQl4FmKP4Zpj5hSKJp3gSIWW9VUwbQdVEVRU=
 github.com/jfrog/gofrog v1.1.1/go.mod h1:9YN5v4LlsCfLIXpwQnzSf1wVtgjdHM20FzuIu58RMI4=
+github.com/jfrog/jfrog-cli-core/v2 v2.15.3-0.20220606064015-b5073f9a4db9 h1:TPER7CDWm3k86nNZOYUh8UOkU3KzLV8amddvPEVSmWg=
+github.com/jfrog/jfrog-cli-core/v2 v2.15.3-0.20220606064015-b5073f9a4db9/go.mod h1:AYhQTokJ4oIREyyzC15gpYWxZzs3mSaK3FzgX+NVF/8=
+github.com/jfrog/jfrog-client-go v1.13.2-0.20220606063419-74332a39e430 h1:YkncPri11Q1OzHdwqKMppj9+zmeO4//m1O2dXv0rg7M=
+github.com/jfrog/jfrog-client-go v1.13.2-0.20220606063419-74332a39e430/go.mod h1:YMQg8b69lyNOxqHyRqnKloWr2nbi6fy2H7BMe3wue/0=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,12 @@ github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugX
 github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXGjwU=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/Or-Geva/build-info-go v0.1.7-0.20220601133811-f65f58cd8e91 h1:fNcbY4X2EX1xXvjfx36ZtDkT4z2rHNEQsFsauMT++X4=
+github.com/Or-Geva/build-info-go v0.1.7-0.20220601133811-f65f58cd8e91/go.mod h1:/o44xAZfSGbMRWSG1SwmtqcZ9g4a5H8wQMsgjahFiSs=
+github.com/Or-Geva/jfrog-cli-core/v2 v2.0.0-20220606060434-edcb477fbcb0 h1:PgRiJjTYkOWHW1BWs1gMOd4VL/cNlMTffGqEI5gsZcw=
+github.com/Or-Geva/jfrog-cli-core/v2 v2.0.0-20220606060434-edcb477fbcb0/go.mod h1:Eia3HlDjMjWW0UzeArFlyvN5oo+CMlaGnxFnHA2Gxbg=
+github.com/Or-Geva/jfrog-client-go v0.5.1-0.20220606060109-827e009fefd9 h1:XX9ce3NqircPUoiWh+tvveFXDbb9s6WiklhUSpXXhYY=
+github.com/Or-Geva/jfrog-client-go v0.5.1-0.20220606060109-827e009fefd9/go.mod h1:gjVBz+ARIJ0OaveFeT5ZYShVnY4rXaR1N6p4R6AXE7A=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
@@ -292,14 +298,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jedib0t/go-pretty/v6 v6.3.0 h1:QQ5yZPDUMEjbZRXDJtZlvwfDQqCYFaxV3yEzTkogUgk=
 github.com/jedib0t/go-pretty/v6 v6.3.0/go.mod h1:FMkOpgGD3EZ91cW8g/96RfxoV7bdeJyzXPYgz1L1ln0=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/build-info-go v1.2.6 h1:Ul1bQ8bv7hZdIZ4w0fysXHnZNABbYz8boKvA8OnBNR0=
-github.com/jfrog/build-info-go v1.2.6/go.mod h1:/o44xAZfSGbMRWSG1SwmtqcZ9g4a5H8wQMsgjahFiSs=
 github.com/jfrog/gofrog v1.1.1 h1:uRjeZWidQl4FmKP4Zpj5hSKJp3gSIWW9VUwbQdVEVRU=
 github.com/jfrog/gofrog v1.1.1/go.mod h1:9YN5v4LlsCfLIXpwQnzSf1wVtgjdHM20FzuIu58RMI4=
-github.com/jfrog/jfrog-cli-core/v2 v2.15.2 h1:AjarJJzHQBUfZTq7BVFDmrdfdwL/bW+4sW3csHHM6bY=
-github.com/jfrog/jfrog-cli-core/v2 v2.15.2/go.mod h1:l4KSAJLflqaYV3FKXdZCML9tFlrElO+S23K43W6FyxU=
-github.com/jfrog/jfrog-client-go v1.13.1 h1:6f1Y9+VHcE6uod4jbEU6Q29ro22Or0tYSGzUa6TTHLs=
-github.com/jfrog/jfrog-client-go v1.13.1/go.mod h1:97A832qf/UzPKG3ZpxzOSycyiLWiTBw6uEGZ4pyfL18=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Depends on: 
* https://github.com/jfrog/build-info-go/pull/85
* https://github.com/jfrog/jfrog-client-go/pull/594
* https://github.com/jfrog/jfrog-cli-core/pull/406
