### PR TITLE
Transfer files - fix repo snapshot manager error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,7 @@ require (
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 dev
+replace github.com/jfrog/jfrog-cli-core/v2 => /Users/eyalb/dev/forks/jfrog-cli-core
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.2.6-0.20230418122323-2bf299dd6d27
 

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,6 @@ github.com/jfrog/build-info-go v1.9.6 h1:lCJ2j5uXAlJsSwDe5J8WD7Co1f/hUlZvMfwfb5A
 github.com/jfrog/build-info-go v1.9.6/go.mod h1:GbuFS+viHCKZYx9nWHYu7ab1DgQkFdtVN3BJPUNb2D4=
 github.com/jfrog/gofrog v1.3.0 h1:o4zgsBZE4QyDbz2M7D4K6fXPTBJht+8lE87mS9bw7Gk=
 github.com/jfrog/gofrog v1.3.0/go.mod h1:IFMc+V/yf7rA5WZ74CSbXe+Lgf0iApEQLxRZVzKRUR0=
-github.com/jfrog/jfrog-cli-core/v2 v2.39.3 h1:GtBwEAchuvI4c8ZwaJ6CKN/KavMlEu5+DwNX9OesYMI=
-github.com/jfrog/jfrog-cli-core/v2 v2.39.3/go.mod h1:/HJ9mO3AZsACtQWxkwMj7REWPdXT3yHKjJXjPHlmB34=
 github.com/jfrog/jfrog-client-go v1.31.2 h1:foy8owM2lS8jZL7zuBPtcx1RpF1GeIXaXF8hIufyr4I=
 github.com/jfrog/jfrog-client-go v1.31.2/go.mod h1:qEJxoe68sUtqHJ1YhXv/7pKYP/9p1D5tJrruzJKYeoI=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -367,7 +367,7 @@ func addChildWithFiles(t *testing.T, parent *reposnapshot.Node, dirName string, 
 		assert.NoError(t, childNode.IncrementFilesCount())
 	}
 
-	assert.NoError(t, parent.AddChildNode(dirName, []*reposnapshot.Node{childNode}))
+	assert.NoError(t, parent.AddChildNode(dirName))
 
 	if explored {
 		assert.NoError(t, childNode.MarkDoneExploring())


### PR DESCRIPTION
This PR depends on https://github.com/jfrog/jfrog-cli-core/pull/880, which includes the full description for the fixed issue.