### PR TITLE
GitLab - Support downloading JFrog CLI from remote repository

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,7 +126,7 @@ def runRelease(architectures) {
                     if (identifier == "v2-jf") {
                         sh """#!/bin/bash
                             $builderPath rt cp jfrog-cli/$identifier/$version/scripts/setup-cli.sh jfrog-cli/setup/scripts/getCli.sh --flat $options --fail-no-op
-                            $builderPath rt cp jfrog-cli/$identifier/$version/scripts/.setup-jfrog.yml jfrog-cli/gitlab/.setup-jfrog.yml --flat $options --fail-no-op
+                            $builderPath rt cp jfrog-cli/$identifier/$version/scripts/gitlab/(*) jfrog-cli/gitlab/{1} $options --fail-no-op
                         """
                     }
                 }
@@ -304,7 +304,7 @@ def uploadSetupCliToJfrogRepo21() {
 
 def uploadGitLabSetupToJfrogRepo21() {
     sh """#!/bin/bash
-        $builderPath rt u $jfrogCliRepoDir/build/gitlab/.setup-jfrog.yml ecosys-jfrog-cli/$identifier/$version/scripts/.setup-jfrog.yml --flat
+        $builderPath rt u $jfrogCliRepoDir/build/gitlab/(*) ecosys-jfrog-cli/$identifier/$version/scripts/gitlab/{1}
     """
 }
 

--- a/build/gitlab/.setup-jfrog.yml
+++ b/build/gitlab/.setup-jfrog.yml
@@ -1,5 +1,8 @@
 .setup_jfrog:
   script:
+    - echo 'A new major version of this setup is available.'
+    - echo 'To use it, include the setup from the updated URL "https://releases.jfrog.io/artifactory/jfrog-cli/gitlab/v2/.setup-jfrog-unix.yml"'
+
     - PLUGIN_VERSION="1.0.0"
 
     # Get custom CLI version, if set
@@ -45,6 +48,10 @@
 
 .setup_jfrog_windows:
   script:
+    - Write-Host 'A new major version of this setup is available.'
+    - Write-Host 'To use it, include the setup from the updated URL "https://releases.jfrog.io/artifactory/jfrog-cli/gitlab/v2/.setup-jfrog-windows.yml"'
+    - Write-Host 'Then change the reference to the cleanup script to .cleanup_jfrog (from .cleanup_jfrog_windows)'
+
     - $PLUGIN_VERSION="1.0.0"
 
     # Get custom CLI version, if set

--- a/build/gitlab/v2/.setup-jfrog-unix.yml
+++ b/build/gitlab/v2/.setup-jfrog-unix.yml
@@ -1,0 +1,161 @@
+# This script downloads the latest version of JFrog CLI, unless a specific version is requested.
+# By default, JFrog CLI is downloaded from releases.jfrog.io.
+# The script also supports downloading from a remote repository, by setting the following environment variables:
+# 1. JF_RELEASES_REPO - name of the remote repository, pointing to "https://releases.jfrog.io/artifactory/"
+# 2. JF_URL - URL of the JFrog Platform that includes the remote repository.
+# 3. Credentials to the JFrog Platform:
+#   a. JF_ACCESS_TOKEN
+#   OR
+#   b. JF_USER & JF_PASSWORD
+.download_jf: &download_jf
+  # Install the latest JFrog CLI version, unless JFROG_CLI_VERSION is provided.
+  - |
+    if [ -n "${JFROG_CLI_VERSION}" ]; then
+      VERSION="${JFROG_CLI_VERSION}"
+      echo "Downloading version $VERSION of JFrog CLI..."
+    else
+      VERSION="[RELEASE]"
+      echo "Downloading the latest version of JFrog CLI..."
+    fi
+
+  # Download from remote repository if required.
+  - |
+    if [ -z "${JF_RELEASES_REPO}" ]
+    then
+        BASE_URL="https://releases.jfrog.io/artifactory"
+        AUTH_HEADER=""
+        echo "Downloading directly from releases.jfrog.io..."
+    else
+        # Make sure URL does not contain duplicate separators.
+        BASE_URL="${JF_URL%/}/artifactory/${JF_RELEASES_REPO%/}"
+        if [ -n "${JF_ACCESS_TOKEN}" ]; then
+            AUTH_HEADER="Authorization: Bearer ${JF_ACCESS_TOKEN}"
+        else
+            AUTH_HEADER="Authorization: Basic $(printf ${JF_USER}:${JF_PASSWORD} | base64)"
+        fi
+        echo "Downloading from remote repository '${JF_RELEASES_REPO}'..."
+    fi
+    echo ""
+
+  # Build the URL to the executable matching the OS.
+  - |
+    if $(echo "${OSTYPE}" | grep -q darwin); then
+        CLI_OS="mac"
+        if [[ $(uname -m) == 'arm64' ]]; then
+          URL="${BASE_URL}/jfrog-cli/v2-jf/${VERSION}/jfrog-cli-mac-arm64/jf"
+        else
+          URL="${BASE_URL}/jfrog-cli/v2-jf/${VERSION}/jfrog-cli-mac-386/jf"
+        fi
+        FILE_NAME="jf"
+    else
+        CLI_OS="linux"
+        MACHINE_TYPE="$(uname -m)"
+        case $MACHINE_TYPE in
+            i386 | i486 | i586 | i686 | i786 | x86)
+                ARCH="386"
+                ;;
+            amd64 | x86_64 | x64)
+                ARCH="amd64"
+                ;;
+            arm | armv7l)
+                ARCH="arm"
+                ;;
+            aarch64)
+                ARCH="arm64"
+                ;;
+            s390x)
+                ARCH="s390x"
+                ;;
+            ppc64)
+               ARCH="ppc64"
+               ;;
+            ppc64le)
+               ARCH="ppc64le"
+               ;;
+            *)
+                echo "Unknown machine type: $MACHINE_TYPE"
+                exit -1
+                ;;
+        esac
+        URL="${BASE_URL}/jfrog-cli/v2-jf/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/jf"
+        FILE_NAME="jf"
+    fi
+
+  # Download with curl and verify exit code and status code.
+  - status_code=$(curl -XGET "$URL" -L -k -g -w "%{http_code}" -f -O -H "${AUTH_HEADER}")
+  - exit_code=$?
+  - |
+    if [ $exit_code -ne 0 ]; then
+      echo "Error: Failed downloading JFrog CLI"
+      exit $exit_code
+    fi
+
+  - |
+    if [ $status_code != "200" ]; then
+      echo "Error: Received unexpected HTTP status code: $status_code"
+      exit 1
+    fi
+  - chmod u+x $FILE_NAME
+
+.set_jfrog_bin: &set_jfrog_bin
+  - JFROG_BIN="$HOME/.jfrog/bin/"
+  - PATH="$JFROG_BIN:$PATH"
+
+.setup_jfrog:
+  script:
+    - PLUGIN_VERSION="1.1.0"
+
+    # Assert JF_URL is provided.
+    - |
+      if [ -z "${JF_URL}" ]; then
+        echo "The 'JF_URL' variable is mandatory."
+        exit 1
+      fi
+
+    # Configure JFrog bin directory to download JFrog CLI to.
+    - *set_jfrog_bin
+    - mkdir -p $JFROG_BIN
+    - chmod +x $JFROG_BIN
+
+    # Download JFrog CLI and move to the bin directory.
+    - *download_jf
+    - mv ./jf "$JFROG_BIN/"
+
+    # Verify CLI was downloaded.
+    - |
+      if [ ! -f $(which jf) ]; then
+          echo "JFrog CLI Installation failed."
+          exit 1
+      fi
+
+    # Create server ID.
+    - CONFIG_CMD="jf c add setup-jfrog-gitlab-ci-server-${CI_JOB_ID} --overwrite --url ${JF_URL}"
+    - |
+      if [ -n "${JF_ACCESS_TOKEN}" ]; then
+        CONFIG_CMD="${CONFIG_CMD} --access-token=${JF_ACCESS_TOKEN}"
+      elif [ -n "${JF_USER}" ] && [ -n "${JF_PASSWORD}" ]; then
+        CONFIG_CMD="${CONFIG_CMD} --user=${JF_USER} --password=${JF_PASSWORD}"
+      fi
+    - "${CONFIG_CMD}"
+
+    # Export general environment variables:
+    - export JFROG_CLI_USER_AGENT="setup-jfrog-for-gitlab/${PLUGIN_VERSION}"
+    - export CI=${CI:=true}
+    - export JFROG_CLI_BUILD_NAME=$CI_PROJECT_PATH_SLUG-$CI_COMMIT_REF_NAME
+    - export JFROG_CLI_BUILD_NUMBER=$CI_PIPELINE_ID
+    - export JFROG_CLI_BUILD_URL=$CI_PIPELINE_URL
+    - export JFROG_CLI_ENV_EXCLUDE=${JFROG_CLI_ENV_EXCLUDE:='*password*;*secret*;*key*;*token*;*auth*;JF_URL;JF_USER;JF_PASSWORD;JF_ACCESS_TOKEN'}
+
+    # Override registry variables if JF_DOCKER_REGISTRY was set:
+    - |
+      if [ -n "${JF_DOCKER_REGISTRY}" ]; then
+        export CI_REGISTRY=$JF_DOCKER_REGISTRY
+        export CI_REGISTRY_IMAGE="$JF_DOCKER_REGISTRY/$CI_PROJECT_NAMESPACE/$CI_PROJECT_NAME"
+        export CI_REGISTRY_USER=$JF_USER
+        export CI_REGISTRY_PASSWORD=${JF_ACCESS_TOKEN:=$JF_PASSWORD}
+      fi
+
+.cleanup_jfrog:
+  script:
+    - *set_jfrog_bin
+    - jf c rm setup-jfrog-gitlab-ci-server-${CI_JOB_ID} --quiet

