### PR TITLE
Fix version check timeout

### DIFF
--- a/utils/cliutils/utils.go
+++ b/utils/cliutils/utils.go
@@ -829,7 +829,8 @@ func getLatestCliVersionFromGithubAPI() (githubVersionInfo githubResponse, err e
 		return
 	}
 	resp, body, err := doHttpRequest(client, req)
-	if errorutils.CheckError(err) != nil {
+	if err != nil {
+		err = errors.New("couldn't get latest JFrog CLI latest version info from GitHub API: " + err.Error())
 		return
 	}
 	err = errorutils.CheckResponseStatusWithBody(resp, body, http.StatusOK)

--- a/utils/cliutils/utils.go
+++ b/utils/cliutils/utils.go
@@ -2,6 +2,7 @@ package cliutils
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/jfrog/gofrog/version"
 	"io"
@@ -26,7 +27,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/content"
 	"github.com/jfrog/jfrog-client-go/utils/log"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -824,7 +824,7 @@ func getLatestCliVersionFromGithubAPI() (githubVersionInfo githubResponse, err e
 	if errorutils.CheckError(err) != nil {
 		return
 	}
-	req, err := http.NewRequest("GET", "https://api.github.com/repos/jfrog/jfrog-cli/releases/latest", nil)
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/jfrog/jfrog-cli/releases/latest", nil)
 	if errorutils.CheckError(err) != nil {
 		return
 	}
@@ -848,10 +848,8 @@ func doHttpRequest(client *http.Client, req *http.Request) (resp *http.Response,
 	}
 	defer func() {
 		if resp != nil && resp.Body != nil {
-			e := resp.Body.Close()
-			if err == nil {
-				err = errorutils.CheckError(e)
-			}
+			e := errorutils.CheckError(resp.Body.Close())
+			err = errors.Join(err, e)
 		}
 	}()
 	body, err = io.ReadAll(resp.Body)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Send CLI version check request without printing warnings to the log (in case of failure) and with a timeout.