### PR TITLE
Transfer config - Support setting the work dir

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -2318,6 +2318,7 @@ func transferConfigCmd(c *cli.Context) error {
 	includeReposPatterns, excludeReposPatterns := getTransferIncludeExcludeRepos(c)
 	transferConfigCmd.SetIncludeReposPatterns(includeReposPatterns)
 	transferConfigCmd.SetExcludeReposPatterns(excludeReposPatterns)
+	transferConfigCmd.SetWorkingDir(c.String(cliutils.WorkingDir))
 	if err := transferConfigCmd.Run(); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -125,6 +125,6 @@ require (
 
 replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.24.4-0.20221115164233-2fc98bd790c0
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.24.4-0.20221116072019-644c140961d4
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20221116104610-32f77ecdd6ca
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.2.5-0.20221107113836-a4c9225c690e

--- a/go.mod
+++ b/go.mod
@@ -125,6 +125,6 @@ require (
 
 replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.24.4-0.20221115164233-2fc98bd790c0
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20221116104610-32f77ecdd6ca
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.24.4-0.20221117155416-a319fd93acd6
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.2.5-0.20221107113836-a4c9225c690e

--- a/go.sum
+++ b/go.sum
@@ -531,6 +531,8 @@ github.com/jfrog/build-info-go v1.8.2 h1:T7XDBAiZmSAxaqjXXASgsYUHX5V2N4BQZiRQQIS
 github.com/jfrog/build-info-go v1.8.2/go.mod h1:iSTj26qEX3eUtyAGMH0qKsW4WJT+MceYxLWP9FfiAq4=
 github.com/jfrog/gofrog v1.2.5 h1:jCgJC0iGQ8bU7jCC+YEFJTNINyngApIrhd8BjZAVRIE=
 github.com/jfrog/gofrog v1.2.5/go.mod h1:o00tSRff6IapTgaCMuX1Cs9MH08Y1JqnsKgRtx91Gc4=
+github.com/jfrog/jfrog-cli-core/v2 v2.24.4-0.20221117155416-a319fd93acd6 h1:AULCnz8g1x0jpAWnFFBe6r14PrtyIMJpk+crZv1Z9oY=
+github.com/jfrog/jfrog-cli-core/v2 v2.24.4-0.20221117155416-a319fd93acd6/go.mod h1:RH677n5SKrQVo/AxZxQY5nJ0awFRn62RR434qCBvIh0=
 github.com/jfrog/jfrog-client-go v1.24.4-0.20221115164233-2fc98bd790c0 h1:Is97MbpnIrsVDP1HMrVAp4Hhbc/7w5PhqajoH5g1XL4=
 github.com/jfrog/jfrog-client-go v1.24.4-0.20221115164233-2fc98bd790c0/go.mod h1:sthdGUxwuD9LZROqycovtYvgONBkuv074MmRN1ye/CM=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -873,8 +875,6 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20221116104610-32f77ecdd6ca h1:ZKbKSgO37pygqLh7ruKWuI3+ECcoFyIna4nx9Zs8FWU=
-github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20221116104610-32f77ecdd6ca/go.mod h1:RH677n5SKrQVo/AxZxQY5nJ0awFRn62RR434qCBvIh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -531,8 +531,6 @@ github.com/jfrog/build-info-go v1.8.2 h1:T7XDBAiZmSAxaqjXXASgsYUHX5V2N4BQZiRQQIS
 github.com/jfrog/build-info-go v1.8.2/go.mod h1:iSTj26qEX3eUtyAGMH0qKsW4WJT+MceYxLWP9FfiAq4=
 github.com/jfrog/gofrog v1.2.5 h1:jCgJC0iGQ8bU7jCC+YEFJTNINyngApIrhd8BjZAVRIE=
 github.com/jfrog/gofrog v1.2.5/go.mod h1:o00tSRff6IapTgaCMuX1Cs9MH08Y1JqnsKgRtx91Gc4=
-github.com/jfrog/jfrog-cli-core/v2 v2.24.4-0.20221116072019-644c140961d4 h1:z4xd+fZ2awxHjUWUyGX4f3TnV9UTk1tey21vdScJwpA=
-github.com/jfrog/jfrog-cli-core/v2 v2.24.4-0.20221116072019-644c140961d4/go.mod h1:RH677n5SKrQVo/AxZxQY5nJ0awFRn62RR434qCBvIh0=
 github.com/jfrog/jfrog-client-go v1.24.4-0.20221115164233-2fc98bd790c0 h1:Is97MbpnIrsVDP1HMrVAp4Hhbc/7w5PhqajoH5g1XL4=
 github.com/jfrog/jfrog-client-go v1.24.4-0.20221115164233-2fc98bd790c0/go.mod h1:sthdGUxwuD9LZROqycovtYvgONBkuv074MmRN1ye/CM=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -875,6 +873,8 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20221116104610-32f77ecdd6ca h1:ZKbKSgO37pygqLh7ruKWuI3+ECcoFyIna4nx9Zs8FWU=
+github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20221116104610-32f77ecdd6ca/go.mod h1:RH677n5SKrQVo/AxZxQY5nJ0awFRn62RR434qCBvIh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -378,8 +378,9 @@ const (
 	xrayScan = "scan"
 
 	// Unique config transfer flags
-	Force   = "force"
-	Verbose = "verbose"
+	Force      = "force"
+	Verbose    = "verbose"
+	WorkingDir = "working-dir"
 
 	// *** Distribution Commands' flags ***
 	// Base flags
@@ -1089,6 +1090,10 @@ var flagsMap = map[string]cli.Flag{
 		Name:  Verbose,
 		Usage: "[Default: false] Set to true to increase verbosity during the export configuration from the source Artifactory phase.` `",
 	},
+	WorkingDir: cli.StringFlag{
+		Name:  WorkingDir,
+		Usage: "[Default: '/storage'] Local working directory in the target Artifactory server.` `",
+	},
 
 	// Distribution's commands Flags
 	distUrl: cli.StringFlag{
@@ -1582,7 +1587,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken,
 	},
 	TransferConfig: {
-		Force, Verbose, IncludeRepos, ExcludeRepos,
+		Force, Verbose, IncludeRepos, ExcludeRepos, WorkingDir,
 	},
 	Ping: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -1092,7 +1092,7 @@ var flagsMap = map[string]cli.Flag{
 	},
 	WorkingDir: cli.StringFlag{
 		Name:  WorkingDir,
-		Usage: "[Default: '/storage'] Local working directory in the target Artifactory server.` `",
+		Usage: "[Default: '/storage'] Local working directory on the target Artifactory server.` `",
 	},
 
 	// Distribution's commands Flags


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Depend on: https://github.com/jfrog/jfrog-cli-core/pull/623

Support setting to the working directory in the source Artifactory server. This flag is useful for running transfer-config in an on-prem server. This also helps when trying to test the transfer-config locally in the user's machine.

Usage:
```
jf rt transfer-config source-server target-server --working-dir=<dir-in-target-server>
```