### PR TITLE
Adding support for rescan flag on build-scan

### DIFF
--- a/scan/cli.go
+++ b/scan/cli.go
@@ -329,8 +329,14 @@ func BuildScan(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	buildScanCmd := scan.NewBuildScanCommand().SetServerDetails(serverDetails).SetFailBuild(c.BoolT("fail")).SetBuildConfiguration(buildConfiguration).
-		SetIncludeVulnerabilities(c.Bool("vuln")).SetOutputFormat(format).SetPrintExtendedTable(c.Bool(cliutils.ExtendedTable))
+	buildScanCmd := scan.NewBuildScanCommand().
+		SetServerDetails(serverDetails).
+		SetFailBuild(c.BoolT("fail")).
+		SetBuildConfiguration(buildConfiguration).
+		SetIncludeVulnerabilities(c.Bool("vuln")).
+		SetOutputFormat(format).
+		SetPrintExtendedTable(c.Bool(cliutils.ExtendedTable)).
+		SetRescan(c.Bool("rescan"))
 	return commands.Exec(buildScanCmd)
 }
 

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -263,7 +263,8 @@ const (
 	configFlag = "config"
 
 	// Unique build-scan flags
-	fail = "fail"
+	fail   = "fail"
+	rescan = "rescan"
 
 	// Unique build-promote flags
 	buildPromotePrefix  = "bpr-"
@@ -1223,6 +1224,10 @@ var flagsMap = map[string]cli.Flag{
 		Name:  Go,
 		Usage: "[Optional] Request audit for a Go project.` `",
 	},
+	rescan: cli.BoolFlag{
+		Name:  rescan,
+		Usage: "[Optional] Set to true when scanning an already successfully scanned build, for example after adding an ignore rule.",
+	},
 
 	// Mission Control's commands Flags
 	mcUrl: cli.StringFlag{
@@ -1595,7 +1600,7 @@ var commandFlags = map[string][]string{
 		serverId, project, watches, repoPath, licenses, xrOutput, fail, ExtendedTable,
 	},
 	BuildScan: {
-		xrUrl, user, password, accessToken, serverId, project, vuln, xrOutput, fail, ExtendedTable,
+		xrUrl, user, password, accessToken, serverId, project, vuln, xrOutput, fail, ExtendedTable, rescan,
 	},
 	// Mission Control's commands
 	McConfig: {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
