### PR TITLE
Hide deprecated audit-<tech> commands from help and auto-complete.

### DIFF
--- a/scan/cli.go
+++ b/scan/cli.go
@@ -55,6 +55,7 @@ func GetCommands() []cli.Command {
 			ArgsUsage:    common.CreateEnvVars(),
 			BashComplete: corecommondocs.CreateBashCompletionFunc(),
 			Action:       AuditMvnCmd,
+			Hidden:       true,
 		},
 		{
 			Name:         "audit-gradle",
@@ -66,6 +67,7 @@ func GetCommands() []cli.Command {
 			ArgsUsage:    common.CreateEnvVars(),
 			BashComplete: corecommondocs.CreateBashCompletionFunc(),
 			Action:       AuditGradleCmd,
+			Hidden:       true,
 		},
 		{
 			Name:         "audit-npm",
@@ -77,6 +79,7 @@ func GetCommands() []cli.Command {
 			ArgsUsage:    common.CreateEnvVars(),
 			BashComplete: corecommondocs.CreateBashCompletionFunc(),
 			Action:       AuditNpmCmd,
+			Hidden:       true,
 		},
 		{
 			Name:         "audit-go",
@@ -88,6 +91,7 @@ func GetCommands() []cli.Command {
 			ArgsUsage:    common.CreateEnvVars(),
 			BashComplete: corecommondocs.CreateBashCompletionFunc(),
 			Action:       AuditGoCmd,
+			Hidden:       true,
 		},
 		{
 			Name:         "audit-pip",
@@ -99,6 +103,7 @@ func GetCommands() []cli.Command {
 			ArgsUsage:    common.CreateEnvVars(),
 			BashComplete: corecommondocs.CreateBashCompletionFunc(),
 			Action:       AuditPipCmd,
+			Hidden:       true,
 		},
 		{
 			Name:         "audit-pipenv",
@@ -110,6 +115,7 @@ func GetCommands() []cli.Command {
 			ArgsUsage:    common.CreateEnvVars(),
 			BashComplete: corecommondocs.CreateBashCompletionFunc(),
 			Action:       AuditPipenvCmd,
+			Hidden:       true,
 		},
 		{
 			Name:         "scan",

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -1196,32 +1196,39 @@ var flagsMap = map[string]cli.Flag{
 		Usage: "[Default: table] Defines the output format of the command. Acceptable values are: table and json.` `",
 	},
 	Mvn: cli.BoolFlag{
-		Name:  Mvn,
-		Usage: "[Optional] Request audit for a Maven project.` `",
+		Name:   Mvn,
+		Usage:  "[Optional] Request audit for a Maven project.` `",
+		Hidden: true,
 	},
 	Gradle: cli.BoolFlag{
-		Name:  Gradle,
-		Usage: "[Optional] Request audit for a Gradle project.` `",
+		Name:   Gradle,
+		Usage:  "[Optional] Request audit for a Gradle project.` `",
+		Hidden: true,
 	},
 	Npm: cli.BoolFlag{
-		Name:  Npm,
-		Usage: "[Optional] Request audit for a npm project.` `",
+		Name:   Npm,
+		Usage:  "[Optional] Request audit for a npm project.` `",
+		Hidden: true,
 	},
 	Nuget: cli.BoolFlag{
-		Name:  Nuget,
-		Usage: "[Optional] Request audit for a .Net project.` `",
+		Name:   Nuget,
+		Usage:  "[Optional] Request audit for a .Net project.` `",
+		Hidden: true,
 	},
 	Pip: cli.BoolFlag{
-		Name:  Pip,
-		Usage: "[Optional] Request audit for a Pip project.` `",
+		Name:   Pip,
+		Usage:  "[Optional] Request audit for a Pip project.` `",
+		Hidden: true,
 	},
 	Pipenv: cli.BoolFlag{
-		Name:  Pipenv,
-		Usage: "[Optional] Request audit for a Pipenv project.` `",
+		Name:   Pipenv,
+		Usage:  "[Optional] Request audit for a Pipenv project.` `",
+		Hidden: true,
 	},
 	Go: cli.BoolFlag{
-		Name:  Go,
-		Usage: "[Optional] Request audit for a Go project.` `",
+		Name:   Go,
+		Usage:  "[Optional] Request audit for a Go project.` `",
+		Hidden: true,
 	},
 
 	// Mission Control's commands Flags


### PR DESCRIPTION
…re deprecated.

- [ ] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
Hide deprecated audit-<tech> commands from help and auto-complete.