--- a/build/gitlab/v2/.setup-jfrog-unix.yml
+++ b/build/gitlab/v2/.setup-jfrog-unix.yml
@@ -1,7 +1,7 @@
 # This script downloads the latest version of JFrog CLI, unless a specific version is requested.
 # By default, JFrog CLI is downloaded from releases.jfrog.io.
-# The script also supports downloading from a remote repository, by setting the following environment variables:
-# 1. JF_RELEASES_REPO - name of the remote repository, pointing to "https://releases.jfrog.io/artifactory/"
+# The script also supports downloading JFrog CLI from an Artifactory remote repository, by setting the following environment variables:
+# 1. JF_RELEASES_REPO - name of the generic remote repository, pointing to "https://releases.jfrog.io/artifactory/"
 # 2. JF_URL - URL of the JFrog Platform that includes the remote repository.
 # 3. Credentials to the JFrog Platform:
 #   a. JF_ACCESS_TOKEN
@@ -103,7 +103,7 @@
 
 .setup_jfrog:
   script:
-    - PLUGIN_VERSION="1.1.0"
+    - PLUGIN_VERSION="2.0.0"
 
     # Assert JF_URL is provided.
     - |

--- a/build/gitlab/v2/.setup-jfrog-unix.yml
+++ b/build/gitlab/v2/.setup-jfrog-unix.yml
@@ -139,7 +139,7 @@
     - "${CONFIG_CMD}"
 
     # Export general environment variables:
