### PR TITLE
Remove redundant git test that moved to client

### DIFF
--- a/buildinfo_test.go
+++ b/buildinfo_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/jfrog/jfrog-cli/utils/tests"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
 	rtutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
-	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -734,38 +733,6 @@ func cleanBuildAddGitTest(t *testing.T, baseDir, originalFolder, oldHomeDir, dot
 	coretests.RenamePath(dotGitPath, filepath.Join(baseDir, originalFolder), t)
 	inttestutils.DeleteBuild(serverDetails.ArtifactoryUrl, tests.RtBuildName1, artHttpDetails)
 	clientTestUtils.SetEnvAndAssert(t, coreutils.HomeDir, oldHomeDir)
-	cleanArtifactoryTest()
-}
-
-func TestReadGitConfig(t *testing.T) {
-	initArtifactoryTest(t, "")
-	dotGitPath := getCliDotGitPath(t)
-	gitManager := clientutils.NewGitManager(dotGitPath)
-	err := gitManager.ReadConfig()
-	assert.NoError(t, err, "Failed to read .git config file.")
-
-	workingDir, err := os.Getwd()
-	assert.NoError(t, err, "Failed to get current dir")
-	gitExecutor := tests.GitExecutor(workingDir)
-	revision, _, err := gitExecutor.GetRevision()
-	assert.NoError(t, err)
-	assert.Equal(t, revision, gitManager.GetRevision(), "Wrong revision")
-
-	url, _, err := gitExecutor.GetUrl()
-	assert.NoError(t, err)
-	if !strings.HasSuffix(url, ".git") {
-		url += ".git"
-	}
-	assert.Equal(t, url, gitManager.GetUrl(), "Wrong url")
-
-	branch, _, err := gitExecutor.GetBranch()
-	assert.NoError(t, err)
-	assert.Equal(t, branch, gitManager.GetBranch(), "Wrong branch")
-
-	message, _, err := gitExecutor.GetMessage(revision)
-	assert.NoError(t, err)
-	assert.Equal(t, message, gitManager.GetMessage(), "Wrong message")
-
 	cleanArtifactoryTest()
 }
 

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -283,42 +282,6 @@ func (cli *JfrogCli) LegacyBuildToolExec(args ...string) error {
 
 func (cli *JfrogCli) WithoutCredentials() *JfrogCli {
 	return &JfrogCli{cli.main, cli.prefix, ""}
-}
-
-type gitManager struct {
-	dotGitPath string
-}
-
-func GitExecutor(dotGitPath string) *gitManager {
-	return &gitManager{dotGitPath: dotGitPath}
-}
-
-func (m *gitManager) GetUrl() (string, string, error) {
-	return m.execGit("config", "--get", "remote.origin.url")
-}
-
-func (m *gitManager) GetRevision() (string, string, error) {
-	return m.execGit("show", "-s", "--format=%H", "HEAD")
-}
-
-func (m *gitManager) GetBranch() (string, string, error) {
-	return m.execGit("branch", "--show-current")
-}
-
-func (m *gitManager) GetMessage(revision string) (string, string, error) {
-	return m.execGit("show", "-s", "--format=%B", revision)
-}
-
-func (m *gitManager) execGit(args ...string) (string, string, error) {
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd := exec.Command("git", args...)
-	cmd.Dir = m.dotGitPath
-	cmd.Stdin = nil
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), errorutils.CheckError(err)
 }
 
 func DeleteFiles(deleteSpec *spec.SpecFiles, serverDetails *config.ServerDetails) (successCount, failCount int, err error) {


### PR DESCRIPTION
Signed-off-by: sverdlov93 <sverdlov93@gmail.com>

- [ ] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
