### PR TITLE
Add ability to ignore checksum failures when downloading files

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -2629,6 +2629,7 @@ func createDownloadConfiguration(c *cli.Context) (downloadConfiguration *utils.D
 	if err != nil {
 		return nil, err
 	}
+	downloadConfiguration.SkipChecksum = c.Bool("skip-checksum")
 	downloadConfiguration.Symlink = true
 	return
 }

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -207,6 +207,27 @@ func TestArtifactoryUploadPathWithSpecialCharsAsNoRegex(t *testing.T) {
 	cleanArtifactoryTest()
 }
 
+func TestArtifactoryIgnoreChecksumOnFilteredResource(t *testing.T) {
+	initArtifactoryTest(t, "")
+	filePath := "testdata/filtered/a.txt"
+
+	// Upload a filtered resource
+	runRt(t, "upload", filePath, tests.RtRepo1, "--flat", "--target-props", "artifactory.filtered=true")
+	searchFilePath, err := tests.CreateSpec(tests.SearchAllRepo1)
+	assert.NoError(t, err)
+
+	inttestutils.VerifyExistInArtifactory(tests.GetSimpleUploadFilteredRepo1(), searchFilePath, serverDetails, t)
+
+	// Attempt to download the filtered resource (this will fail the checksum check)
+	err = artifactoryCli.Exec([]string{"download", tests.RtRepo1 + "/a.txt", tests.Out + "/mypath2/filtered.txt"}...)
+	assert.Error(t, err)
+
+	// Attempt to download the filtered resource but skip the checksum
+	runRt(t, "download", tests.RtRepo1+"/a.txt", tests.Out+"/mypath2/filtered.txt", "--skip-checksum")
+
+	cleanArtifactoryTest()
+}
+
 func TestArtifactoryEmptyBuild(t *testing.T) {
 	initArtifactoryTest(t, "")
 	inttestutils.DeleteBuild(serverDetails.ArtifactoryUrl, tests.RtBuildName1, artHttpDetails)

--- a/go.mod
+++ b/go.mod
@@ -97,8 +97,8 @@ require (
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.4.1-0.20220815064747-507baf9c3b23
 
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.19.1-0.20220816075310-f157a8ecb6eb
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.20.2-0.20220817143134-e047de972343
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.19.4-0.20220815164638-6fd962ee885d
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.20.3-0.20220817143413-f4fd1959eab5
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.2.1-0.20220815100750-05cbe65dbcf9

--- a/go.sum
+++ b/go.sum
@@ -475,10 +475,10 @@ github.com/jfrog/build-info-go v1.4.1 h1:JdkMVpN+Cr+wMKVRJ1/2JeXtL7MLjVnGv23b/tA
 github.com/jfrog/build-info-go v1.4.1/go.mod h1:LM0CXNLF2FkvcyXrPEp6Ox1ARmcOsx/eOrVG2Jer2Ss=
 github.com/jfrog/gofrog v1.2.0 h1:vlVwEL5ppuwOjBHUphxxuHUAv4QC3vwF3FDI9aDrbqM=
 github.com/jfrog/gofrog v1.2.0/go.mod h1:IXM6bw5sI6hMdhamlCYQpB1W17S0D1dwvBtzhaIarNU=
-github.com/jfrog/jfrog-cli-core/v2 v2.20.2 h1:aLwcBCB0JfN31+/6vVGzYOpyYUb3Q1AtfdlpMxLP7Kw=
-github.com/jfrog/jfrog-cli-core/v2 v2.20.2/go.mod h1:Fye6jJa6s4hh+lkEIJVgsHhOOdizubvYmY/rDCCYo5Y=
-github.com/jfrog/jfrog-client-go v1.20.1 h1:TFdPaK9+rp6j2M5M2RBbTAJ74ERLEXTXPk/58kTDnBo=
-github.com/jfrog/jfrog-client-go v1.20.1/go.mod h1:cuNzLQVvGILul2F37/tTtLQLObWcz46wrK1H8OeyktQ=
+github.com/jfrog/jfrog-cli-core/v2 v2.20.3-0.20220817143413-f4fd1959eab5 h1:sf9GzSIXC1tsEaFtnMK6RBF610fp6rtYHTkUPovosN4=
+github.com/jfrog/jfrog-cli-core/v2 v2.20.3-0.20220817143413-f4fd1959eab5/go.mod h1:Fye6jJa6s4hh+lkEIJVgsHhOOdizubvYmY/rDCCYo5Y=
+github.com/jfrog/jfrog-client-go v1.20.2-0.20220817143134-e047de972343 h1:ehlfCFfEf8eeS4EbeKSOwYS3GBRoDlCu2ZQhMlVHcSY=
+github.com/jfrog/jfrog-client-go v1.20.2-0.20220817143134-e047de972343/go.mod h1:cuNzLQVvGILul2F37/tTtLQLObWcz46wrK1H8OeyktQ=
 github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
 github.com/jingyugao/rowserrcheck v1.1.1/go.mod h1:4yvlZSDb3IyDTUZJUmpZfm2Hwok+Dtp+nu2qOq+er9c=

--- a/testdata/filtered/a.txt
+++ b/testdata/filtered/a.txt
@@ -1,0 +1,1 @@
+jfrogIoUsername=${security.getCurrentUsername()}

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -212,6 +212,7 @@ const (
 	minSplit             = "min-split"
 	splitCount           = "split-count"
 	validateSymlinks     = "validate-symlinks"
+	skipChecksum         = "skip-checksum"
 
 	// Unique move flags
 	movePrefix       = "move-"
@@ -689,6 +690,10 @@ var flagsMap = map[string]cli.Flag{
 		Name:  minSplit,
 		Value: "",
 		Usage: "[Default: " + strconv.Itoa(DownloadMinSplitKb) + "] Minimum file size in KB to split into ranges when downloading. Set to -1 for no splits.` `",
+	},
+	skipChecksum: cli.BoolFlag{
+		Name:  skipChecksum,
+		Usage: "[Default: false] Set to true to ignore hash check failures when downloading.` `",
 	},
 	splitCount: cli.StringFlag{
 		Name:  splitCount,
@@ -1387,6 +1392,7 @@ var commandFlags = map[string][]string{
 		sortOrder, limit, offset, downloadRecursive, downloadFlat, build, includeDeps, excludeArtifacts, minSplit, splitCount,
 		retries, retryWaitTime, dryRun, downloadExplode, validateSymlinks, bundle, publicGpgKey, includeDirs, downloadProps, downloadExcludeProps,
 		failNoOp, threads, archiveEntries, downloadSyncDeletes, syncDeletesQuiet, InsecureTls, detailedSummary, project,
+		skipChecksum,
 	},
 	Move: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,

--- a/utils/tests/consts.go
+++ b/utils/tests/consts.go
@@ -271,6 +271,12 @@ func GetSimpleUploadSpecialCharNoRegexExpectedRepo1() []string {
 	}
 }
 
+func GetSimpleUploadFilteredRepo1() []string {
+	return []string{
+		RtRepo1 + "/a.txt",
+	}
+}
+
 func GetSimpleUploadSpecialCharNoRegexExpectedRepo2() []string {
 	return []string{
 		RtRepo2 + "/a1.in",


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Filtered resources manipulate the contents of artifacts during download.
The SHA1 supplied by the server does not reflect those changes, but
instead only hashes the raw unfiltered template. In the current
implementation, the client always checks that the hash matches the
expected hash and returns an error if they do not match.

This change adds a flag to indicate whether the checksum should be
validated defaulting to false.
```
jfrog rt dl repo/blah.filtered --skip-checksum
```
Feature request: https://github.com/jfrog/jfrog-cli/issues/1636