-    - export JFROG_CLI_USER_AGENT="setup-jfrog-for-gitlab/${PLUGIN_VERSION}"
+    - export JFROG_CLI_USER_AGENT="setup-jfrog-for-gitlab-unix/${PLUGIN_VERSION}"
     - export CI=${CI:=true}
     - export JFROG_CLI_BUILD_NAME=$CI_PROJECT_PATH_SLUG-$CI_COMMIT_REF_NAME
     - export JFROG_CLI_BUILD_NUMBER=$CI_PIPELINE_ID

--- a/build/gitlab/v2/.setup-jfrog-windows.yml
+++ b/build/gitlab/v2/.setup-jfrog-windows.yml
@@ -55,7 +55,7 @@
     - Invoke-Expression $CONFIG_CMD
 
     # Export general environment variables:
-    - $env:JFROG_CLI_USER_AGENT="setup-jfrog-for-gitlab/$PLUGIN_VERSION"
+    - $env:JFROG_CLI_USER_AGENT="setup-jfrog-for-gitlab-windows/$PLUGIN_VERSION"
     - $env:CI=${env:CI -or $true}
     - $env:JFROG_CLI_BUILD_NAME="$env:CI_PROJECT_PATH_SLUG-$env:CI_COMMIT_REF_NAME"
     - $env:JFROG_CLI_BUILD_NUMBER=$env:CI_PIPELINE_ID

