### PR TITLE
Changed the main.go path to ../main.go in the build.sh file

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -8,5 +8,5 @@ if [ $# -eq 0 ]
 	exe_name="$1"
 fi
 
-CGO_ENABLED=0 go build -o $exe_name -ldflags '-w -extldflags "-static"' main.go
+CGO_ENABLED=0 go build -o $exe_name -ldflags '-w -extldflags "-static"' ../main.go
 echo "The $exe_name executable was successfully created."


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
When attempting to run the build on MacOS using the 'sh build.sh' command, the build process encountered a failure due to an incorrect path of the main.go file, with the following message:
`no required module provides package main.go; to add it:
        go get main.go`
However, after modifying the build.sh file and updating the path to ../main.go, the build process was successful.