### PR TITLE
File Spec schema - set sortBy property as type array of strings

### DIFF
--- a/schema/filespec-schema.json
+++ b/schema/filespec-schema.json
@@ -134,7 +134,7 @@
         "items": {
           "type": "string"
         },
-        "description": "A list of semicolon-separated fields to sort by. The fields must be part of the 'items' AQL domain.",
+        "description": "A list of fields to sort by. The fields must be part of the 'items' AQL domain.",
         "examples": [
           "repo",
           "path",

--- a/schema/filespec-schema.json
+++ b/schema/filespec-schema.json
@@ -130,7 +130,10 @@
         "default": "false"
       },
       "sortBy": {
-        "type": "string",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
         "description": "A list of semicolon-separated fields to sort by. The fields must be part of the 'items' AQL domain.",
         "examples": [
           "repo",


### PR DESCRIPTION
Hello

using a filespec defined as follow

```json 
{
    "files": [
        {
            "sortBy": "path",
            "sortOrder": "asc",
            "aql": {
                "items.find": {
                    "repo": {
                        "$match": "docker-*"
                    },
                    "type": "folder",
                    "$and": [
                        {"@name": {"$match":"*"}},
                        {"@version": {"$match":"*"}}
                    ]
                }
            }
        }
    ]
}
```

and calling the cli with the previous spec file content 

`jf rt s --spec=search-docker.filespec`

I receive the following error

```
[Debug] JFrog CLI version: 2.34.1
[Debug] OS/Arch: darwin/amd64
[🚨Error] json: cannot unmarshal string into Go struct field File.Files.SortBy of type []string
```

This should means that in the filespec-schema.json the sortBy property should be defined as type array of strings.