--- a/build/gitlab/v2/.setup-jfrog-windows.yml
+++ b/build/gitlab/v2/.setup-jfrog-windows.yml
@@ -4,7 +4,7 @@
 
 .setup_jfrog:
   script:
-    - $PLUGIN_VERSION="1.1.0"
+    - $PLUGIN_VERSION="2.0.0"
 
     # Download the latest JFrog CLI version, unless JFROG_CLI_VERSION is provided.
     - |

--- a/build/gitlab/v2/.setup-jfrog-windows.yml
+++ b/build/gitlab/v2/.setup-jfrog-windows.yml
@@ -1,0 +1,77 @@
+.set_jfrog_bin: &set_jfrog_bin
+  - $JFROG_BIN="$env:USERPROFILE\.jfrog\bin\"
+  - $env:PATH="$JFROG_BIN;$env:PATH"
+
+.setup_jfrog:
+  script:
+    - $PLUGIN_VERSION="1.1.0"
+
+    # Download the latest JFrog CLI version, unless JFROG_CLI_VERSION is provided.
+    - |
+      if ($env:JFROG_CLI_VERSION) {
+        Write-Host "Downloading version $env:JFROG_CLI_VERSION of JFrog CLI..."
+      } else {
+        $env:JFROG_CLI_VERSION = "[RELEASE]"
+        Write-Host "Downloading the latest version of JFrog CLI..."
+      }
+
+    # Configure JFrog bin directory to download JFrog CLI to.
+    - *set_jfrog_bin
+    - If (!(test-path $JFROG_BIN)) { mkdir $JFROG_BIN }
+
+    # Download will be done from a remote repository if JF_RELEASES_REPO was set.
+    - |
+      if (-not $env:JF_RELEASES_REPO) {
+        Write-Host "Downloading JFrog CLI directly from releases.jfrog.io..."
+        $BASE_URL="https://releases.jfrog.io/artifactory"
+        $AUTH_HEADER=@{}
+      } else {
+        Write-Host "Downloading JFrog CLI from remote repository '$env:JF_RELEASES_REPO'..."
+        $BASE_URL=$env:JF_URL.trim('/') + "/artifactory/" + $env:JF_RELEASES_REPO.trim('/')
+        if ($env:JF_ACCESS_TOKEN) {
+          $AUTH_HEADER = @{Authorization = "Bearer $env:JF_ACCESS_TOKEN"}
+        } else {
+          $ENCODED_CREDS = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($env:JF_USER + ":" + $env:JF_PASSWORD))
+          $AUTH_HEADER = @{Authorization = "Basic $ENCODED_CREDS"}
+        }
+      }
+    - iwr $BASE_URL/jfrog-cli/v2-jf/$env:JFROG_CLI_VERSION/jfrog-cli-windows-amd64/jf.exe -OutFile $JFROG_BIN\jf.exe -Headers $AUTH_HEADER
+
+    # Verify CLI was downloaded.
+    - |
+      if (-not (Get-Command "jf" -ErrorAction SilentlyContinue)) {
+        Write-Host "JFrog CLI Installation failed."
+      exit 1
+      }
+
+    # Create server ID.
+    - $CONFIG_CMD="jf c add setup-jfrog-gitlab-ci-server-$env:CI_JOB_ID --overwrite --url $env:JF_URL"
+    - |
+      if ($env:JF_ACCESS_TOKEN) {
+          $CONFIG_CMD="$CONFIG_CMD --access-token=$env:JF_ACCESS_TOKEN"
+      } elseif ($env:JF_USER -and $env:JF_PASSWORD) {
+          $CONFIG_CMD="$CONFIG_CMD --user=$env:JF_USER --password=$env:JF_PASSWORD"
+      }
+    - Invoke-Expression $CONFIG_CMD
+
+    # Export general environment variables:
+    - $env:JFROG_CLI_USER_AGENT="setup-jfrog-for-gitlab/$PLUGIN_VERSION"
+    - $env:CI=${env:CI -or $true}
+    - $env:JFROG_CLI_BUILD_NAME="$env:CI_PROJECT_PATH_SLUG-$env:CI_COMMIT_REF_NAME"
+    - $env:JFROG_CLI_BUILD_NUMBER=$env:CI_PIPELINE_ID
+    - $env:JFROG_CLI_BUILD_URL=$env:CI_PIPELINE_URL
+    - if (-not $env:JFROG_CLI_ENV_EXCLUDE) { $env:JFROG_CLI_ENV_EXCLUDE='password;secret;key;token;auth;JF_URL;JF_USER;JF_PASSWORD;JF_ACCESS_TOKEN' }
+
+    # Override registry variables if JF_DOCKER_REGISTRY was set:
+    - |
+      if ($env:JF_DOCKER_REGISTRY) {
+        $env:CI_REGISTRY=$env:JF_DOCKER_REGISTRY
+        $env:CI_REGISTRY_IMAGE="$env:JF_DOCKER_REGISTRY/$env:CI_PROJECT_NAMESPACE/$env:CI_PROJECT_NAME"
+        $env:CI_REGISTRY_USER=$env:JF_USER
+        if ($env:JF_ACCESS_TOKEN) { $env:CI_REGISTRY_PASSWORD=$env:JF_ACCESS_TOKEN } elseif ($env:JF_PASSWORD) { $env:CI_REGISTRY_PASSWORD=$env:JF_PASSWORD }
+      }
+
+.cleanup_jfrog:
+  script:
+    - *set_jfrog_bin
+    - jf c rm setup-jfrog-gitlab-ci-server-${CI_JOB_ID} --quiet


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Setup JFrog for GitLab:

This PR introduces a new major version, and changes the way the setup should be included and referenced.
For Unix agents:
```yaml
include:
  - remote: 'https://releases.jfrog.io/artifactory/jfrog-cli/gitlab/v2/.setup-jfrog-unix.yml'
```
For Windows agents:
```yaml
include:
  - remote: 'https://releases.jfrog.io/artifactory/jfrog-cli/gitlab/v2/.setup-jfrog-windows.yml'
```

Then, referencing the script is the same on both agents:
```yaml
job:
  script:
    - !reference [.setup_jfrog, script]
```

```yaml
job:
  after_script:
    - !reference [.cleanup_jfrog, script]
```

Improvements:
1. Support downloading JFrog CLI from a remote repository, for runners with limited access to the internet. To use, set `JF_RELEASES_REPO` as a CI/CD variable which value is a name of a remote repository pointing to `https://releases.jfrog.io/artifactory/`. (Following #1857)
2. Add logs stating when the latest version of JFrog CLI is downloaded, or the requested version otherwise. (Following #1865 )

Bug fix:
 - Fix a bug where the JFrog CLI couldn't be installed due to a permissions issue when the runner does not run as root.

