### PR TITLE
Podman - Fix Pulling Docker images with manifest v2 schema 1 to this repository is blocked.

### DIFF
--- a/testdata/docker_local_promote_repository_config.json
+++ b/testdata/docker_local_promote_repository_config.json
@@ -1,5 +1,6 @@
 {
   "key": "${DOCKER_PROMOTE_REPO}",
   "rclass": "local",
-  "packageType": "docker"
+  "packageType": "docker",
+  "blockPushingSchema1": "false"
 }

--- a/testdata/docker_local_repository_config.json
+++ b/testdata/docker_local_repository_config.json
@@ -1,5 +1,6 @@
 {
   "key": "${DOCKER_REPO}",
   "rclass": "local",
-  "packageType": "docker"
+  "packageType": "docker",
+  "blockPushingSchema1": "false"
 }

--- a/testdata/docker_remote_repository_config.json
+++ b/testdata/docker_remote_repository_config.json
@@ -2,5 +2,7 @@
   "key": "${DOCKER_REMOTE_REPO}",
   "rclass": "remote",
   "packageType": "docker",
-  "url": "https://registry-1.docker.io/"
+  "url": "https://registry-1.docker.io/",
+  "blockPushingSchema1": "false"
+
 }

--- a/testdata/docker_virtual_repository_config.json
+++ b/testdata/docker_virtual_repository_config.json
@@ -3,5 +3,7 @@
   "rclass": "virtual",
   "packageType": "docker",
   "repositories": ["${DOCKER_REMOTE_REPO}", "${DOCKER_REPO}"],
-  "defaultDeploymentRepo": "${DOCKER_REPO}"
+  "defaultDeploymentRepo": "${DOCKER_REPO}",
+  "blockPushingSchema1": "false"
+
 }


### PR DESCRIPTION
This PR attempt to fix Podman tests for error :
```
Pulling Docker images with manifest v2 schema 1 to this repository is blocked.
```
- [ ] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
