### PR TITLE
Increase chocolatey publish retries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -411,9 +411,9 @@ def publishNpmPackage(jfrogCliRepoDir) {
 }
 
 def publishChocoPackageWithRetries(version, jfrogCliRepoDir, architectures) {
-    def maxAttempts = 3
+    def maxAttempts = 10
     def currentAttempt = 1
-    def waitSeconds = 20
+    def waitSeconds = 18
 
     while (currentAttempt <= maxAttempts) {
         try {


### PR DESCRIPTION
Publishing the new released executables to chocolatey fails quite often.
This PR increases the retry time to 3min.