### PR TITLE
Add --stop option to rt transfer-files

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -2373,12 +2373,13 @@ func dataTransferPluginInstallCmd(c *cli.Context) error {
 }
 
 func transferFilesCmd(c *cli.Context) error {
-	if c.Bool(cliutils.Status) {
+	if c.Bool(cliutils.Status) || c.Bool(cliutils.Stop) {
 		newTransferFilesCmd, err := transferfilescore.NewTransferFilesCommand(nil, nil)
 		if err != nil {
 			return err
 		}
 		newTransferFilesCmd.SetStatus(c.Bool(cliutils.Status))
+		newTransferFilesCmd.SetStop(c.Bool(cliutils.Stop))
 		return newTransferFilesCmd.Run()
 	}
 	if c.NArg() != 2 {

--- a/go.mod
+++ b/go.mod
@@ -127,6 +127,6 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.24.6-0.20230102092554-c56fc329c8fc
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.27.1-0.20230115091321-60cc5ac4d796
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20230115155109-fcb8822e6193
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.2.5-0.20221107113836-a4c9225c690e

--- a/go.mod
+++ b/go.mod
@@ -127,6 +127,6 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.24.6-0.20230102092554-c56fc329c8fc
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20230115155109-fcb8822e6193
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.27.1-0.20230116081647-a8b8e4830eb7
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.2.5-0.20221107113836-a4c9225c690e

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,6 @@ github.com/jfrog/build-info-go v1.8.5 h1:NXk0LrgGZzaK1QwHS8wMjvyLob9iLwi8//80vja
 github.com/jfrog/build-info-go v1.8.5/go.mod h1:iSTj26qEX3eUtyAGMH0qKsW4WJT+MceYxLWP9FfiAq4=
 github.com/jfrog/gofrog v1.2.5 h1:jCgJC0iGQ8bU7jCC+YEFJTNINyngApIrhd8BjZAVRIE=
 github.com/jfrog/gofrog v1.2.5/go.mod h1:o00tSRff6IapTgaCMuX1Cs9MH08Y1JqnsKgRtx91Gc4=
-github.com/jfrog/jfrog-cli-core/v2 v2.27.1-0.20230115091321-60cc5ac4d796 h1:Lv893n6Z+ubmO7LIzlHyRKMV4HUxhpbg73xvxTifaHM=
-github.com/jfrog/jfrog-cli-core/v2 v2.27.1-0.20230115091321-60cc5ac4d796/go.mod h1:lD9vRmJeggZFjNOPRigtcw5gl17lm29PQJRvmnO9UbA=
 github.com/jfrog/jfrog-client-go v1.25.0 h1:baSjeB9OrE4+bFtulyD0IPRkTt5Ynr7XGsTvtlIUztg=
 github.com/jfrog/jfrog-client-go v1.25.0/go.mod h1:3UIKpuDbH+CeWXHrIqnYPqZmG0+0lXnFh5WJ7qN3jAM=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -877,6 +875,8 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20230115155109-fcb8822e6193 h1:CWORT/PqP4EQLSPbCSBI/JzHCxmCA4IeuOw0IBEIP8A=
+github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20230115155109-fcb8822e6193/go.mod h1:lD9vRmJeggZFjNOPRigtcw5gl17lm29PQJRvmnO9UbA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -528,6 +528,8 @@ github.com/jfrog/build-info-go v1.8.5 h1:NXk0LrgGZzaK1QwHS8wMjvyLob9iLwi8//80vja
 github.com/jfrog/build-info-go v1.8.5/go.mod h1:iSTj26qEX3eUtyAGMH0qKsW4WJT+MceYxLWP9FfiAq4=
 github.com/jfrog/gofrog v1.2.5 h1:jCgJC0iGQ8bU7jCC+YEFJTNINyngApIrhd8BjZAVRIE=
 github.com/jfrog/gofrog v1.2.5/go.mod h1:o00tSRff6IapTgaCMuX1Cs9MH08Y1JqnsKgRtx91Gc4=
+github.com/jfrog/jfrog-cli-core/v2 v2.27.1-0.20230116081647-a8b8e4830eb7 h1:2OllZjuHKX1DCJCI201RjJlmgmfQLuXjdNj0Bu20BBo=
+github.com/jfrog/jfrog-cli-core/v2 v2.27.1-0.20230116081647-a8b8e4830eb7/go.mod h1:lD9vRmJeggZFjNOPRigtcw5gl17lm29PQJRvmnO9UbA=
 github.com/jfrog/jfrog-client-go v1.25.0 h1:baSjeB9OrE4+bFtulyD0IPRkTt5Ynr7XGsTvtlIUztg=
 github.com/jfrog/jfrog-client-go v1.25.0/go.mod h1:3UIKpuDbH+CeWXHrIqnYPqZmG0+0lXnFh5WJ7qN3jAM=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -875,8 +877,6 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20230115155109-fcb8822e6193 h1:CWORT/PqP4EQLSPbCSBI/JzHCxmCA4IeuOw0IBEIP8A=
-github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20230115155109-fcb8822e6193/go.mod h1:lD9vRmJeggZFjNOPRigtcw5gl17lm29PQJRvmnO9UbA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -488,6 +488,7 @@ const (
 	IgnoreState         = "ignore-state"
 	ProxyKey            = "proxy-key"
 	transferFilesStatus = transferFilesPrefix + "status"
+	Stop                = "stop"
 	PreChecks           = "prechecks"
 
 	// Transfer flags
@@ -1435,6 +1436,10 @@ var flagsMap = map[string]cli.Flag{
 		Name:  Status,
 		Usage: "[Default: false] Set to true to show the status of the transfer-files command currently in progress.` `",
 	},
+	Stop: cli.BoolFlag{
+		Name:  Stop,
+		Usage: "[Default: false] Set to true to stop the transfer-files command currently in progress. Useful when running the transfer-files command in the background.` `",
+	},
 	installPluginVersion: cli.StringFlag{
 		Name:  Version,
 		Usage: "[Default: latest] The plugin version to download and install.` `",
@@ -1721,7 +1726,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, deleteQuiet,
 	},
 	TransferFiles: {
-		Filestore, IncludeRepos, ExcludeRepos, IgnoreState, ProxyKey, transferFilesStatus, PreChecks,
+		Filestore, IncludeRepos, ExcludeRepos, IgnoreState, ProxyKey, transferFilesStatus, Stop, PreChecks,
 	},
 	TransferInstall: {
 		installPluginVersion, InstallPluginSrcDir, InstallPluginHomeDir,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

Depends on https://github.com/jfrog/jfrog-cli-core/pull/667

Add --stop flag to the `jf rt transfer-files` command.
Usage:
```
# Run transfer files in the background
nohup jf rt transfer-files <source-server> <target-server> &

# Stop from a different process
jf rt transfer-files --stop
```