### PR TITLE
Add deprecation message to old release notes page

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,8 @@
-# Release Notes (deprecated view - moved to https://github.com/jfrog/jfrog-cli/releases)
+# Release Notes
+
+| Release notes moved to https://github.com/jfrog/jfrog-cli/releases |
+|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+
 
 ## 2.16.1 (April 21, 2022)
 - Update the Go version used to build JFrog CLI to 1.17.9

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,5 @@
-# Release Notes
+# Release Notes (deprecated view - moved to https://github.com/jfrog/jfrog-cli/releases)
+
 ## 2.16.1 (April 21, 2022)
 - Update the Go version used to build JFrog CLI to 1.17.9
 - Bug fix - The JSON output of the "jf build-scan" command also includes a log message


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
following https://github.com/jfrog/jfrog-cli/issues/1675
![Screen Shot 2022-09-01 at 16 05 51](https://user-images.githubusercontent.com/29822394/187920965-4e2a66f1-b4af-427b-b0b1-ad56e07fea3a.png)
