### PR TITLE
Add a tree view to artifacts deployment

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1320,6 +1320,10 @@ func uploadCmd(c *cli.Context) error {
 	// This error is being checked latter on because we need to generate summary report before return.
 	err = progressbar.ExecWithProgress(uploadCmd, false)
 	result := uploadCmd.Result()
+	output := result.Output()
+	if len(output) > 0 {
+		log.Info("These files were uploaded:\n", output)
+	}
 	err = cliutils.PrintDetailedSummaryReport(result.SuccessCount(), result.FailCount(), result.Reader(), true, cliutils.IsFailNoOp(c), err)
 
 	return cliutils.GetCliError(err, result.SuccessCount(), result.FailCount(), cliutils.IsFailNoOp(c))

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -3961,7 +3961,7 @@ func testFailNoOpSummaryReport(t *testing.T, failNoOp bool) {
 }
 
 func testSummaryReport(t *testing.T, argsMap map[string][]string, expected summaryExpected) {
-	buffer, previousLog := tests.RedirectLogOutputToBuffer()
+	buffer, _, previousLog := tests.RedirectLogOutputToBuffer()
 	// Restore previous logger when the function returns
 	defer log.SetLogger(previousLog)
 
@@ -4906,7 +4906,7 @@ func TestArtifactoryReplicationCreate(t *testing.T) {
 func TestAccessTokenCreate(t *testing.T) {
 	initArtifactoryTest(t, "")
 
-	buffer, previousLog := tests.RedirectLogOutputToBuffer()
+	buffer, _, previousLog := tests.RedirectLogOutputToBuffer()
 	// Restore previous logger when the function returns
 	defer log.SetLogger(previousLog)
 

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -3973,6 +3973,18 @@ func testSummaryReport(t *testing.T, argsMap map[string][]string, expected summa
 	cleanArtifactoryTest()
 }
 
+func TestUploadDeploymentView(t *testing.T) {
+	initArtifactoryTest(t, "")
+	assertPrintedDeploymentViewFunc, cleanupFunc := initDeploymentViewTest(t)
+	defer cleanupFunc()
+	uploadCmd := generic.NewUploadCommand()
+	fileSpec := spec.NewBuilder().Pattern(filepath.Join("testdata", "a", "a*.in")).Target(tests.RtRepo1).BuildSpec()
+	uploadCmd.SetUploadConfiguration(createUploadConfiguration()).SetSpec(fileSpec).SetServerDetails(serverDetails)
+	assert.NoError(t, artifactoryCli.Exec("upload", filepath.Join("testdata", "a", "a*.in"), tests.RtRepo1))
+	assertPrintedDeploymentViewFunc()
+	cleanArtifactoryTest()
+}
+
 func TestUploadDetailedSummary(t *testing.T) {
 	initArtifactoryTest(t, "")
 	uploadCmd := generic.NewUploadCommand()

--- a/buildinfo_test.go
+++ b/buildinfo_test.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/jfrog/jfrog-cli-core/v2/artifactory/formats"
-	clientTestUtils "github.com/jfrog/jfrog-client-go/utils/tests"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/jfrog/jfrog-cli-core/v2/artifactory/formats"
+	clientTestUtils "github.com/jfrog/jfrog-client-go/utils/tests"
 
 	buildinfo "github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/jfrog-cli-core/v2/common/spec"
@@ -201,7 +202,7 @@ func TestBuildPublishDetailedSummary(t *testing.T) {
 	// Verify build dir is not empty
 	assert.NotEmpty(t, getFilesFromBuildDir(t, tests.RtBuildName1, buildNumber, ""))
 
-	buffer, previousLog := tests.RedirectLogOutputToBuffer()
+	buffer, _, previousLog := tests.RedirectLogOutputToBuffer()
 	// Restore previous logger when the function returns
 	defer log.SetLogger(previousLog)
 	// Execute the bp command with --detailed-summary.
@@ -226,7 +227,7 @@ func TestBuildPublishDryRun(t *testing.T) {
 	// Verify build dir is not empty
 	assert.NotEmpty(t, getFilesFromBuildDir(t, tests.RtBuildName1, buildNumber, ""))
 
-	buffer, previousLog := tests.RedirectLogOutputToBuffer()
+	buffer, _, previousLog := tests.RedirectLogOutputToBuffer()
 	// Restore previous logger when the function returns
 	defer log.SetLogger(previousLog)
 

--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -635,6 +635,10 @@ func GoPublishCmd(c *cli.Context) error {
 	goPublishCmd.SetConfigFilePath(configFilePath).SetBuildConfiguration(buildConfiguration).SetVersion(version).SetDetailedSummary(c.Bool("detailed-summary"))
 	err = commands.Exec(goPublishCmd)
 	result := goPublishCmd.Result()
+	output := result.Output()
+	if len(output) > 0 {
+		log.Info("These files were uploaded:\n", output)
+	}
 	return cliutils.PrintDetailedSummaryReport(result.SuccessCount(), result.FailCount(), result.Reader(), true, false, err)
 }
 

--- a/distribution_test.go
+++ b/distribution_test.go
@@ -486,7 +486,7 @@ func TestReleaseBundleCreateDetailedSummary(t *testing.T) {
 	assert.NoError(t, err)
 	runRt(t, "u", "--spec="+specFile)
 
-	buffer, previousLog := tests.RedirectLogOutputToBuffer()
+	buffer, _, previousLog := tests.RedirectLogOutputToBuffer()
 	// Restore previous logger when the function returns
 	defer log.SetLogger(previousLog)
 
@@ -508,7 +508,7 @@ func TestReleaseBundleUpdateDetailedSummary(t *testing.T) {
 	assert.NoError(t, err)
 	runRt(t, "u", "--spec="+specFile)
 
-	buffer, previousLog := tests.RedirectLogOutputToBuffer()
+	buffer, _, previousLog := tests.RedirectLogOutputToBuffer()
 	// Restore previous logger when the function returns
 	defer log.SetLogger(previousLog)
 
@@ -533,7 +533,7 @@ func TestReleaseBundleSignDetailedSummary(t *testing.T) {
 	assert.NoError(t, err)
 	runRt(t, "u", "--spec="+specFile)
 
-	buffer, previousLog := tests.RedirectLogOutputToBuffer()
+	buffer, _, previousLog := tests.RedirectLogOutputToBuffer()
 	// Restore previous logger when the function returns
 	defer log.SetLogger(previousLog)
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -147,6 +147,12 @@ func TestContainerPushWithDetailedSummary(t *testing.T) {
 
 			imagePath := path.Join(repo, imageName, "1") + "/"
 			validateContainerBuild(tests.DockerBuildName, buildNumber, imagePath, module, 7, 5, 7, t)
+
+			// Check deployment view
+			assertPrintedDeploymentViewFunc, cleanupFunc := initDeploymentViewTest(t)
+			defer cleanupFunc()
+			runRt(t, containerManager.String()+"-push", pushCommand.ImageTag(), *tests.DockerLocalRepo)
+			assertPrintedDeploymentViewFunc()
 			inttestutils.ContainerTestCleanup(t, serverDetails, artHttpDetails, imageName, tests.DockerBuildName, repo)
 		}
 	}

--- a/general/cisetup/cisetup.go
+++ b/general/cisetup/cisetup.go
@@ -108,7 +108,7 @@ func inactivePipelinesNote(pipelinesUrl string) error {
 }
 
 func colorTitle(title string) string {
-	if coreutils.IsTerminal() {
+	if log.IsTerminal() {
 		return color.Green.Render(title)
 	}
 	return title

--- a/go.mod
+++ b/go.mod
@@ -91,8 +91,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/or-geva/jfrog-client-go v0.5.1-0.20220619105935-47f38895f35e
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.14.1-0.20220619153115-264f3959811e
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.3.0
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220619110105-bd7294f41e3b
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.16.1-0.20220619154615-81b18287b8f8

--- a/go.mod
+++ b/go.mod
@@ -91,8 +91,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/or-geva/jfrog-client-go v0.5.1-0.20220616063331-950e017e0237
+replace github.com/jfrog/jfrog-client-go => github.com/or-geva/jfrog-client-go v0.5.1-0.20220619105935-47f38895f35e
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.3.0
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220616065226-742c7cbd00ba
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220619110105-bd7294f41e3b

--- a/go.mod
+++ b/go.mod
@@ -91,8 +91,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
 
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.13.2-0.20220607094927-52dc3f597671
+replace github.com/jfrog/jfrog-client-go => github.com/or-geva/jfrog-client-go v0.5.1-0.20220613124109-11348618fafe
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.3.0
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.16.1-0.20220616140011-e1c3549a7543
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220613132135-5fab62917c34

--- a/go.mod
+++ b/go.mod
@@ -91,8 +91,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/or-geva/jfrog-client-go v0.5.1-0.20220613124109-11348618fafe
+replace github.com/jfrog/jfrog-client-go => github.com/or-geva/jfrog-client-go v0.5.1-0.20220616063331-950e017e0237
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.3.0
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220613164849-11af996437a2
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220616065226-742c7cbd00ba

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/urfave/cli v1.22.5
 	github.com/vbauerster/mpb/v7 v7.4.1
 	github.com/xeipuuv/gojsonschema v1.2.0
-	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -95,4 +95,4 @@ replace github.com/jfrog/jfrog-client-go => github.com/or-geva/jfrog-client-go v
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.3.0
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220613132135-5fab62917c34
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220613164849-11af996437a2

--- a/go.sum
+++ b/go.sum
@@ -385,10 +385,10 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
-github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220613164849-11af996437a2 h1:Oa+IzGObw0l/DW+bJp8tsC45vUWL9p0GGYTCBlfe8fs=
-github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220613164849-11af996437a2/go.mod h1:JSFhWbYSHMgTYBoksRPFteAQsSr0zikHp913Sp1gVPA=
-github.com/or-geva/jfrog-client-go v0.5.1-0.20220613124109-11348618fafe h1:2na3twGBlDDm27vmEdm6QgC7lY8+3oR2K2nniZBuJSE=
-github.com/or-geva/jfrog-client-go v0.5.1-0.20220613124109-11348618fafe/go.mod h1:IRxbnT/kVsTEpqAYNC9sZgKUrL4ekUYiqXFXhoLe0J4=
+github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220616065226-742c7cbd00ba h1:BOcfEE0ogL3/fHAENX7d3SjiqziWjrpFvPcfdBjdVCs=
+github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220616065226-742c7cbd00ba/go.mod h1:DFn/UtcDtygkn3d1qugDskiewMDiNOY5Pltn/9yGm6E=
+github.com/or-geva/jfrog-client-go v0.5.1-0.20220616063331-950e017e0237 h1:pCtRlo5Dbni5jN+S47S9KXAe7IzxP+pLHcCkZp3xiTE=
+github.com/or-geva/jfrog-client-go v0.5.1-0.20220616063331-950e017e0237/go.mod h1:IRxbnT/kVsTEpqAYNC9sZgKUrL4ekUYiqXFXhoLe0J4=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/go.sum
+++ b/go.sum
@@ -385,10 +385,10 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
-github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220616065226-742c7cbd00ba h1:BOcfEE0ogL3/fHAENX7d3SjiqziWjrpFvPcfdBjdVCs=
-github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220616065226-742c7cbd00ba/go.mod h1:DFn/UtcDtygkn3d1qugDskiewMDiNOY5Pltn/9yGm6E=
-github.com/or-geva/jfrog-client-go v0.5.1-0.20220616063331-950e017e0237 h1:pCtRlo5Dbni5jN+S47S9KXAe7IzxP+pLHcCkZp3xiTE=
-github.com/or-geva/jfrog-client-go v0.5.1-0.20220616063331-950e017e0237/go.mod h1:IRxbnT/kVsTEpqAYNC9sZgKUrL4ekUYiqXFXhoLe0J4=
+github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220619110105-bd7294f41e3b h1:LjQwGrh1AKjm+juybZyTBSuNz77HKdPW2QKP0K/Ffi4=
+github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220619110105-bd7294f41e3b/go.mod h1:MNxVj28kKfRAq+Xav7bimc7Kg0RQdZ7JOuJeJQCOrLE=
+github.com/or-geva/jfrog-client-go v0.5.1-0.20220619105935-47f38895f35e h1:5OpKrMu8oKgKd9F2DotdKLRd9T+d1pwEyYXGQrWwVBs=
+github.com/or-geva/jfrog-client-go v0.5.1-0.20220619105935-47f38895f35e/go.mod h1:q9/FAKgT/nDgaYodc5Fitc7HpuO5kVRU/KLIJ9To104=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/go.sum
+++ b/go.sum
@@ -296,6 +296,10 @@ github.com/jfrog/build-info-go v1.3.0 h1:0NutMPwG4qTCXyPhTCo7eGeot9cTT5A7d9LLCdD
 github.com/jfrog/build-info-go v1.3.0/go.mod h1:S2x0YOFBqBYp22goGRXGfy3ut7XaespgroVJpD6fPwk=
 github.com/jfrog/gofrog v1.1.2 h1:txts7zSFEGan3a8G+AJCrcq4a/z8PrCmZ7m6c7qaALg=
 github.com/jfrog/gofrog v1.1.2/go.mod h1:9YN5v4LlsCfLIXpwQnzSf1wVtgjdHM20FzuIu58RMI4=
+github.com/jfrog/jfrog-cli-core/v2 v2.16.1-0.20220619154615-81b18287b8f8 h1:4tB5TmNVZQNvCbn4Jo0FwWztQIH8Onj0yWh32k3Sstw=
+github.com/jfrog/jfrog-cli-core/v2 v2.16.1-0.20220619154615-81b18287b8f8/go.mod h1:BsouuFdWufw67mo+a9cAJcnR5ipUtYKoOHgZg7oWPi8=
+github.com/jfrog/jfrog-client-go v1.14.1-0.20220619153115-264f3959811e h1:CgUkpCOCxACfZxRRob/wR2aSXBj+lLNIfBpRJvWzUyU=
+github.com/jfrog/jfrog-client-go v1.14.1-0.20220619153115-264f3959811e/go.mod h1:q9/FAKgT/nDgaYodc5Fitc7HpuO5kVRU/KLIJ9To104=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -385,10 +389,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
-github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220619110105-bd7294f41e3b h1:LjQwGrh1AKjm+juybZyTBSuNz77HKdPW2QKP0K/Ffi4=
-github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220619110105-bd7294f41e3b/go.mod h1:MNxVj28kKfRAq+Xav7bimc7Kg0RQdZ7JOuJeJQCOrLE=
-github.com/or-geva/jfrog-client-go v0.5.1-0.20220619105935-47f38895f35e h1:5OpKrMu8oKgKd9F2DotdKLRd9T+d1pwEyYXGQrWwVBs=
-github.com/or-geva/jfrog-client-go v0.5.1-0.20220619105935-47f38895f35e/go.mod h1:q9/FAKgT/nDgaYodc5Fitc7HpuO5kVRU/KLIJ9To104=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
-github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220613132135-5fab62917c34 h1:RcxpYToYeqJ3Qx8VeKxPRxZl/XIOviCQR4zZ6s6sb8c=
-github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220613132135-5fab62917c34/go.mod h1:JSFhWbYSHMgTYBoksRPFteAQsSr0zikHp913Sp1gVPA=
+github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220613164849-11af996437a2 h1:Oa+IzGObw0l/DW+bJp8tsC45vUWL9p0GGYTCBlfe8fs=
+github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220613164849-11af996437a2/go.mod h1:JSFhWbYSHMgTYBoksRPFteAQsSr0zikHp913Sp1gVPA=
 github.com/or-geva/jfrog-client-go v0.5.1-0.20220613124109-11348618fafe h1:2na3twGBlDDm27vmEdm6QgC7lY8+3oR2K2nniZBuJSE=
 github.com/or-geva/jfrog-client-go v0.5.1-0.20220613124109-11348618fafe/go.mod h1:IRxbnT/kVsTEpqAYNC9sZgKUrL4ekUYiqXFXhoLe0J4=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/go.sum
+++ b/go.sum
@@ -296,10 +296,6 @@ github.com/jfrog/build-info-go v1.3.0 h1:0NutMPwG4qTCXyPhTCo7eGeot9cTT5A7d9LLCdD
 github.com/jfrog/build-info-go v1.3.0/go.mod h1:S2x0YOFBqBYp22goGRXGfy3ut7XaespgroVJpD6fPwk=
 github.com/jfrog/gofrog v1.1.2 h1:txts7zSFEGan3a8G+AJCrcq4a/z8PrCmZ7m6c7qaALg=
 github.com/jfrog/gofrog v1.1.2/go.mod h1:9YN5v4LlsCfLIXpwQnzSf1wVtgjdHM20FzuIu58RMI4=
-github.com/jfrog/jfrog-cli-core/v2 v2.16.1-0.20220616140011-e1c3549a7543 h1:60AxD60FC4dZynf2ZkcxLnDlzlyW1DtYGYG9yqpDsOY=
-github.com/jfrog/jfrog-cli-core/v2 v2.16.1-0.20220616140011-e1c3549a7543/go.mod h1:2E2H5hKqhu1FrBVSEM3upoUjpP+CYq9+ppwS2ViWgGo=
-github.com/jfrog/jfrog-client-go v1.14.0 h1:QA8K0DZbiVsTFYxHXy2Gfm/gYj+mqGhZYA5vf3ogwIs=
-github.com/jfrog/jfrog-client-go v1.14.0/go.mod h1:q9/FAKgT/nDgaYodc5Fitc7HpuO5kVRU/KLIJ9To104=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -389,6 +385,10 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
+github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220613132135-5fab62917c34 h1:RcxpYToYeqJ3Qx8VeKxPRxZl/XIOviCQR4zZ6s6sb8c=
+github.com/or-geva/jfrog-cli-core/v2 v2.0.0-20220613132135-5fab62917c34/go.mod h1:JSFhWbYSHMgTYBoksRPFteAQsSr0zikHp913Sp1gVPA=
+github.com/or-geva/jfrog-client-go v0.5.1-0.20220613124109-11348618fafe h1:2na3twGBlDDm27vmEdm6QgC7lY8+3oR2K2nniZBuJSE=
+github.com/or-geva/jfrog-client-go v0.5.1-0.20220613124109-11348618fafe/go.mod h1:IRxbnT/kVsTEpqAYNC9sZgKUrL4ekUYiqXFXhoLe0J4=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/go.sum
+++ b/go.sum
@@ -703,8 +703,9 @@ golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158 h1:rm+CHSpPEEW2IsXUib1ThaHIjuBVZjxNgSKmBLFfD4c=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go_test.go
+++ b/go_test.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	coretests "github.com/jfrog/jfrog-cli-core/v2/utils/tests"
-	clientTestUtils "github.com/jfrog/jfrog-client-go/utils/tests"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	coretests "github.com/jfrog/jfrog-cli-core/v2/utils/tests"
+	clientTestUtils "github.com/jfrog/jfrog-client-go/utils/tests"
 
 	buildinfo "github.com/jfrog/build-info-go/entities"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/golang"
@@ -176,6 +177,27 @@ func TestGoPublishWithDetailedSummary(t *testing.T) {
 	}
 	buildInfo := publishedBuildInfo.BuildInfo
 	validateBuildInfo(buildInfo, t, 4, 3, ModuleNameJFrogTest, buildinfo.Go)
+
+	// Restore workspace
+	clientTestUtils.ChangeDirAndAssert(t, wd)
+}
+
+func TestGoPublishWithDeploymentView(t *testing.T) {
+	_, goCleanupFunc := initGoTest(t)
+	defer goCleanupFunc()
+	assertPrintedDeploymentViewFunc, cleanupFunc := initDeploymentViewTest(t)
+	defer cleanupFunc()
+
+	wd, err := os.Getwd()
+	assert.NoError(t, err, "Failed to get current dir")
+	prepareGoProject("project1", "", t, true)
+	jfrogCli := tests.NewJfrogCli(execMain, "jf", "")
+	err = execGo(jfrogCli, "gp", "v1.1.1")
+	if err != nil {
+		assert.NoError(t, err)
+		return
+	}
+	assertPrintedDeploymentViewFunc()
 
 	// Restore workspace
 	clientTestUtils.ChangeDirAndAssert(t, wd)

--- a/main_test.go
+++ b/main_test.go
@@ -299,7 +299,7 @@ func TestSearchSimilarCmds(t *testing.T) {
 	}
 }
 
-// Prepare and return the tool to check if the deployment view was printed after any  command by redirect all the logs output into a buffer
+// Prepare and return the tool to check if the deployment view was printed after any command, by redirecting all the logs output into a buffer
 // Returns:
 // 1. assertDeploymentViewFunc - A function to check if the deployment view was printed to the screen after running jfrog cli command
 // 2. cleanup func to be run at the end of the test

--- a/main_test.go
+++ b/main_test.go
@@ -304,7 +304,7 @@ func TestSearchSimilarCmds(t *testing.T) {
 // 1. assertDeploymentViewFunc - A function to check if the deployment view was printed to the screen after running jfrog cli command
 // 2. cleanup func to be run at the end of the test
 func initDeploymentViewTest(t *testing.T) (assertDeploymentViewFunc func(), cleanupFunc func()) {
-	buffer, previousLog := tests.RedirectLogOutputToBuffer()
+	_, buffer, previousLog := tests.RedirectLogOutputToBuffer()
 	copyterminalMode := clientlog.TerminalMode
 	tmpTerminalMode := true
 	clientlog.TerminalMode = &tmpTerminalMode

--- a/maven_test.go
+++ b/maven_test.go
@@ -231,7 +231,7 @@ func runMavenAndValidateDeployedArtifacts(t *testing.T, shouldDeployArtifact boo
 }
 func TestMavenWithSummary(t *testing.T) {
 	testcases := []struct {
-		isdetailedSummary bool
+		isDetailedSummary bool
 		isDeploymentView  bool
 		expectedString    string
 		expectedError     error
@@ -251,7 +251,7 @@ func TestMavenWithSummary(t *testing.T) {
 	}()
 	for _, test := range testcases {
 		args := []string{"install"}
-		if test.isdetailedSummary {
+		if test.isDetailedSummary {
 			args = append(args, "--detailed-summary")
 		}
 
@@ -260,13 +260,13 @@ func TestMavenWithSummary(t *testing.T) {
 		output := buffer.Bytes()
 		buffer.Truncate(0)
 		assert.True(t, strings.Contains(string(output), test.expectedString), fmt.Sprintf("cant find '%s' in '%s'", test.expectedString, string(output)))
-		if test.isdetailedSummary {
+		if test.isDetailedSummary {
 			assert.False(t, strings.Contains(string(output), "These files were uploaded:"), fmt.Sprintf("found '%s' in '%s'", "These files were uploaded:", string(output)))
 		}
 	}
 	deleteDeployedArtifacts(t)
-
 }
+
 func deleteDeployedArtifacts(t *testing.T) {
 	deleteSpec := spec.NewBuilder().Pattern(tests.MvnRepo1).BuildSpec()
 	_, _, err := tests.DeleteFiles(deleteSpec, serverDetails)

--- a/maven_test.go
+++ b/maven_test.go
@@ -239,7 +239,7 @@ func TestMavenWithSummary(t *testing.T) {
 		{false, true, "These files were uploaded:", nil},
 	}
 	initMavenTest(t, false)
-	buffer, previousLog := tests.RedirectLogOutputToBuffer()
+	outputBuffer, stderrBuffer, previousLog := tests.RedirectLogOutputToBuffer()
 	copyterminalMode := clientlog.TerminalMode
 	tmpTerminalMode := true
 	clientlog.TerminalMode = &tmpTerminalMode
@@ -255,13 +255,15 @@ func TestMavenWithSummary(t *testing.T) {
 		}
 
 		assert.NoError(t, runMaven(t, createMultiMavenProject, tests.MavenIncludeExcludePatternsConfig, args...))
-
-		output := buffer.Bytes()
-		buffer.Truncate(0)
-		assert.True(t, strings.Contains(string(output), test.expectedString), fmt.Sprintf("cant find '%s' in '%s'", test.expectedString, string(output)))
+		var output []byte
 		if test.isDetailedSummary {
-			assert.False(t, strings.Contains(string(output), "These files were uploaded:"), fmt.Sprintf("found '%s' in '%s'", "These files were uploaded:", string(output)))
+			output = outputBuffer.Bytes()
+			outputBuffer.Truncate(0)
+		} else {
+			output = stderrBuffer.Bytes()
+			stderrBuffer.Truncate(0)
 		}
+		assert.True(t, strings.Contains(string(output), test.expectedString), fmt.Sprintf("cant find '%s' in '%s'", test.expectedString, string(output)))
 	}
 	deleteDeployedArtifacts(t)
 }

--- a/maven_test.go
+++ b/maven_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/jfrog/jfrog-cli/utils/tests/proxy/server/certificate"
-	"github.com/jfrog/jfrog-client-go/utils/log"
 	clientlog "github.com/jfrog/jfrog-client-go/utils/log"
 	clientTestUtils "github.com/jfrog/jfrog-client-go/utils/tests"
 
@@ -246,7 +245,7 @@ func TestMavenWithSummary(t *testing.T) {
 	clientlog.TerminalMode = &tmpTerminalMode
 	// Restore previous logger and terminal mode when the function returns
 	defer func() {
-		log.SetLogger(previousLog)
+		clientlog.SetLogger(previousLog)
 		clientlog.TerminalMode = copyterminalMode
 	}()
 	for _, test := range testcases {

--- a/npm_test.go
+++ b/npm_test.go
@@ -393,6 +393,22 @@ func TestNpmPublishDetailedSummary(t *testing.T) {
 	assert.Equal(t, 64, len(files[0].Sha256), "Summary validation failed - sha256 should be in size 64 digits.")
 }
 
+func TestNpmPublishWithDeploymentView(t *testing.T) {
+	initNpmTest(t)
+	defer cleanNpmTest(t)
+	wd, err := os.Getwd()
+	assert.NoError(t, err, "Failed to get current dir")
+	defer clientTestUtils.ChangeDirAndAssert(t, wd)
+	initNpmProjectTest(t)
+	assertPrintedDeploymentViewFunc, cleanupFunc := initDeploymentViewTest(t)
+	defer cleanupFunc()
+	runGenericNpm(t, "npm", "publish")
+	// Check deployment view
+	assertPrintedDeploymentViewFunc()
+	// Restore workspace
+	clientTestUtils.ChangeDirAndAssert(t, wd)
+}
+
 func TestNpmPackInstall(t *testing.T) {
 	initNpmTest(t)
 	defer cleanNpmTest(t)

--- a/npm_test.go
+++ b/npm_test.go
@@ -387,7 +387,7 @@ func TestNpmPublishDetailedSummary(t *testing.T) {
 	expectedSourcePath := npmProjectPath + tarballName
 	expectedTargetPath := serverDetails.ArtifactoryUrl + tests.NpmRepo + "/jfrog-cli-tests/-/" + tarballName
 	assert.Equal(t, expectedSourcePath, files[0].SourcePath, "Summary validation failed - unmatched SourcePath.")
-	assert.Equal(t, expectedTargetPath, files[0].TargetPath, "Summary validation failed - unmatched TargetPath.")
+	assert.Equal(t, expectedTargetPath, files[0].RtUrl+files[0].TargetPath, "Summary validation failed - unmatched TargetPath.")
 	assert.Equal(t, 1, len(files), "Summary validation failed - only one archive should be deployed.")
 	// Verify sha256 is valid (a string size 256 characters) and not an empty string.
 	assert.Equal(t, 64, len(files[0].Sha256), "Summary validation failed - sha256 should be in size 64 digits.")

--- a/utils/cliutils/testdata/reader/printcommandsummary.json
+++ b/utils/cliutils/testdata/reader/printcommandsummary.json
@@ -1,0 +1,58 @@
+{
+    "results": [
+        {
+            "sourcePath": "testdata/a/b/c/c1.in",
+            "targetPath": "generic-snapshot/testdata/a/b/c/c1.in",
+            "rtUrl": "https://127.0.0.1/artifactory/",
+            "sha256": "8b511ab4559d91c559e033d60888da1409b617db21491355386242577d651af4"
+        },
+        {
+            "sourcePath": "testdata/a/b/c/c2.in",
+            "targetPath": "generic-snapshot/testdata/a/b/c/c2.in",
+            "rtUrl": "https://127.0.0.1/artifactory/",
+            "sha256": "822505a4aa0e0ada22ae6b9a23ae88b46f718df7ca64fee629739396fdefb846"
+        },
+        {
+            "sourcePath": "testdata/a/b/c/c3.in",
+            "targetPath": "generic-snapshot/testdata/a/b/c/c3.in",
+            "rtUrl": "https://127.0.0.1/artifactory/",
+            "sha256": "69efd5b0596c22cd7629a96ee4fe061b3020cd9078e9e192235053ab1cbdc35d"
+        },
+        {
+            "sourcePath": "testdata/a/b/b2.in",
+            "targetPath": "generic-snapshot/testdata/a/b/b2.in",
+            "rtUrl": "https://127.0.0.1/artifactory/",
+            "sha256": "2f96053cc48504bca84360967659abc3c145a56a530f7679bc75d9b1a66182b2"
+        },
+        {
+            "sourcePath": "testdata/a/b/b3.in",
+            "targetPath": "generic-snapshot/testdata/a/b/b3.in",
+            "rtUrl": "https://127.0.0.1/artifactory/",
+            "sha256": "b04c0632c0f647ce07741c8a6cb5ad1d2da6e8047d0127bd4171e1201cf9bf7e"
+        },
+        {
+            "sourcePath": "testdata/a/b/b1.in",
+            "targetPath": "generic-snapshot/testdata/a/b/b1.in",
+            "rtUrl": "https://127.0.0.1/artifactory/",
+            "sha256": "b06c458f2aa21bd89e75e365bf5a9227c8b8d2b0728b1116d6738d214113def2"
+        },
+        {
+            "sourcePath": "testdata/a/a3.in",
+            "targetPath": "generic-snapshot/testdata/a/a3.in",
+            "rtUrl": "https://127.0.0.1/artifactory/",
+            "sha256": "14e3dc4749bf42df13a67a271065b0f334d0ad36bb34a74cc57c6e137f9af09e"
+        },
+        {
+            "sourcePath": "testdata/a/a2.in",
+            "targetPath": "generic-snapshot/testdata/a/a2.in",
+            "rtUrl": "https://127.0.0.1/artifactory/",
+            "sha256": "3e3deb6628658a48cf0d280a2210211f9d977ec2e10a4619b95d5fb85cb10450"
+        },
+        {
+            "sourcePath": "testdata/a/a1.in",
+            "targetPath": "generic-snapshot/testdata/a/a1.in",
+            "rtUrl": "https://127.0.0.1/artifactory/",
+            "sha256": "4eb341b5d2762a853d79cc25e622aa8b978eb6e12c3259e2d99dc9dc60d82c5d"
+        }
+    ]
+}

--- a/utils/cliutils/utils.go
+++ b/utils/cliutils/utils.go
@@ -114,10 +114,11 @@ func PrintBriefSummaryReport(success, failed int, failNoOp bool, originalErr err
 	return summaryPrintError(mErr, originalErr)
 }
 
+// Print a file tree based on the items' path in the reader's list.
 func PrintDeploymentView(reader *content.ContentReader) error {
 	tree := artifactoryUtils.NewFileTree()
 	for transferDetails := new(clientutils.FileTransferDetails); reader.NextRecord(transferDetails) == nil; transferDetails = new(clientutils.FileTransferDetails) {
-		tree.AddFile(strings.TrimLeft(transferDetails.TargetPath, transferDetails.RtUrl))
+		tree.AddFile(transferDetails.TargetPath)
 	}
 	if err := reader.GetError(); err != nil {
 		return err
@@ -125,7 +126,7 @@ func PrintDeploymentView(reader *content.ContentReader) error {
 	reader.Reset()
 	output := tree.String()
 	if len(output) > 0 {
-		log.Output("These files were uploaded:\n", output)
+		log.Info("These files were uploaded:\n\n" + output)
 	}
 	return nil
 }

--- a/utils/cliutils/utils_test.go
+++ b/utils/cliutils/utils_test.go
@@ -17,13 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type summaryExpected struct {
-	errors  bool
-	status  string
-	success int64
-	failure int64
-}
-
 func TestSplitAgentNameAndVersion(t *testing.T) {
 	tests := []struct {
 		fullAgentName        string

--- a/utils/cliutils/utils_test.go
+++ b/utils/cliutils/utils_test.go
@@ -1,9 +1,28 @@
 package cliutils
 
 import (
-	"github.com/stretchr/testify/assert"
+	"fmt"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	coretests "github.com/jfrog/jfrog-cli-core/v2/utils/tests"
+	"github.com/jfrog/jfrog-cli/utils/tests"
+	"github.com/pkg/errors"
+
+	commandUtils "github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/utils"
+	"github.com/jfrog/jfrog-client-go/utils/io/content"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+	"github.com/stretchr/testify/assert"
 )
+
+type summaryExpected struct {
+	errors  bool
+	status  string
+	success int64
+	failure int64
+}
 
 func TestSplitAgentNameAndVersion(t *testing.T) {
 	tests := []struct {
@@ -22,5 +41,49 @@ func TestSplitAgentNameAndVersion(t *testing.T) {
 		actualAgentName, actualAgentVersion := splitAgentNameAndVersion(test.fullAgentName)
 		assert.Equal(t, test.expectedAgentName, actualAgentName)
 		assert.Equal(t, test.expectedAgentVersion, actualAgentVersion)
+	}
+}
+func TestPrintCommandSummary(t *testing.T) {
+	buffer, previousLog := tests.RedirectLogOutputToBuffer()
+	// Restore previous logger when the function returns
+	defer log.SetLogger(previousLog)
+
+	result := &commandUtils.Result{}
+	result.SetSuccessCount(1)
+	result.SetFailCount(0)
+	teastdata := filepath.Join(tests.GetTestResourcesPath(), "reader", "printcommandsummary.json")
+	tmpDir, createTempDirCallback := coretests.CreateTempDirWithCallbackAndAssert(t)
+	defer createTempDirCallback()
+	err := fileutils.CopyFile(tmpDir, teastdata)
+	assert.NoError(t, err)
+
+	reader := content.NewContentReader(filepath.Join(tmpDir, "printcommandsummary.json"), content.DefaultKey)
+	result.SetReader(reader)
+	assert.NoError(t, err)
+	tests := []struct {
+		isDetailedSummary bool
+		isDeploymentView  bool
+		expectedString    string
+		expectedError     error
+	}{
+		{true, false, `"status": "success",`, nil},
+		{true, false, `"status": "failure",`, errors.New("test")},
+		{false, true, "These files were uploaded:", nil},
+		{false, true, `"status": "failure",`, errors.New("test")},
+	}
+	for _, test := range tests {
+		err = PrintCommandSummary(result, test.isDetailedSummary, test.isDeploymentView, false, test.expectedError)
+		if test.expectedError != nil {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+		output := buffer.Bytes()
+		buffer.Truncate(0)
+		assert.True(t, strings.Contains(string(output), test.expectedString), fmt.Sprintf("cant find '%s' in '%s'", test.expectedString, string(output)))
+		if test.isDetailedSummary {
+			// Make sure the deployment view is not printed
+			assert.False(t, strings.Contains(string(output), "These files were uploaded:"), fmt.Sprintf("cant find '%s' in '%s'", "These files were uploaded:", string(output)))
+		}
 	}
 }

--- a/utils/cliutils/utils_test.go
+++ b/utils/cliutils/utils_test.go
@@ -43,6 +43,7 @@ func TestSplitAgentNameAndVersion(t *testing.T) {
 		assert.Equal(t, test.expectedAgentVersion, actualAgentVersion)
 	}
 }
+
 func TestPrintCommandSummary(t *testing.T) {
 	buffer, previousLog := tests.RedirectLogOutputToBuffer()
 	// Restore previous logger when the function returns

--- a/utils/progressbar/progressbar.go
+++ b/utils/progressbar/progressbar.go
@@ -37,7 +37,7 @@ var ShouldInitProgressBar = func() (bool, error) {
 	if ci || err != nil {
 		return false, err
 	}
-	if !isTerminal() {
+	if !log.IsTerminal() {
 		return false, err
 	}
 	err = setTerminalWidthVar()
@@ -282,11 +282,6 @@ func InitProgressBarIfPossible(printLogPath bool) (ioUtils.ProgressMgr, error) {
 	newProgressBar.logFile = logFile
 
 	return newProgressBar, nil
-}
-
-// Check if Stderr is a terminal
-func isTerminal() bool {
-	return term.IsTerminal(int(os.Stderr.Fd()))
 }
 
 // Get terminal dimensions

--- a/utils/tests/consts.go
+++ b/utils/tests/consts.go
@@ -1809,9 +1809,9 @@ func GetFileWithDownloadedPlaceHolderSlashSuffix() []string {
 func GetExpectedUploadSummaryDetails(RtUrl string) []clientutils.FileTransferDetails {
 	path1, path2, path3 := filepath.Join("testdata", "a", "a1.in"), filepath.Join("testdata", "a", "a2.in"), filepath.Join("testdata", "a", "a3.in")
 	return []clientutils.FileTransferDetails{
-		{SourcePath: path1, TargetPath: RtUrl + RtRepo1 + "/testdata/a/a1.in", Sha256: "4eb341b5d2762a853d79cc25e622aa8b978eb6e12c3259e2d99dc9dc60d82c5d"},
-		{SourcePath: path2, TargetPath: RtUrl + RtRepo1 + "/testdata/a/a2.in", Sha256: "3e3deb6628658a48cf0d280a2210211f9d977ec2e10a4619b95d5fb85cb10450"},
-		{SourcePath: path3, TargetPath: RtUrl + RtRepo1 + "/testdata/a/a3.in", Sha256: "14e3dc4749bf42df13a67a271065b0f334d0ad36bb34a74cc57c6e137f9af09e"},
+		{SourcePath: path1, RtUrl: RtUrl, TargetPath: RtRepo1 + "/testdata/a/a1.in", Sha256: "4eb341b5d2762a853d79cc25e622aa8b978eb6e12c3259e2d99dc9dc60d82c5d"},
+		{SourcePath: path2, RtUrl: RtUrl, TargetPath: RtRepo1 + "/testdata/a/a2.in", Sha256: "3e3deb6628658a48cf0d280a2210211f9d977ec2e10a4619b95d5fb85cb10450"},
+		{SourcePath: path3, RtUrl: RtUrl, TargetPath: RtRepo1 + "/testdata/a/a3.in", Sha256: "14e3dc4749bf42df13a67a271065b0f334d0ad36bb34a74cc57c6e137f9af09e"},
 	}
 }
 

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -649,6 +649,7 @@ func RedirectLogOutputToBuffer() (buffer *bytes.Buffer, previousLog log.Log) {
 	newLog := log.NewLogger(corelog.GetCliLogLevel(), nil)
 	buffer = &bytes.Buffer{}
 	newLog.SetOutputWriter(buffer)
+	newLog.SetLogsWriter(buffer, 0)
 	log.SetLogger(newLog)
 	return buffer, previousLog
 }

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -644,14 +644,14 @@ func CleanUpOldItems(baseItemNames []string, getActualItems func() ([]string, er
 
 // Set new logger with output redirection to a buffer.
 // Caller is responsible to set the old log back.
-func RedirectLogOutputToBuffer() (buffer *bytes.Buffer, previousLog log.Log) {
+func RedirectLogOutputToBuffer() (outputBuffer, stderrBuffer *bytes.Buffer, previousLog log.Log) {
+	stderrBuffer, outputBuffer = &bytes.Buffer{}, &bytes.Buffer{}
 	previousLog = log.Logger
 	newLog := log.NewLogger(corelog.GetCliLogLevel(), nil)
-	buffer = &bytes.Buffer{}
-	newLog.SetOutputWriter(buffer)
-	newLog.SetLogsWriter(buffer, 0)
+	newLog.SetOutputWriter(outputBuffer)
+	newLog.SetLogsWriter(stderrBuffer, 0)
 	log.SetLogger(newLog)
-	return buffer, previousLog
+	return outputBuffer, stderrBuffer, previousLog
 }
 
 // Redirect stdout to new temp, os.pipe


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Create a tree view for artifacts deployment for upload, docker push, npm publish, maven, Gradle, and go publish commands.
The tree view is visible if the flag *--detailed-summary* is not specified in each command.


![image](https://user-images.githubusercontent.com/9606235/173523982-0e27495c-5669-4e61-a014-bc7e8542e7d6.png)


Depends on:
* https://github.com/jfrog/jfrog-cli-core/pull/411
* https://github.com/jfrog/jfrog-client-go/pull/597
