### PR TITLE
Fixing gradleCmd to allow args to have spaces similarly to fix on PR 921

### DIFF
--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -497,7 +497,7 @@ func GradleCmd(c *cli.Context) (err error) {
 		return err
 	}
 	printDeploymentView := log.IsStdErrTerminal()
-	gradleCmd := gradle.NewGradleCommand().SetConfiguration(buildConfiguration).SetTasks(strings.Join(filteredGradleArgs, " ")).SetConfigPath(configFilePath).SetThreads(threads).SetDetailedSummary(detailedSummary || printDeploymentView).SetXrayScan(xrayScan).SetScanOutputFormat(scanOutputFormat)
+	gradleCmd := gradle.NewGradleCommand().SetConfiguration(buildConfiguration).SetTasks(filteredGradleArgs).SetConfigPath(configFilePath).SetThreads(threads).SetDetailedSummary(detailedSummary || printDeploymentView).SetXrayScan(xrayScan).SetScanOutputFormat(scanOutputFormat)
 	err = commands.Exec(gradleCmd)
 	result := gradleCmd.Result()
 	defer cliutils.CleanupResult(result, &err)


### PR DESCRIPTION

- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
This PR is related to https://github.com/jfrog/jfrog-cli/pull/921 and is needed to pass in multiple tags with space. For example:
-Dkarate.options="--tags=@Smoke --tags=~@Regression"

This command fails when being passed as the gradle command using jfrog cli like so
'jfrog rt gradle clean assemble myTest -Dkarate.options="--tags=@Smoke --tags=~@Regression"'

Currently the gradleCmd is not taking the complete value of -Dkarate.options and is interpreting the white space in the command as a break in the cmd line argument for -Dkarate.options and is then looking at --tags as a commandline argument. Here is an example of how it is appearing in the logs.

'jfrog rt gradle clean assemble myTest -Dkarate.options=--tags=@Smoke --tags=~@Regression'

Note the space after '@Smoke'. This is what appears to be causing us issues. As the error coming into our logs is saying --tags is not a command line argument.

