### PR TITLE
Verify that default credentials are not configured before executing 'transfer-config'

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -2328,6 +2328,16 @@ func transferConfigCmd(c *cli.Context) error {
 		return nil
 	}
 
+	// Check if there is a configured user using default credentials in the source platform.
+	if isDefaultCredentials(sourceServerDetails.ArtifactoryUrl) {
+		defaultCredMsg := "The default 'admin:password' credentials are used by a configured user in your source platform.\n" +
+			"Those credentials will be transferred to your SaaS target platform.\n" +
+			"Are you sure you want to continue?"
+		if !coreutils.AskYesNo(defaultCredMsg, false) {
+			return nil
+		}
+	}
+
 	// Run transfer config command
 	transferConfigCmd := transferconfig.NewTransferConfigCommand(sourceServerDetails, targetServerDetails).SetForce(c.Bool(cliutils.Force)).SetVerbose(c.Bool(cliutils.Verbose))
 	includeReposPatterns, excludeReposPatterns := getTransferIncludeExcludeRepos(c)
@@ -2341,6 +2351,21 @@ func transferConfigCmd(c *cli.Context) error {
 	log.Info("Config transfer completed successfully!")
 	log.Info("☝️  Please make sure to disable configuration transfer in MyJFrog before running the 'jf transfer-files' command.")
 	return nil
+}
+
+// Check if there is a configured user using default credentials 'admin:password' by pinging Artifactory.
+func isDefaultCredentials(url string) bool {
+	err := pingWithDefaultCred(url)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+func pingWithDefaultCred(url string) error {
+	artDetails := coreConfig.ServerDetails{ArtifactoryUrl: url, User: "admin", Password: "password"}
+	pingCmd := generic.NewPingCommand().SetServerDetails(&artDetails)
+	return commands.Exec(pingCmd)
 }
 
 func transferFilesCmd(c *cli.Context) error {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Before executing the 'transfer-config' command we want to check if there is a configured user using the default 'admin:password' credentials in the source platform.
If a user like this exists - print a warning before continuing and ask the user to confirm.