### PR TITLE
Fix maven & npm tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           dotnet-version: '3.x'
         if: ${{ matrix.suite == 'nuget' }}
-        
+
       - name: Setup Python3
         uses: actions/setup-python@v4
         with:
@@ -105,14 +105,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          
+
       - name: Go Cache
         uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
-            
+
       - name: Setup Artifactory
         run: |
           go install github.com/jfrog/jfrog-testing-infra/local-rt-setup@latest
@@ -120,15 +120,15 @@ jobs:
         env:
           RTLIC: ${{secrets.RTLIC}}
           GOPROXY: direct
-        if: ${{ matrix.suite != 'distribution' && matrix.suite != 'xray' && matrix.suite != 'access' }}
+        if: ${{ matrix.suite != 'distribution' && matrix.suite != 'xray' && matrix.suite != 'access' && matrix.suite != 'artifactoryProject' }}
 
       - name: Run Artifactory / Build tools tests
         run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.${{ matrix.suite }}=true --ci.runId=${{ runner.os }}-${{ matrix.suite }}
-        if: ${{ matrix.suite != 'distribution' && matrix.suite != 'xray' && matrix.suite != 'access' }}
+        if: ${{ matrix.suite != 'distribution' && matrix.suite != 'xray' && matrix.suite != 'access'&& matrix.suite != 'artifactoryProject' }}
 
       - name: Run Distribution / Xray / Access tests
         run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.${{ matrix.suite }}=true --jfrog.url=${{ secrets.PLATFORM_URL }} --jfrog.adminToken=${{ secrets.PLATFORM_ADMIN_TOKEN }} --jfrog.user=${{ secrets.PLATFORM_USER }} --ci.runId=${{ runner.os }}-${{ matrix.suite }}
-        if: ${{ matrix.suite == 'distribution' || matrix.suite == 'xray' || matrix.suite == 'access' }}
+        if: ${{ matrix.suite == 'distribution' || matrix.suite == 'xray' || matrix.suite == 'access' || matrix.suite == 'artifactoryProject' }}
 
   Go-Tests:
     # Go modules doesn't allow passing credentials to a private registry using an HTTP URL. Therefore, the Go tests run against a remote Artifactory server.
@@ -155,7 +155,7 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
-            
+
       - name: Run Go tests
         run: go test -v -timeout 0 --test.go --jfrog.url=${{ secrets.PLATFORM_URL }} --jfrog.adminToken=${{ secrets.PLATFORM_ADMIN_TOKEN }}
 
@@ -179,7 +179,7 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
-            
+
       - name: Run Docker tests
         run: go test -v -timeout 0 --test.docker=true --jfrog.url=${{ secrets.PLATFORM_URL }} --jfrog.adminToken=${{ secrets.PLATFORM_ADMIN_TOKEN }} --rt.dockerRepoDomain=${{ secrets.CONTAINER_REGISTRY }} --rt.dockerVirtualRepo=${{ secrets.DOCKER_VIRTUAL }} --rt.dockerLocalRepo=${{ secrets.DOCKER_LOCAL }} --rt.dockerRemoteRepo=${{ secrets.DOCKER_REMOTE }} --rt.dockerPromoteLocalRepo=${{ secrets.DOCKER_PROMOTE_LOCAL }}
 

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -95,7 +95,7 @@ func InitArtifactoryTests() {
 
 func authenticate(configCli bool) string {
 	*tests.JfrogUrl = clientutils.AddTrailingSlashIfNeeded(*tests.JfrogUrl)
-	serverDetails = &config.ServerDetails{ArtifactoryUrl: *tests.JfrogUrl + tests.ArtifactoryEndpoint, SshKeyPath: *tests.JfrogSshKeyPath, SshPassphrase: *tests.JfrogSshPassphrase}
+	serverDetails = &config.ServerDetails{Url: *tests.JfrogUrl, ArtifactoryUrl: *tests.JfrogUrl + tests.ArtifactoryEndpoint, SshKeyPath: *tests.JfrogSshKeyPath, SshPassphrase: *tests.JfrogSshPassphrase}
 	var cred string
 	if configCli {
 		cred += "--artifactory-url=" + serverDetails.ArtifactoryUrl

--- a/testdata/maven_repository_config1.json
+++ b/testdata/maven_repository_config1.json
@@ -1,5 +1,6 @@
 {
   "key": "${MAVEN_REPO1}",
   "rclass": "local",
-  "packageType": "maven"
+  "packageType": "maven",
+  "snapshotVersionBehavior":"non-unique"
 }

--- a/testdata/maven_repository_config1.json
+++ b/testdata/maven_repository_config1.json
@@ -2,5 +2,5 @@
   "key": "${MAVEN_REPO1}",
   "rclass": "local",
   "packageType": "maven",
-  "snapshotVersionBehavior":"non-unique"
+  "snapshotVersionBehavior": "non-unique"
 }

--- a/testdata/maven_repository_config2.json
+++ b/testdata/maven_repository_config2.json
@@ -1,5 +1,6 @@
 {
   "key": "${MAVEN_REPO2}",
   "rclass": "local",
-  "packageType": "maven"
+  "packageType": "maven",
+  "snapshotVersionBehavior":"non-unique"
 }

--- a/testdata/maven_repository_config2.json
+++ b/testdata/maven_repository_config2.json
@@ -2,5 +2,5 @@
   "key": "${MAVEN_REPO2}",
   "rclass": "local",
   "packageType": "maven",
-  "snapshotVersionBehavior":"non-unique"
+  "snapshotVersionBehavior": "non-unique"
 }

--- a/testdata/npm/npmpostinstall/package.json
+++ b/testdata/npm/npmpostinstall/package.json
@@ -4,7 +4,7 @@
   "description": "test package",
   "main": "index.js",
   "scripts": {
-    "postinstall": "npm i --prefix subdir"
+    "postinstall": "cd subdir && npm i"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
The following issues have been fixed in this PR:
1. Npm 8 fails to run postscript tests because the flag '--prefix' is deprecated.
2. Maven tests fail because the default configuration of 'snapshotVersionBehavior' has changed. By overriding the defaults with "non-unique", we overcome this problem.
3. The platform URL was added because access tests required it. 