### PR TITLE
Upload - Add timezone to each zip file before uploading

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -4174,6 +4174,7 @@ func TestUploadZipAndCheckDeploymentViewWithArchive(t *testing.T) {
 	assert.NoError(t, os.Mkdir(tests.Out, 0755))
 	wd, err := os.Getwd()
 	assert.NoError(t, err)
+	defer cleanArtifactoryTest()
 	chdirCallback := clientTestUtils.ChangeDirWithCallback(t, wd, tests.Out)
 	defer chdirCallback()
 
@@ -4196,7 +4197,6 @@ func TestUploadZipAndCheckDeploymentViewWithArchive(t *testing.T) {
 		assert.Equal(t, sysTimezoneOffset, fileTimezoneOffset)
 	}
 
-	cleanArtifactoryTest()
 }
 
 func TestUploadDetailedSummary(t *testing.T) {

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"archive/zip"
 	"bytes"
 	"crypto/tls"
 	"encoding/csv"
@@ -4163,6 +4164,38 @@ func TestUploadDeploymentViewWithArchive(t *testing.T) {
 	defer cleanupFunc()
 	assert.NoError(t, artifactoryCli.Exec("upload", filepath.Join("testdata", "a", "a*.in"), path.Join(tests.RtRepo1, "z.zip"), "--archive", "zip"))
 	assertPrintedDeploymentViewFunc()
+	cleanArtifactoryTest()
+}
+
+func TestUploadZipAndCheckDeploymentViewWithArchive(t *testing.T) {
+	initArtifactoryTest(t, "")
+
+	// Create tmp dir
+	assert.NoError(t, os.Mkdir(tests.Out, 0755))
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	chdirCallback := clientTestUtils.ChangeDirWithCallback(t, wd, tests.Out)
+	defer chdirCallback()
+
+	// Create file and a zip
+	fileName := "dummy_file.txt"
+	zipName := "test.zip"
+	assert.NoError(t, os.WriteFile(fileName, nil, 0644))
+
+	// Upload & download zip file
+	assert.NoError(t, artifactoryCli.Exec("upload", fileName, path.Join(tests.RtRepo1, zipName), "--archive", "zip"))
+	assert.NoError(t, artifactoryCli.Exec("download", path.Join(tests.RtRepo1, zipName)))
+
+	// Check for time-zone offset for each file in the zip
+	r, err := zip.OpenReader(zipName)
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, r.Close()) }()
+	_, sysTimezoneOffset := time.Now().Zone()
+	for _, file := range r.File {
+		_, fileTimezoneOffset := file.Modified.Zone()
+		assert.Equal(t, sysTimezoneOffset, fileTimezoneOffset)
+	}
+
 	cleanArtifactoryTest()
 }
 

--- a/go.sum
+++ b/go.sum
@@ -315,8 +315,6 @@ github.com/opencontainers/runc v1.1.5 h1:L44KXEpKmfWDcS02aeGm8QNTFXTo2D+8MYGDIJ/
 github.com/opencontainers/runc v1.1.5/go.mod h1:1J5XiS+vdZ3wCyZybsuxXZWGrgSr8fFJHLXuG2PsnNg=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
-github.com/or-geva/jfrog-client-go v0.5.1-0.20230731084716-4faa9868c57d h1:/jhhsCLIe9C7WDG3aq2bWJ4Z1cYPhQf7SaXja3c4UaE=
-github.com/or-geva/jfrog-client-go v0.5.1-0.20230731084716-4faa9868c57d/go.mod h1:qEJxoe68sUtqHJ1YhXv/7pKYP/9p1D5tJrruzJKYeoI=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/owenrumney/go-sarif/v2 v2.2.0 h1:1DmZaijK0HBZCR1fgcDSGa7VzYkU9NDmbZ7qC2QfUjE=
 github.com/owenrumney/go-sarif/v2 v2.2.0/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=

--- a/go.sum
+++ b/go.sum
@@ -315,6 +315,8 @@ github.com/opencontainers/runc v1.1.5 h1:L44KXEpKmfWDcS02aeGm8QNTFXTo2D+8MYGDIJ/
 github.com/opencontainers/runc v1.1.5/go.mod h1:1J5XiS+vdZ3wCyZybsuxXZWGrgSr8fFJHLXuG2PsnNg=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
+github.com/or-geva/jfrog-client-go v0.5.1-0.20230731084716-4faa9868c57d h1:/jhhsCLIe9C7WDG3aq2bWJ4Z1cYPhQf7SaXja3c4UaE=
+github.com/or-geva/jfrog-client-go v0.5.1-0.20230731084716-4faa9868c57d/go.mod h1:qEJxoe68sUtqHJ1YhXv/7pKYP/9p1D5tJrruzJKYeoI=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/owenrumney/go-sarif/v2 v2.2.0 h1:1DmZaijK0HBZCR1fgcDSGa7VzYkU9NDmbZ7qC2QfUjE=
 github.com/owenrumney/go-sarif/v2 v2.2.0/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
By uploading files with archive as zip, the timezone offset is not saved.
This PR checks that each file has the correct timezone.

Dependent on:
* https://github.com/jfrog/jfrog-client-go/pull/802
