### PR TITLE
Remove unnecessary search from interactive selection and replace selection emoji(🐸) on windows

### DIFF
--- a/general/cisetup/cisetup.go
+++ b/general/cisetup/cisetup.go
@@ -786,7 +786,7 @@ func promptARepoSelection(repoDetails *[]services.RepositoryDetails, promptMsg s
 		selectableItems = append(selectableItems, ioutils.PromptItem{Option: repo.Key, TargetValue: &selectedRepoName, DefaultValue: repo.Url})
 	}
 	log.Output(promptMsg)
-	err = ioutils.SelectString(selectableItems, "", func(item ioutils.PromptItem) {
+	err = ioutils.SelectString(selectableItems, "", true, func(item ioutils.PromptItem) {
 		*item.TargetValue = item.Option
 	})
 	return
@@ -806,7 +806,7 @@ func promptGitProviderSelection() (selected string, err error) {
 		selectableItems = append(selectableItems, ioutils.PromptItem{Option: string(provider), TargetValue: &selected})
 	}
 	log.Output("Choose your project Git provider:")
-	err = ioutils.SelectString(selectableItems, "", func(item ioutils.PromptItem) {
+	err = ioutils.SelectString(selectableItems, "", false, func(item ioutils.PromptItem) {
 		*item.TargetValue = item.Option
 	})
 	return
@@ -824,7 +824,7 @@ func promptCiProviderSelection() (selected string, err error) {
 		selectableItems = append(selectableItems, ioutils.PromptItem{Option: string(ci), TargetValue: &selected})
 	}
 	log.Output("Select a CI provider:")
-	err = ioutils.SelectString(selectableItems, "", func(item ioutils.PromptItem) {
+	err = ioutils.SelectString(selectableItems, "", false, func(item ioutils.PromptItem) {
 		*item.TargetValue = item.Option
 	})
 	return

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,6 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.18.2-0.20220809085432-4437966c6d64
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.19.4-0.20220810143708-9506ec654cec
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.19.4-0.20220811104649-1d6fde00c71b
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.1.3-0.20220630130242-df9cdb0c9e2d

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/jfrog/build-info-go v1.4.0
 	github.com/jfrog/gofrog v1.2.0
 	github.com/jfrog/jfrog-cli-core/v2 v2.19.1
-	github.com/jfrog/jfrog-client-go v1.18.1
+	github.com/jfrog/jfrog-client-go v1.19.0
 	github.com/jszwec/csvutil v1.7.1
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/pkg/errors v0.9.1
@@ -99,6 +99,6 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.18.1-0.20220731163434-83bf7f62d04e
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.19.1-0.20220807120352-b9738c91655b
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.19.4-0.20220810143708-9506ec654cec
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.1.3-0.20220630130242-df9cdb0c9e2d

--- a/go.sum
+++ b/go.sum
@@ -474,8 +474,8 @@ github.com/jfrog/build-info-go v1.4.0 h1:1O+zvovje/JC4ja8XeVp1pGByIIxWKW6kjdj8eW
 github.com/jfrog/build-info-go v1.4.0/go.mod h1:LM0CXNLF2FkvcyXrPEp6Ox1ARmcOsx/eOrVG2Jer2Ss=
 github.com/jfrog/gofrog v1.2.0 h1:vlVwEL5ppuwOjBHUphxxuHUAv4QC3vwF3FDI9aDrbqM=
 github.com/jfrog/gofrog v1.2.0/go.mod h1:IXM6bw5sI6hMdhamlCYQpB1W17S0D1dwvBtzhaIarNU=
-github.com/jfrog/jfrog-cli-core/v2 v2.19.4-0.20220810143708-9506ec654cec h1:I3DcI3QNkHjfsYMNqBTgZLw4EeyaHlku1tg8OUCRa+Q=
-github.com/jfrog/jfrog-cli-core/v2 v2.19.4-0.20220810143708-9506ec654cec/go.mod h1:G4+Fey3RbjrfZ+PfxTYSdN0QYN6dornxMKtA6VYDWiU=
+github.com/jfrog/jfrog-cli-core/v2 v2.19.4-0.20220811104649-1d6fde00c71b h1:/aUby7K/hVn6hcd90fA6+84QDfyOw6Ca82jcHxYpGgg=
+github.com/jfrog/jfrog-cli-core/v2 v2.19.4-0.20220811104649-1d6fde00c71b/go.mod h1:G4+Fey3RbjrfZ+PfxTYSdN0QYN6dornxMKtA6VYDWiU=
 github.com/jfrog/jfrog-client-go v1.19.0 h1:ogCSJhteCC3qv+KAqA/9pJnKN4XEgYBsEzhqrPqVjKY=
 github.com/jfrog/jfrog-client-go v1.19.0/go.mod h1:OwYfCvG+v8iv+BtjztM6c/KhVU5uOM1Z+eLgW/vbZig=
 github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=

--- a/go.sum
+++ b/go.sum
@@ -474,10 +474,10 @@ github.com/jfrog/build-info-go v1.4.0 h1:1O+zvovje/JC4ja8XeVp1pGByIIxWKW6kjdj8eW
 github.com/jfrog/build-info-go v1.4.0/go.mod h1:LM0CXNLF2FkvcyXrPEp6Ox1ARmcOsx/eOrVG2Jer2Ss=
 github.com/jfrog/gofrog v1.2.0 h1:vlVwEL5ppuwOjBHUphxxuHUAv4QC3vwF3FDI9aDrbqM=
 github.com/jfrog/gofrog v1.2.0/go.mod h1:IXM6bw5sI6hMdhamlCYQpB1W17S0D1dwvBtzhaIarNU=
-github.com/jfrog/jfrog-cli-core/v2 v2.19.1 h1:OcftJdvpEINQ43Nx4HwU6RwScLSGTaUVqzQsCILzatE=
-github.com/jfrog/jfrog-cli-core/v2 v2.19.1/go.mod h1:/DJpxkDTIc1AvvY4CVYDFM+Qs2IFGA8wkw4/q8UmkM4=
-github.com/jfrog/jfrog-client-go v1.18.1 h1:GrwYnNVRp9L/FJXKJx2psv2mnG6iSBtq0lfepEpkjko=
-github.com/jfrog/jfrog-client-go v1.18.1/go.mod h1:OwYfCvG+v8iv+BtjztM6c/KhVU5uOM1Z+eLgW/vbZig=
+github.com/jfrog/jfrog-cli-core/v2 v2.19.4-0.20220810143708-9506ec654cec h1:I3DcI3QNkHjfsYMNqBTgZLw4EeyaHlku1tg8OUCRa+Q=
+github.com/jfrog/jfrog-cli-core/v2 v2.19.4-0.20220810143708-9506ec654cec/go.mod h1:G4+Fey3RbjrfZ+PfxTYSdN0QYN6dornxMKtA6VYDWiU=
+github.com/jfrog/jfrog-client-go v1.19.0 h1:ogCSJhteCC3qv+KAqA/9pJnKN4XEgYBsEzhqrPqVjKY=
+github.com/jfrog/jfrog-client-go v1.19.0/go.mod h1:OwYfCvG+v8iv+BtjztM6c/KhVU5uOM1Z+eLgW/vbZig=
 github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
 github.com/jingyugao/rowserrcheck v1.1.1/go.mod h1:4yvlZSDb3IyDTUZJUmpZfm2Hwok+Dtp+nu2qOq+er9c=

--- a/go.sum
+++ b/go.sum
@@ -474,8 +474,8 @@ github.com/jfrog/build-info-go v1.4.0 h1:1O+zvovje/JC4ja8XeVp1pGByIIxWKW6kjdj8eW
 github.com/jfrog/build-info-go v1.4.0/go.mod h1:LM0CXNLF2FkvcyXrPEp6Ox1ARmcOsx/eOrVG2Jer2Ss=
 github.com/jfrog/gofrog v1.2.0 h1:vlVwEL5ppuwOjBHUphxxuHUAv4QC3vwF3FDI9aDrbqM=
 github.com/jfrog/gofrog v1.2.0/go.mod h1:IXM6bw5sI6hMdhamlCYQpB1W17S0D1dwvBtzhaIarNU=
-github.com/jfrog/jfrog-cli-core/v2 v2.19.3 h1:p883m1OtK6EnOtBxR0pZ+z0AXl2t52sqtGdJqDlG5hk=
-github.com/jfrog/jfrog-cli-core/v2 v2.19.3/go.mod h1:G4+Fey3RbjrfZ+PfxTYSdN0QYN6dornxMKtA6VYDWiU=
+github.com/jfrog/jfrog-cli-core/v2 v2.19.4-0.20220810143708-9506ec654cec h1:I3DcI3QNkHjfsYMNqBTgZLw4EeyaHlku1tg8OUCRa+Q=
+github.com/jfrog/jfrog-cli-core/v2 v2.19.4-0.20220810143708-9506ec654cec/go.mod h1:G4+Fey3RbjrfZ+PfxTYSdN0QYN6dornxMKtA6VYDWiU=
 github.com/jfrog/jfrog-client-go v1.19.0 h1:ogCSJhteCC3qv+KAqA/9pJnKN4XEgYBsEzhqrPqVjKY=
 github.com/jfrog/jfrog-client-go v1.19.0/go.mod h1:OwYfCvG+v8iv+BtjztM6c/KhVU5uOM1Z+eLgW/vbZig=
 github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=

--- a/utils/progressbar/filesprogressbar.go
+++ b/utils/progressbar/filesprogressbar.go
@@ -1,6 +1,7 @@
 package progressbar
 
 import (
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"net/url"
 	"os"
 	"strings"
@@ -279,6 +280,8 @@ func (p *filesProgressBarManager) SetHeadlineMsg(msg string) {
 		defer p.barsWg.Done()
 		defer current.Abort(true)
 	}
+	// Remove emojis from non-supported terminals
+	msg = coreutils.RemoveEmojisIfNonSupportedTerminal(msg)
 	p.newHeadlineBar(msg)
 }
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
Replace selection emoji - `🐸` on windows and other non-supported terminals to `>`

![Screen Shot 2022-08-10 at 18 49 15](https://user-images.githubusercontent.com/29822394/183952027-b824d4e9-e0bf-4c04-bb65-9ffad91871fc.png)

Remove search field from selection when it's unnecessary, for example here:

![Screen Shot 2022-08-10 at 18 09 42](https://user-images.githubusercontent.com/29822394/183953864-9931f47e-3217-4f71-b403-dc087c994ee8.png)

depends on https://github.com/jfrog/jfrog-cli-core/pull/503
