### PR TITLE
Fix the link of the header  image in the JFrog CLI documentation

### DIFF
--- a/documentation/JFrog-CLI.md
+++ b/documentation/JFrog-CLI.md
@@ -1,5 +1,6 @@
 # JFrog CLI 
-[![JFrog CLI](https://github.com/jfrog/jfrog-cli/blob/v2/images/jfrog-cli-intro.png)](https://jfrog.com/help/r/jfrog-cli/jfrog-cli)
+[![JFrog CLI](https://jfrog.com/help/r/jfrog-cli/jfrog-cli)](https://github.com/jfrog/jfrog-cli/blob/v2/images/jfrog-cli-intro.png)
+
 
 ## About JFrog CLI
 ### General

--- a/documentation/JFrog-CLI.md
+++ b/documentation/JFrog-CLI.md
@@ -1,6 +1,5 @@
 # JFrog CLI 
-[![JFrog CLI](https://jfrog.com/help/r/jfrog-cli/jfrog-cli)](https://github.com/jfrog/jfrog-cli/blob/v2/images/jfrog-cli-intro.png)
-
+![image](https://github.com/jfrog/jfrog-cli/blob/v2/images/jfrog-cli-intro.png)
 
 ## About JFrog CLI
 ### General


### PR DESCRIPTION
Fix the link of the header  image in the JFrog CLI documentation.