### PR TITLE
Add a flag for auto-creation repos in Distribution

### DIFF
--- a/distribution/cli.go
+++ b/distribution/cli.go
@@ -232,7 +232,13 @@ func releaseBundleDistributeCmd(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	releaseBundleDistributeCmd.SetServerDetails(rtDetails).SetDistributeBundleParams(params).SetDistributionRules(distributionRules).SetDryRun(c.Bool("dry-run")).SetSync(c.Bool("sync")).SetMaxWaitMinutes(maxWaitMinutes)
+	releaseBundleDistributeCmd.SetServerDetails(rtDetails).
+		SetDistributeBundleParams(params).
+		SetDistributionRules(distributionRules).
+		SetDryRun(c.Bool("dry-run")).
+		SetSync(c.Bool("sync")).
+		SetMaxWaitMinutes(maxWaitMinutes).
+		SetCreateRepo(c.Bool("create-repo"))
 
 	return commands.Exec(releaseBundleDistributeCmd)
 }

--- a/distribution_test.go
+++ b/distribution_test.go
@@ -155,7 +155,7 @@ func TestBundleCreateByAql(t *testing.T) {
 	spec, err := tests.CreateSpec(tests.DistributionCreateByAql)
 	assert.NoError(t, err)
 	runDs(t, "rbc", tests.BundleName, bundleVersion, "--spec="+spec, "--sign")
-	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
+	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync", "--create-repo")
 
 	// Download by bundle version, b2 and b3 should not be downloaded, b1 should
 	specFile, err = tests.CreateSpec(tests.BundleDownloadSpec)
@@ -181,7 +181,7 @@ func TestBundleDownloadNoPattern(t *testing.T) {
 
 	// Create release bundle
 	runDs(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/b1.in", "--sign")
-	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
+	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync", "--create-repo")
 
 	// Download by bundle name and version with pattern "*", b2 and b3 should not be downloaded, b1 should
 	runRt(t, "dl", "*", "out/download/simple_by_build/data/", "--bundle="+tests.BundleName+"/"+bundleVersion, "--flat")
@@ -216,7 +216,7 @@ func TestBundleExclusions(t *testing.T) {
 
 	// Create release bundle. Include b1.in and b2.in. Exclude b3.in.
 	runDs(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/b*.in", "--sign", "--exclusions=*b3.in")
-	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
+	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync", "--create-repo")
 
 	// Download by bundle version, b2 and b3 should not be downloaded, b1 should
 	runRt(t, "dl", tests.DistRepo1+"/data/*", tests.Out+fileutils.GetFileSeparator()+"download"+fileutils.GetFileSeparator()+"simple_by_build"+fileutils.GetFileSeparator(), "--bundle="+tests.BundleName+"/"+bundleVersion, "--exclusions=*b2.in")
@@ -243,7 +243,7 @@ func TestBundleCopy(t *testing.T) {
 
 	// Create release bundle
 	runDs(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/a*", "--sign")
-	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
+	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync", "--create-repo")
 
 	// Copy by bundle name and version
 	specFile, err := tests.CreateSpec(tests.CopyByBundleSpec)
@@ -267,7 +267,7 @@ func TestBundleSetProperties(t *testing.T) {
 
 	// Create release bundle
 	runDs(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/a.in", "--sign")
-	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
+	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync", "--create-repo")
 
 	// Set the 'prop=red' property to the file.
 	runRt(t, "sp", tests.DistRepo1+"/a.*", "prop=red", "--bundle="+tests.BundleName+"/"+bundleVersion)
@@ -350,7 +350,7 @@ func TestUpdateReleaseBundle(t *testing.T) {
 	runDs(t, "rbu", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/b1.in", "--sign")
 
 	// Distribute release bundle
-	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
+	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync", "--create-repo")
 
 	// GPG validation for release bundle
 	keyPath := filepath.Join(tests.GetTestResourcesPath(), "distribution", "public.key.1")
@@ -408,7 +408,7 @@ func TestCreateBundleProps(t *testing.T) {
 	// Create and distribute release bundle with added props
 	runDs(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*", "--target-props=key1=val1;key2=val2,val3", "--sign")
 	inttestutils.VerifyLocalBundleExistence(t, tests.BundleName, bundleVersion, true, distHttpDetails)
-	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
+	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync", "--create-repo")
 
 	// Verify props are added to the distributes artifact
 	verifyExistInArtifactoryByProps(tests.GetBundlePropsExpected(), tests.DistRepo1+"/data/", "key1=val1;key2=val2;key2=val3", t)
@@ -428,7 +428,7 @@ func TestUpdateBundleProps(t *testing.T) {
 	runDs(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*")
 	runDs(t, "rbu", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/*", "--target-props=key1=val1", "--sign")
 	inttestutils.VerifyLocalBundleExistence(t, tests.BundleName, bundleVersion, true, distHttpDetails)
-	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
+	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync", "--create-repo")
 
 	// Verify props are added to the distributes artifact
 	verifyExistInArtifactoryByProps(tests.GetBundlePropsExpected(), tests.DistRepo1+"/data/", "key1=val1", t)
@@ -446,7 +446,7 @@ func TestBundlePathMapping(t *testing.T) {
 
 	// Create and distribute release bundle with path mapping from <DistRepo1>/data/ to <DistRepo2>/target/
 	runDs(t, "rbc", tests.BundleName, bundleVersion, tests.DistRepo1+"/data/(*)", "--sign", "--target="+tests.DistRepo2+"/target/{1}")
-	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
+	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync", "--create-repo")
 
 	// Validate files are distributed to the target mapping
 	spec, err := tests.CreateSpec(tests.DistributionMappingDownload)
@@ -468,7 +468,7 @@ func TestBundlePathMappingUsingSpec(t *testing.T) {
 	spec, err := tests.CreateSpec(tests.DistributionCreateWithMapping)
 	assert.NoError(t, err)
 	runDs(t, "rbc", tests.BundleName, bundleVersion, "--sign", "--spec="+spec)
-	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync")
+	runDs(t, "rbd", tests.BundleName, bundleVersion, "--site=*", "--sync", "--create-repo")
 
 	// Validate files are distributed to the target mapping
 	spec, err = tests.CreateSpec(tests.DistributionMappingDownload)

--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,6 @@ require (
 
 replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.3.1-0.20220620130614-83dda95caddf
 
-replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.14.1-0.20220621123826-1e21b88b991f
+replace github.com/jfrog/jfrog-client-go => github.com/sverdlov93/jfrog-client-go v1.0.2-0.20220621150744-8286e767799d
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.16.1-0.20220621124242-4fe813879da6
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/sverdlov93/jfrog-cli-core/v2 v2.0.2-0.20220621150941-04c2d33b841b

--- a/go.sum
+++ b/go.sum
@@ -444,10 +444,6 @@ github.com/jfrog/build-info-go v1.3.1-0.20220620130614-83dda95caddf h1:LprYKtz11
 github.com/jfrog/build-info-go v1.3.1-0.20220620130614-83dda95caddf/go.mod h1:S2x0YOFBqBYp22goGRXGfy3ut7XaespgroVJpD6fPwk=
 github.com/jfrog/gofrog v1.1.2 h1:txts7zSFEGan3a8G+AJCrcq4a/z8PrCmZ7m6c7qaALg=
 github.com/jfrog/gofrog v1.1.2/go.mod h1:9YN5v4LlsCfLIXpwQnzSf1wVtgjdHM20FzuIu58RMI4=
-github.com/jfrog/jfrog-cli-core/v2 v2.16.1-0.20220621124242-4fe813879da6 h1:Jp3uRvcUkRPw4BglFcZhgTZOQoCx7pQ8QXAxyKi7h7E=
-github.com/jfrog/jfrog-cli-core/v2 v2.16.1-0.20220621124242-4fe813879da6/go.mod h1:/PUSjB1NR6PF1LO9tcdbUnrA8YsFoRwsMAXx9Ntfk/o=
-github.com/jfrog/jfrog-client-go v1.14.1-0.20220621123826-1e21b88b991f h1:l+vtDv9wmgCyUnECIO2gtRuwirZ2ulrbDJm7VsYrDPQ=
-github.com/jfrog/jfrog-client-go v1.14.1-0.20220621123826-1e21b88b991f/go.mod h1:s1sXsJo8sXngALx5hEd/w5U0INuKKFmZnNk6Tk/QXQE=
 github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
 github.com/jingyugao/rowserrcheck v1.1.1/go.mod h1:4yvlZSDb3IyDTUZJUmpZfm2Hwok+Dtp+nu2qOq+er9c=
@@ -758,6 +754,10 @@ github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/sverdlov93/jfrog-cli-core/v2 v2.0.2-0.20220621150941-04c2d33b841b h1:vhOfgAQBloDtY7fGsP2u994oBllpBpjNEQSHVedXl7E=
+github.com/sverdlov93/jfrog-cli-core/v2 v2.0.2-0.20220621150941-04c2d33b841b/go.mod h1:DKFkJ/tIyQ/6Vk76Bj6CBcZHw4LNXKTsJHagDk5/8M8=
+github.com/sverdlov93/jfrog-client-go v1.0.2-0.20220621150744-8286e767799d h1:ka7CLdp2amG6t/MA7agmUkPf1AcP/PYEwRr/JneqRXg=
+github.com/sverdlov93/jfrog-client-go v1.0.2-0.20220621150744-8286e767799d/go.mod h1:s1sXsJo8sXngALx5hEd/w5U0INuKKFmZnNk6Tk/QXQE=
 github.com/sylvia7788/contextcheck v1.0.4/go.mod h1:vuPKJMQ7MQ91ZTqfdyreNKwZjyUg6KO+IebVyQDedZQ=
 github.com/tdakkota/asciicheck v0.1.1/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tenntenn/modver v1.0.1/go.mod h1:bePIyQPb7UeioSRkw3Q0XeMhYZSMx9B8ePqg6SAMGH0=

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -394,6 +394,7 @@ const (
 	sync                = "sync"
 	maxWaitMinutes      = "max-wait-minutes"
 	deleteFromDist      = "delete-from-dist"
+	createRepo          = "create-repo"
 
 	// *** Xray Commands' flags ***
 	// Base flags
@@ -1317,6 +1318,10 @@ var flagsMap = map[string]cli.Flag{
 		Name:   "format",
 		Hidden: true,
 	},
+	createRepo: cli.BoolFlag{
+		Name:  createRepo,
+		Usage: "[Default: false] Set to true to enable auto-creating repository if it does not exist.` `",
+	},
 }
 
 var commandFlags = map[string][]string{
@@ -1530,7 +1535,7 @@ var commandFlags = map[string][]string{
 	},
 	ReleaseBundleDistribute: {
 		distUrl, user, password, accessToken, serverId, rbDryRun, distRules,
-		site, city, countryCodes, sync, maxWaitMinutes, InsecureTls,
+		site, city, countryCodes, sync, maxWaitMinutes, InsecureTls, createRepo,
 	},
 	ReleaseBundleDelete: {
 		distUrl, user, password, accessToken, serverId, rbDryRun, distRules,


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
There is a new feature in the Distribution API of auto-creating repository if it does not exist.
Add support for a flag as well in jfrog cli e.g.:
jfrog ds rbd saas-helm-values 1.1.23 --site "repo21edges*" --url https://entplus.jfrog.io/distribution --sync --create-repo=true

depends on https://github.com/jfrog/jfrog-cli-core/pull/422
depends on https://github.com/jfrog/jfrog-client-go/pull/602