### PR TITLE
Add installDataTransferPlugin to transfer tests

### DIFF
--- a/.github/workflows/transferTests.yml
+++ b/.github/workflows/transferTests.yml
@@ -46,4 +46,4 @@ jobs:
           JFROG_HOME: ${{ runner.temp }}
 
       - name: Run transfer tests
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.transfer --jfrog.targetUrl=${{ secrets.PLATFORM_URL }} --jfrog.targetAdminToken=${{ secrets.PLATFORM_ADMIN_TOKEN }} --jfrog.home=${{ runner.temp }} --ci.runId=${{ runner.os }}-transfer
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.transfer --test.installDataTransferPlugin --jfrog.targetUrl=${{ secrets.PLATFORM_URL }} --jfrog.targetAdminToken=${{ secrets.PLATFORM_ADMIN_TOKEN }} --jfrog.home=${{ runner.temp }} --ci.runId=${{ runner.os }}-transfer

--- a/README.md
+++ b/README.md
@@ -276,11 +276,12 @@ go test -v github.com/jfrog/jfrog-cli -test.distribution [flags]
 The transfer tests execute `transfer-files` commnads between a local Artifactory server and a remote SaaS instance.
 In addition to [general optional flags](#Usage) you _must_ use the following flags:
 
-| Flag                      | Description                                                     |
-| ------------------------- | --------------------------------------------------------------- |
-| `-jfrog.targetUrl`        | JFrog target platform URL.                                      |
-| `-jfrog.targetAdminToken` | JFrog target platform admin token.                              |
-| `-jfrog.jfrogHome`        | The JFrog home directory of the local Artifactory installation. |
+| Flag                               | Description                                                                                                     |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `-jfrog.targetUrl`                 | JFrog target platform URL.                                                                                      |
+| `-jfrog.targetAdminToken`          | JFrog target platform admin token.                                                                              |
+| `-jfrog.jfrogHome`                 | The JFrog home directory of the local Artifactory installation.                                                 |
+| `-jfrog.installDataTransferPlugin` | Set to true if you'de like the test to install the data-transfer automatically in the source Artifactory server |
 
 To run transfer tests execute the following command:
 

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -28,7 +28,9 @@ func InitTransferTests() {
 	cleanUpOldBuilds()
 	tests.AddTimestampToGlobalVars()
 	createRequiredRepos()
-	inttestutils.InstallDataTransferPlugin()
+	if *tests.InstallDataTransferPlugin {
+		inttestutils.InstallDataTransferPlugin()
+	}
 	var creds string
 	creds, targetServerDetails, targetArtHttpDetails = inttestutils.AuthenticateTarget()
 	targetArtifactoryCli = tests.NewJfrogCli(execMain, "jfrog rt", creds)
@@ -57,7 +59,9 @@ func initTransferTest(t *testing.T) func() {
 	err = tests.NewJfrogCli(execMain, "jfrog config", "--access-token="+*tests.JfrogTargetAccessToken).Exec("add", inttestutils.TargetServerId, "--interactive=false", "--artifactory-url="+*tests.JfrogTargetUrl+tests.ArtifactoryEndpoint)
 	assert.NoError(t, err)
 
-	assert.NoError(t, artifactoryCli.WithoutCredentials().Exec("curl", "-XPOST", "/api/plugins/reload"))
+	if *tests.InstallDataTransferPlugin {
+		assert.NoError(t, artifactoryCli.WithoutCredentials().Exec("curl", "-XPOST", "/api/plugins/reload"))
+	}
 	return func() {
 		cleanArtifactory()
 		inttestutils.CleanTargetRepos(targetArtifactoryCli)

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -38,39 +38,40 @@ import (
 )
 
 var (
-	JfrogUrl               *string
-	JfrogUser              *string
-	JfrogPassword          *string
-	JfrogSshKeyPath        *string
-	JfrogSshPassphrase     *string
-	JfrogAccessToken       *string
-	JfrogTargetUrl         *string
-	JfrogTargetAccessToken *string
-	JfrogHome              *string
-	TestArtifactoryProject *bool
-	TestArtifactory        *bool
-	TestArtifactoryProxy   *bool
-	TestDistribution       *bool
-	TestDocker             *bool
-	TestGo                 *bool
-	TestNpm                *bool
-	TestGradle             *bool
-	TestMaven              *bool
-	TestNuget              *bool
-	TestPip                *bool
-	TestPipenv             *bool
-	TestPlugins            *bool
-	TestXray               *bool
-	TestAccess             *bool
-	TestTransfer           *bool
-	DockerRepoDomain       *string
-	DockerVirtualRepo      *string
-	DockerRemoteRepo       *string
-	DockerLocalRepo        *string
-	DockerPromoteLocalRepo *string
-	HideUnitTestLog        *bool
-	ciRunId                *string
-	timestampAdded         bool
+	JfrogUrl                  *string
+	JfrogUser                 *string
+	JfrogPassword             *string
+	JfrogSshKeyPath           *string
+	JfrogSshPassphrase        *string
+	JfrogAccessToken          *string
+	JfrogTargetUrl            *string
+	JfrogTargetAccessToken    *string
+	JfrogHome                 *string
+	TestArtifactoryProject    *bool
+	TestArtifactory           *bool
+	TestArtifactoryProxy      *bool
+	TestDistribution          *bool
+	TestDocker                *bool
+	TestGo                    *bool
+	TestNpm                   *bool
+	TestGradle                *bool
+	TestMaven                 *bool
+	TestNuget                 *bool
+	TestPip                   *bool
+	TestPipenv                *bool
+	TestPlugins               *bool
+	TestXray                  *bool
+	TestAccess                *bool
+	TestTransfer              *bool
+	DockerRepoDomain          *string
+	DockerVirtualRepo         *string
+	DockerRemoteRepo          *string
+	DockerLocalRepo           *string
+	DockerPromoteLocalRepo    *string
+	HideUnitTestLog           *bool
+	ciRunId                   *string
+	InstallDataTransferPlugin *bool
+	timestampAdded            bool
 )
 
 func init() {
@@ -105,6 +106,7 @@ func init() {
 	DockerLocalRepo = flag.String("rt.dockerLocalRepo", "", "Docker local repo")
 	DockerPromoteLocalRepo = flag.String("rt.dockerPromoteLocalRepo", "", "Docker promote local repo")
 	HideUnitTestLog = flag.Bool("test.hideUnitTestLog", false, "Hide unit tests logs and print it in a file")
+	InstallDataTransferPlugin = flag.Bool("test.installDataTransferPlugin", false, "Install data-transfer plugin on the source Artifactory server")
 	ciRunId = flag.String("ci.runId", "", "A unique identifier used as a suffix to create repositories and builds in the tests")
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Add new `-test.installDataTransferPlugin` flag to the transfer tests.
The reason for this change is to allow the data-transfer plugin tests to install the latest data-transfer code instead of the latest release.