### PR TITLE
Avoid creating the release on GitHub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,13 +149,6 @@ def createTagAndRelease() {
                 sh """#!/bin/bash
                     git tag $releaseTag
                     git push "https://$GITHUB_ACCESS_TOKEN@github.com/jfrog/jfrog-cli.git" --tags
-                    curl -L \
-                      -X POST \
-                      -H "Accept: application/vnd.github+json" \
-                      -H "Authorization: Bearer $GITHUB_ACCESS_TOKEN"\
-                      -H "X-GitHub-Api-Version: 2022-11-28" \
-                      https://api.github.com/repos/jfrog/jfrog-cli/releases \
-                      -d '{"tag_name":"$releaseTag","target_commitish":"$BRANCH","name":"$RELEASE_VERSION","generate_release_notes":true}'
                     """
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,7 +133,7 @@ def runRelease(architectures) {
                 }
             }
             if (identifier == "v2") {
-                createTagAndRelease()
+                createTag()
             }
         }
     } finally {
@@ -141,7 +141,7 @@ def runRelease(architectures) {
     }
 }
 
-def createTagAndRelease() {
+def createTag() {
     stage('Create a tag and a GitHub release') {
         dir("$jfrogCliRepoDir") {
             releaseTag = "v$RELEASE_VERSION"


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli/actions/workflows/analysis.yml) passed.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

This pull request proposes abstaining from generating the release on GitHub and creating the release notes during the CI process in order to deliver the final release notes to users via email. Instead, it suggests that the ecosystem developer manually create the release and release notes.