### PR TITLE
Transfer - Support HTTP proxy

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -2351,6 +2351,7 @@ func transferFilesCmd(c *cli.Context) error {
 	newTransferFilesCmd.SetIncludeReposPatterns(includeReposPatterns)
 	newTransferFilesCmd.SetExcludeReposPatterns(excludeReposPatterns)
 	newTransferFilesCmd.SetIgnoreState(c.Bool(cliutils.IgnoreState))
+	newTransferFilesCmd.SetProxyKey(c.String(cliutils.ProxyKey))
 	return newTransferFilesCmd.Run()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,6 @@ replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.5.3-
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.22.1-0.20220905085449-7f5c7587f4d4
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20220915131156-f5cc1c3c043c
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.20.9-0.20220918063145-c453114561ba
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.2.1-0.20220815100750-05cbe65dbcf9

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.1.0 // indirect
 	github.com/CycloneDX/cyclonedx-go v0.6.0 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
@@ -95,10 +96,10 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-// replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.5.2-0.20220912090853-016d38955376
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.5.3-0.20220913165819-1a9441240517
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.22.1-0.20220905085449-7f5c7587f4d4
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.20.8-0.20220912091134-cc45ae4e2079
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20220915131156-f5cc1c3c043c
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.2.1-0.20220815100750-05cbe65dbcf9

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ github.com/jfrog/build-info-go v1.5.3-0.20220913165819-1a9441240517 h1:pYHEvPwuN
 github.com/jfrog/build-info-go v1.5.3-0.20220913165819-1a9441240517/go.mod h1:213xp0wMeCy5bgAWvBzReZg5XV4xdUTXTkzTvjX5RsI=
 github.com/jfrog/gofrog v1.2.1 h1:3pIcyPfKcA9SIinE1UiC4+8OLg+UinHH/dfsOZH3qXg=
 github.com/jfrog/gofrog v1.2.1/go.mod h1:lbkGXX/DHKdomaSV34eiOC3pAr1HRNa9ffOYh7U7b1U=
+github.com/jfrog/jfrog-cli-core/v2 v2.20.9-0.20220918063145-c453114561ba h1:9f2ue++8x98KkrQ56JLCMJZIGEi2c8bN8ciNcVevqX0=
+github.com/jfrog/jfrog-cli-core/v2 v2.20.9-0.20220918063145-c453114561ba/go.mod h1:i56E4l2dLk2YwY0Gb9wgSJIF3vL+8ke+jfWTy6vs0Ew=
 github.com/jfrog/jfrog-client-go v1.23.2 h1:ldgMRl5JJtzWkiWuSvg/0h7MXyGuPaYT5BYKxXF29jU=
 github.com/jfrog/jfrog-client-go v1.23.2/go.mod h1:y1i4F8WlaxHUbhEpI2r8xbT6hWnlSHh/4Gn2wi7PeB8=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -348,8 +350,6 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofm
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
-github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20220915131156-f5cc1c3c043c h1:3zvtv2aoN+YgRs+poHCuV1wqoH4Q/OvfAZHfJurtsj4=
-github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20220915131156-f5cc1c3c043c/go.mod h1:i56E4l2dLk2YwY0Gb9wgSJIF3vL+8ke+jfWTy6vs0Ew=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
+github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.6.0 h1:SizWGbZzFTC/O/1yh072XQBMxfvsoWqd//oKCIyzFyE=
 github.com/CycloneDX/cyclonedx-go v0.6.0/go.mod h1:nQCiF4Tvrg5Ieu8qPhYMvzPGMu5I7fANZkrSsJjl5mg=
@@ -202,12 +204,10 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jedib0t/go-pretty/v6 v6.3.7 h1:H3Ulkf7h6A+p0HgKBGzgDn0bZIupRbKKWF4pO4Bs7iA=
 github.com/jedib0t/go-pretty/v6 v6.3.7/go.mod h1:MgmISkTWDSFu0xOqiZ0mKNntMQ2mDgOcwOkwBEkMDJI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/build-info-go v1.5.2 h1:EWNoTAtyg76mmCVWVSiJ/LFJr2MTkHo6UwmakabtEFc=
-github.com/jfrog/build-info-go v1.5.2/go.mod h1:LkGqSQ9C14idhHq75b3tX1X3q51mxnFxrzKE+uxVaGk=
+github.com/jfrog/build-info-go v1.5.3-0.20220913165819-1a9441240517 h1:pYHEvPwuNSLZTp4Zu6/DM5THi5WcPWWalIf3a41YpF0=
+github.com/jfrog/build-info-go v1.5.3-0.20220913165819-1a9441240517/go.mod h1:213xp0wMeCy5bgAWvBzReZg5XV4xdUTXTkzTvjX5RsI=
 github.com/jfrog/gofrog v1.2.1 h1:3pIcyPfKcA9SIinE1UiC4+8OLg+UinHH/dfsOZH3qXg=
 github.com/jfrog/gofrog v1.2.1/go.mod h1:lbkGXX/DHKdomaSV34eiOC3pAr1HRNa9ffOYh7U7b1U=
-github.com/jfrog/jfrog-cli-core/v2 v2.20.8 h1:4sW4D/jSGHq94E5VXpVZZiYIMsmhvYDkC9pd5KBhzvc=
-github.com/jfrog/jfrog-cli-core/v2 v2.20.8/go.mod h1:rfYVJbV1IpkOrxoREg1TSw6EOMOf5IN0OIRVaLRFbaQ=
 github.com/jfrog/jfrog-client-go v1.23.2 h1:ldgMRl5JJtzWkiWuSvg/0h7MXyGuPaYT5BYKxXF29jU=
 github.com/jfrog/jfrog-client-go v1.23.2/go.mod h1:y1i4F8WlaxHUbhEpI2r8xbT6hWnlSHh/4Gn2wi7PeB8=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -348,6 +348,8 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofm
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
+github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20220915131156-f5cc1c3c043c h1:3zvtv2aoN+YgRs+poHCuV1wqoH4Q/OvfAZHfJurtsj4=
+github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20220915131156-f5cc1c3c043c/go.mod h1:i56E4l2dLk2YwY0Gb9wgSJIF3vL+8ke+jfWTy6vs0Ew=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -2,10 +2,11 @@ package cliutils
 
 import (
 	"fmt"
-	"github.com/jfrog/jfrog-client-go/utils/log"
-	"github.com/urfave/cli"
 	"sort"
 	"strconv"
+
+	"github.com/jfrog/jfrog-client-go/utils/log"
+	"github.com/urfave/cli"
 )
 
 const (
@@ -471,6 +472,7 @@ const (
 	// *** TransferFiles Commands' flags ***
 	Filestore   = "filestore"
 	IgnoreState = "ignore-state"
+	ProxyKey    = "proxy-key"
 
 	// Transfer flags
 	IncludeRepos = "include-repos"
@@ -1375,6 +1377,10 @@ var flagsMap = map[string]cli.Flag{
 		Name:  IgnoreState,
 		Usage: "[Default: false] Set to true to ignore the saved state from previous transfer-files operations.` `",
 	},
+	ProxyKey: cli.StringFlag{
+		Name:  ProxyKey,
+		Usage: "[Optional] A proxy key configured in the source Artifactory server to use during the transfer from the source to the target server. Configure this proxy at \"Proxies | Configuration | Proxy Configuration\" in the Administration UI.` `",
+	},
 }
 
 var commandFlags = map[string][]string{
@@ -1638,7 +1644,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, deleteQuiet,
 	},
 	TransferFiles: {
-		Filestore, IncludeRepos, ExcludeRepos, IgnoreState,
+		Filestore, IncludeRepos, ExcludeRepos, IgnoreState, ProxyKey,
 	},
 	// Xray's commands
 	OfflineUpdate: {

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -1379,7 +1379,7 @@ var flagsMap = map[string]cli.Flag{
 	},
 	ProxyKey: cli.StringFlag{
 		Name:  ProxyKey,
-		Usage: "[Optional] A proxy key configured in the source Artifactory server to use during the transfer from the source to the target server. Configure this proxy at \"Proxies | Configuration | Proxy Configuration\" in the Administration UI.` `",
+		Usage: "[Optional] The key of an HTTP proxy configuration in Artifactory. This proxy will be used for the transfer traffic between the source and target instances. To configure this proxy, go to \"Proxies | Configuration | Proxy Configuration\" in the JFrog Administration UI.` `",
 	},
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Depends on:
* https://github.com/jfrog/data-transfer/pull/37
* https://github.com/jfrog/jfrog-cli-core/pull/552


* Add support for an HTTP proxy, configured in the platform UI. This proxy is used between the source and the target Artifactory servers. Usage:
```
jf rt transfer-files <source> <target> --proxy-key <proxy-key>
```
* Check connectivity between the source and the target Artifactory servers before starting the transfer.