### PR TITLE
Remove yarn 2+ restriction from audit flag description and docs

### DIFF
--- a/documentation/CLI-for-JFrog-Artifactory.md
+++ b/documentation/CLI-for-JFrog-Artifactory.md
@@ -45,7 +45,7 @@ To authenticate yourself using your JFrog login credentials, either configure yo
 | --user         | JFrog username                                                        |
 | --password     | JFrog password or API key                                             |
 
-For enhanced security, when JFrog CLI is configured to use username and password / API key, it automatically generates an access token to authenticates with Artifactory. The generated access token is valid for one hour only. JFrog CLI automatically refreshed the token before it expires. The **jfrog c add** command allows disabling this functionality. This feature is currently not supported by commands which use external tools or package managers or work with JFrog Distribution.
+For enhanced security, when JFrog CLI is configured to use a username and password / API key, it automatically generates an access token to authenticate with Artifactory. The generated access token is valid for one hour only. JFrog CLI automatically refreshed the token before it expires. The **jfrog c add** command allows disabling this functionality. This feature is currently not supported by commands which use external tools or package managers or work with JFrog Distribution.
 
 ### Authenticating with an Access Token
 
@@ -76,7 +76,7 @@ From version 4.4, Artifactory supports SSH authentication using RSA public and p
     **Warning** <br><br>
     **Don't include your Artifactory context URL**
     
-    > Make sure that the \[host\] component of the URL only includes the host name or the IP, but not your Artifactory context URL.
+    > Make sure that the \[host\] component of the URL only includes the hostname or the IP, but not your Artifactory context URL.
     ---
     
 * Configure the path to your SSH key file. There are two ways to do this:
@@ -85,7 +85,7 @@ From version 4.4, Artifactory supports SSH authentication using RSA public and p
 
 ### Authenticating using Client Certificates (mTLS)
 
-From Artifactory release 7.38.4, you can authenticate users using a client certificates ([mTLS](https://en.wikipedia.org/wiki/Mutual_authentication#mTLS)). To do so will require a reverse proxy and some setup on the front reverse proxy (Nginx). Read about how to set this up [here](https://jfrog.com/help/r/jfrog-artifactory-documentation/Http-Settings).
+From Artifactory release 7.38.4, you can authenticate users using a client certificate ([mTLS](https://en.wikipedia.org/wiki/Mutual_authentication#mTLS)). To do so will require a reverse proxy and some setup on the front reverse proxy (Nginx). Read about how to set this up [here](https://jfrog.com/help/r/jfrog-artifactory-documentation/Http-Settings).
 
 To authenticate with the proxy using a client certificate, either configure your certificate once using the **jf c add** command or use the --`client-cert-path` and`--client-cert-ket-path` command options with each command.
 
@@ -97,7 +97,7 @@ To authenticate with the proxy using a client certificate, either configure your
 
 Not Using a Public CA (Certificate Authority)?
 
-This section is relevant for you, if you're not using a public CA (Certificate Authority) to issue the SSL certificate used to connect to your Artifactory domain. You may not be using a public CA either because you're using self-signed certificates or you're running your own PKI services in-house (often by using a Microsoft CA).
+This section is relevant for you if you're not using a public CA (Certificate Authority) to issue the SSL certificate used to connect to your Artifactory domain. You may not be using a public CA either because you're using self-signed certificates or you're running your own PKI services in-house (often by using a Microsoft CA).
 
 In this case, you'll need to make those certificates available for JFrog CLI, by placing them inside the **security/certs** directory, which is under JFrog CLI's home directory. By default, the home directory is **~/.jfrog**, but it can be also set using the **JFROG_CLI_HOME_DIR** environment variable.
 
@@ -109,7 +109,7 @@ In this case, you'll need to make those certificates available for JFrog CLI, by
 
 ## Storing Symlinks in Artifactory
 
-JFrog CLI lets you upload and download artifacts from your local file-system to Artifactory, this also includes uploading symlinks (soft links).
+JFrog CLI lets you upload and download artifacts from your local file system to Artifactory, this also includes uploading symlinks (soft links).
 
 Symlinks are stored in Artifactory as files with a zero size, with the following properties:  
 **symlink.dest** - The actual path on the original filesystem to which the symlink points  
@@ -123,7 +123,7 @@ When downloading symlinks stored in Artifactory, the CLI can verify that the fil
 
 ## Using Placeholders
 
-The JFrog CLI offers enormous flexibility in how you **download, upload**, **copy**, or **move** files through use of wildcard or regular expressions with placeholders.
+The JFrog CLI offers enormous flexibility in how you **download, upload**, **copy**, or **move** files through the use of wildcard or regular expressions with placeholders.
 
 Any wildcard enclosed in parentheses in the source path can be matched with a corresponding placeholder in the target path to determine the name of the artifact once uploaded.
 
@@ -131,7 +131,7 @@ Any wildcard enclosed in parentheses in the source path can be matched with a co
 
 ##### **Example 1: Upload all files to the target repository**
 
-For each .tgz file in the source directory, create a corresponding directory with the same name in the target repository and upload it there. For example, a file named **froggy.tgz** should be uploaded to **my-local-rep/froggy**. **froggy** will be created a folder in Artifactory).
+For each .tgz file in the source directory, create a corresponding directory with the same name in the target repository and upload it there. For example, a file named **froggy.tgz** should be uploaded to **my-local-rep/froggy**. **froggy** will be created in a folder in Artifactory).
 ```
 jf rt u "(*).tgz" my-local-repo/{1}/ --recursive=false
 ```
@@ -145,7 +145,7 @@ jf u "(frog*)" my-local-repo/frogfiles/{1}-up --recursive=false
 
 ##### **Example 3: Upload all files to corresponding directories according to extension type**
 
-Upload all files in the current directory to the **my-local-repo** repository and place them in directories which match their file extensions.
+Upload all files in the current directory to the **my-local-repo** repository and place them in directories that match their file extensions.
 ```
 jf rt u "(*).(*)" my-local-repo/{2}/{1}.{2} --recursive=false
 ```
@@ -194,7 +194,7 @@ jf rt ping --server-id=rt-server-1
 
 ##### **Example 3**
 
-Ping the Artifactory server. accessible though the specified URL.
+Ping the Artifactory server. accessible through the specified URL.
 ```
 jf rt ping --url=https://my-rt-server.com/artifactory
 ```
@@ -235,8 +235,8 @@ This command is used to upload files to Artifactory.
 | --retry-wait-time  | \[Default: 0s\]<br><br>Number of seconds or milliseconds to wait between retries. The numeric value should either end with s for seconds or ms for milliseconds.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | --detailed-summary | \[Default: false\]<br><br>Set to true to include a list of the affected files as part of the command output summary.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | --insecure-tls     | \[Default: false\]<br><br>Set to true to skip TLS certificates verification.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| Command arguments  | The command takes two arguments.<br><br>In case the --spec option is used, the commands accepts no arguments.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| Source path        | The first argument specifies the local file system path to artifacts which should be uploaded to Artifactory. You can specify multiple artifacts by using wildcards or a regular expression as designated by the **--regexp** command option. Please read the **--regexp** option description for more information.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Command arguments  | The command takes two arguments.<br><br>In case the --spec option is used, the commands accept no arguments.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| Source path        | The first argument specifies the local file system path to artifacts that should be uploaded to Artifactory. You can specify multiple artifacts by using wildcards or a regular expression as designated by the **--regexp** command option. Please read the **--regexp** option description for more information.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | Target path        | The second argument specifies the target path in Artifactory in the following format: `[repository name]/[repository path]`<br><br>If the target path ends with a slash, the path is assumed to be a folder. For example, if you specify the target as "repo-name/a/b/", then "b" is assumed to be a folder in Artifactory into which files should be uploaded. If there is no terminal slash, the target path is assumed to be a file to which the uploaded file should be renamed. For example, if you specify the target as "repo-name/a/b", the uploaded file is renamed to "b" in Artifactory.<br><br>For flexibility in specifying the upload path, you can include placeholders in the form of {1}, {2} which are replaced by corresponding tokens in the source path that are enclosed in parenthesis. For more details, please refer to [Using Placeholders](https://jfrog.com/help/r/jfrog-cli/using-placeholders). |
 
 #### Examples
@@ -294,7 +294,7 @@ jf rt u "build/" my-local-repo/my-archive.zip --archive zip
 
 This command is used to download files from Artifactory.
 
-> Download from Remote Repositories: <br><br>By default, the command only downloads files which are cached on the current Artifactory instance. It does not download files located on remote Artifactory instances, through remote or virtual repositories. To allow the command to download files from remote Artifactory instances, which are proxied by the use of remote repositories, set the **JFROG_CLI_TRANSITIVE_DOWNLOAD_EXPERIMENTAL** environment variable to **true**. This functionality requires version 7.17 or above of Artifactory. The remote download functionality is supported only on remote repositories which proxy repositories on remote Artifactory instances. Downloading through a remote repository which proxies non Artifactory repositories is not supported. 
+> Download from Remote Repositories: <br><br>By default, the command only downloads files that are cached on the current Artifactory instance. It does not download files located on remote Artifactory instances, through remote or virtual repositories. To allow the command to download files from remote Artifactory instances, which are proxied by the use of remote repositories, set the **JFROG_CLI_TRANSITIVE_DOWNLOAD_EXPERIMENTAL** environment variable to **true**. This functionality requires version 7.17 or above of Artifactory. The remote download functionality is supported only on remote repositories which proxy repositories on remote Artifactory instances. Downloading through a remote repository that proxies non-Artifactory repositories is not supported. 
 
 |                     |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 |---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -312,7 +312,7 @@ This command is used to download files from Artifactory.
 | --exclude-props     | \[Optional\]<br><br>A list of Artifactory [properties](https://jfrog.com/help/r/jfrog-artifactory-documentation/Working-With-Jfrog-Properties) specified as "key=value" pairs separated by a semi-colon (for example, "key1=value1;key2=value2;key3=value3"). Only artifacts **without all** of the specified properties names and values will be downloaded.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | --build             | \[Optional\]<br><br>If specified, only artifacts of the specified build are matched. The property format is build-name/build-number. If you do not specify the build number, the artifacts are filtered by the latest build number.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | --bundle            | \[Optional\]<br><br>If specified, only artifacts of the specified bundle are matched. The value format is bundle-name/bundle-version.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --flat              | \[Default: false\]<br><br>If true, artifacts are downloaded to the exact target path specified and their hierarchy in the source repository is ignored.<br><br>If false, artifacts are downloaded to the target path in the file system while maintaining their hierarchy in the source repository.<br><br>If [Using Placeholders](https://jfrog.com/help/r/jfrog-cli/using-placeholders) are used, and you would like the local file-system (download path) to be determined by placeholders only, or in other words, avoid concatenating the Artifactory folder hierarchy local, set to false.                                                                                                                                                                                                                                                       |
+| --flat              | \[Default: false\]<br><br>If true, artifacts are downloaded to the exact target path specified and their hierarchy in the source repository is ignored.<br><br>If false, artifacts are downloaded to the target path in the file system while maintaining their hierarchy in the source repository.<br><br>If [Using Placeholders](https://jfrog.com/help/r/jfrog-cli/using-placeholders) are used, and you would like the local file system (download path) to be determined by placeholders only, or in other words, avoid concatenating the Artifactory folder hierarchy local, set to false.                                                                                                                                                                                                                                                       |
 | --recursive         | \[Default: true\]<br><br>If true, artifacts are also downloaded from sub-paths under the specified path in the source repository.<br><br>If false, only artifacts in the specified source path directory are downloaded.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | --threads           | \[Default: 3\]<br><br>The number of parallel threads that should be used to download where each thread downloads a single artifact at a time.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | --split-count       | \[Default: 3\]<br><br>The number of segments into which each file should be split for download (provided the artifact is over `--min-split` in size). To download each file in a single thread, set to 0.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
@@ -420,7 +420,7 @@ jf rt cp "source-frog-repo/rabbit/*.zip" target-frog-repo/rabbit/
 
 ##### **Example 3**
 
-Copy all artifacts located under **/rabbit** in the **source-frog-repo** repository and with property "Version=1.0" into the same path in the **target-frog-repo** repository .
+Copy all artifacts located under **/rabbit** in the **source-frog-repo** repository and with property "Version=1.0" into the same path in the **target-frog-repo** repository.
 ```
 jf rt cp "source-frog-repo/rabbit/*" target-frog-repo/rabbit/ --props=Version=1.0
 ```
@@ -1569,7 +1569,7 @@ The following table lists the command arguments and flags:
 | --module           | \[Optional\]<br><br>Optional module name for the build-info.                                                                                                                            |
 | --detailed-summary | \[Default: false\]<br><br>Set true to include a list of the affected files as part of the command output summary.                                                                       |
 | --scan             | \[Default: false\]<br><br>Set if you'd like all files to be scanned by Xray on the local file system prior to the upload, and skip the upload if any of the files are found vulnerable. |
-| --format           | \[Default: table\]<br><br>Should be used with the --scan option. Defines the scan output format. Accepts table or json as values.                                                       |
+| --format           | \[Default: table\]<br><br>Should be used with the --scan option. Defines the scan output format. Accepts table or JSON as values.                                                       |
 | Command argument   | The command accepts the same arguments and options that the **npm pack** command expects.                                                                                               |
 
 ##### Example
@@ -1601,7 +1601,7 @@ Before using the **jf yarn** command, the project needs to be pre-configured wit
 
 #### Installing Npm Packages
 
-The **jf yarn** command execute the yarn client, to fetches the npm dependencies from the npm repositories.
+The **jf yarn** command executes the yarn client, to fetch the npm dependencies from the npm repositories.
 
 > **Note**: Before running the command on a project for the first time, the project should be configured using the **yarn-config** command.
 

--- a/documentation/CLI-for-JFrog-Xray.md
+++ b/documentation/CLI-for-JFrog-Xray.md
@@ -36,7 +36,7 @@ The _**jf audit**_ command allows scanning your source code dependencies to find
 * Maven (mvn) - Version 3.1.0 or above of Maven is supported.
 * Gradle (gradle)
 * Npm (npm)
-* Yarn 2 (yarn)
+* Yarn (yarn)
 * Pip (pip)
 * Pipenv (pipenv)
 * Poetry (poetry)
@@ -47,7 +47,7 @@ The _**jf audit**_ command allows scanning your source code dependencies to find
 The command will detect the package manager used by the project automatically. It requires version 3.29.0 or above of Xray and also version 2.13.0 or above of JFrog CLI.
 
 ### Advanced Scans
-This command also supports the following Advanded Scans with the **Advanced Security Package** enabled on the JFrog Platform instance. To enable the Advanced Security Package, contact us using [this](https://jfrog.com/advanced-security-contact-us/) form.
+This command also supports the following Advanced Scans with the **Advanced Security Package** enabled on the JFrog Platform instance. To enable the Advanced Security Package, contact us using [this](https://jfrog.com/advanced-security-contact-us/) form.
 
 * **Vulnerability Contextual Analysis**: This feature uses the code context to eliminate false positive reports on vulnerable dependencies that are not applicable to the code. Vulnerability Contextual Analysis is currently supported for Python and JavaScript code.
 * **Secrets Detection**: Detect any secrets left exposed inside the code. to stop any accidental leak of internal tokens or credentials.
@@ -68,7 +68,7 @@ This command also supports the following Advanded Scans with the **Advanced Secu
 | --server-id           | \[Optional\]<br><br>Server ID configured using the _jf c add_ command. If not specified, the default configured server is used.                                                                                                                                                                                                                                |
 | --project             | \[Optional\]<br><br>JFrog project key, to enable Xray to determine security violations accordingly. The command accepts this option only if the --repo-path and --watches options are not provided. If none of the three options are provided, the command will show all known vulnerabilities                                                                 |
 | --repo-path           | \[Optional\]<br><br>Artifactory repository path in the form of &lt;repository&gt;/&lt;path in the repository&gt;, to enable Xray to determine violations accordingly. The command accepts this option only if the --project and --watches options are not provided. If none of the three options are provided, the command will show all known vulnerabilities |
-| --watches             | \[Optional\]<br><br>A comma separated list of Xray watches, to enable Xray to determine violations accordingly. The command accepts this option only if the --repo-path and --repo-path options are not provided. If none of the three options are provided, the command will show all known vulnerabilities                                                   |
+| --watches             | \[Optional\]<br><br>A comma-separated list of Xray watches, to enable Xray to determine violations accordingly. The command accepts this option only if the --repo-path and --repo-path options are not provided. If none of the three options are provided, the command will show all known vulnerabilities                                                   |
 | --licenses            | \[Default: false\]<br><br>Set if you'd also like the list of licenses to be displayed.                                                                                                                                                                                                                                                                         |
 | --format              | \[Default: table\]<br><br>Defines the output format of the command. Acceptable values are: table and json.                                                                                                                                                                                                                                                     |
 | --fail                | \[Default: true\]<br><br>Set to false if you do not wish the command to return exit code 3, even if the 'Fail Build' rule is matched by Xray.                                                                                                                                                                                                                  |
@@ -76,8 +76,8 @@ This command also supports the following Advanded Scans with the **Advanced Secu
 | --dep-type            | \[Default: all\] \[npm\]<br><br>Defines npm dependencies type. Possible values are: all, devOnly and prodOnly                                                                                                                                                                                                                                                  |
 | --exclude-test-deps   | \[Default: false\] \[Gradle\]<br><br>Set to true if you'd like to exclude Gradle test dependencies from Xray scanning.                                                                                                                                                                                                                                         |
 | --requirements-file   | \[Optional\] \[Pip\]<br><br>Defines pip requirements file name. For example: 'requirements.txt'                                                                                                                                                                                                                                                                |
-| --working-dirs        | \[Optional\]<br><br>A comma separated list of relative working directories, to determine the audit targets locations.                                                                                                                                                                                                                                          |
-| --fixable-only        | \[Optional\]<br><br>Set to true if you wish to display issues which have a fix version only.                                                                                                                                                                                                                                                                   |
+| --working-dirs        | \[Optional\]<br><br>A comma-separated list of relative working directories, to determine the audit targets locations.                                                                                                                                                                                                                                          |
+| --fixable-only        | \[Optional\]<br><br>Set to true if you wish to display issues that have a fix version only.                                                                                                                                                                                                                                                                   |
 | --min-severity        | \[Optional\]<br><br>Set the minimum severity of issues to display. The following values are accepted: Low, Medium, High or Critical                                                                                                                                                                                                                            |
 | --go                  | \[Default: false\]<br><br>Set to true to request audit for a Go project.                                                                                                                                                                                                                                                                                       |
 | --gradle              | \[Default: false\]<br><br>Set to true to request audit for a Gradle project.                                                                                                                                                                                                                                                                                   |
@@ -86,7 +86,7 @@ This command also supports the following Advanded Scans with the **Advanced Secu
 | --nuget               | \[Default: false\]<br><br>Set to true to request audit for a .Net project.                                                                                                                                                                                                                                                                                     |
 | --pip                 | \[Default: false\]<br><br>Set to true to request audit for a Pip project.                                                                                                                                                                                                                                                                                      |
 | --pipenv              | \[Default: false\]<br><br>Set to true to request audit for a Pipenv project.                                                                                                                                                                                                                                                                                   |
-| --yarn                | \[Default: false\]<br><br>Set to true to request audit for a Yarn 2+ project.                                                                                                                                                                                                                                                                                  |
+| --yarn                | \[Default: false\]<br><br>Set to true to request audit for a Yarn project.                                                                                                                                                                                                                                                                                  |
 | **Command arguments** | The command accepts no arguments                                                                                                                                                                                                                                                                                                                               |
 
 #### **Output Example**
@@ -176,7 +176,7 @@ The [on-demand binary scanning](https://jfrog-staging-external.fluidtopics.net/r
 
 ### Scanning Files on the Local File System
 
-This **jf scan**_ command scans files on the local file-system with Xray.
+This **jf scan**_ command scans files on the local file system with Xray.
 
 ---
 **Note**
@@ -195,7 +195,7 @@ This **jf scan**_ command scans files on the local file-system with Xray.
 | --spec                | \[Optional\]<br><br>Path to a file specifying the files to scan. If the pattern argument is provided to the command, this option should not be provided.                                                                                                                                                                                                        |
 | --project             | \[Optional\]<br><br>JFrog project key, to enable Xray to determine security violations accordingly. The command accepts this option only if the --repo-path and --watches options are not provided. If none of the three options are provided, the command will show all known vulnerabilities.                                                                 |
 | --repo-path           | \[Optional\]<br><br>Artifactory repository path in the form of &lt;repository&gt;/&lt;path in the repository&gt;, to enable Xray to determine violations accordingly. The command accepts this option only if the --project and --watches options are not provided. If none of the three options are provided, the command will show all known vulnerabilities. |
-| --watches             | \[Optional\]<br><br>A comma separated list of Xray watches, to enable Xray to determine violations accordingly. The command accepts this option only if the --project and --repo-path options are not provided. If none of the three options are provided, the command will show all known vulnerabilities.                                                     |
+| --watches             | \[Optional\]<br><br>A comma-separated list of Xray watches, to enable Xray to determine violations accordingly. The command accepts this option only if the --project and --repo-path options are not provided. If none of the three options are provided, the command will show all known vulnerabilities.                                                     |
 | --licenses            | \[Default: false\]<br><br>Set if you also require the list of licenses to be displayed.                                                                                                                                                                                                                                                                         |
 | --format=json         | \[Optional\]<br><br>Produces a JSON file containing the scan results.                                                                                                                                                                                                                                                                                           |
 | **Command arguments** |                                                                                                                                                                                                                                                                                                                                                                 |
@@ -321,7 +321,7 @@ $ jf docker scan reg1/repo1/img1:1.0.0 --watches my-watch
 
 **Example 4**
 
-Scan the local _reg1/repo1/img1:1.0.0_ container and show all violations according to the policy associated with _releases-local/app1/_ path in Artifactory.
+Scan the local _reg1/repo1/img1:1.0.0_ container and show all violations according to the policy associated with the _releases-local/app1/_ path in Artifactory.
 
 ```
 $ docker images
@@ -335,7 +335,7 @@ $ jf docker scan reg1/repo1/img1:1.0.0 --repo-path releases-local/app1/
 
 The ‘`scan`’ command can be used to scan tarballs of Docker and OCI images on the local file system.
 
-It requires saving the image on the file system as an uncompressed tarball using a compliant tool, and then scan it with the ‘`jf s`’ command. The image must be saved to the file-system uncompressed, in a `<name>.tar` file name.
+It requires saving the image on the file system as an uncompressed tarball using a compliant tool, and then scanning it with the ‘`jf s`’ command. The image must be saved to the file system uncompressed, in a `<name>.tar` file name.
 
 ---
 **Note**
@@ -387,7 +387,7 @@ $ jf s my-image-oci.tar
 
 #### Podman
 
-Use Podman CLI to save an image to the file system.Output image can be either OCI or Docker format.
+Use Podman CLI to save an image to the file system. Output image can be either OCI or Docker format.
 
 **Example**:
 
@@ -409,7 +409,7 @@ $ jf s my-image-oci.tar
 
 #### Kaniko
 
-Use Kaniko ‘`--tarPath’` flag to save built images to the file system, later scan them with JFrog CLI. The example below is running Kaniko in Docker.
+Use Kaniko ‘`--tarPath’` flag to save built images to the file system, and later scan them with JFrog CLI. The example below is running Kaniko in Docker.
 
 **Example**:
 
@@ -450,7 +450,7 @@ jf bs my-build-name 18
 
 ## Downloading updates for Xray's database
 
-The offline-update command downloads updates to the for Xray's vulnerabilities database. The Xray UI allows building the command structure for you.
+The offline-update command downloads updates to Xray's vulnerabilities database. The Xray UI allows building the command structure for you.
 
 |                   |                                                                                                            |
 |-------------------|------------------------------------------------------------------------------------------------------------|

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -713,7 +713,7 @@ var flagsMap = map[string]cli.Flag{
 	},
 	BasicAuthOnly: cli.BoolFlag{
 		Name: BasicAuthOnly,
-		Usage: "[Default: false] Set to true to disable replacing username and password/API key with automatically created access token that's refreshed hourly. " +
+		Usage: "[Default: false] Set to true to disable replacing username and password/API key with an automatically created access token that's refreshed hourly. " +
 			"Username and password/API key will still be used with commands which use external tools or the JFrog Distribution service. " +
 			"Can only be passed along with username and password/API key options.` `",
 	},
@@ -1037,11 +1037,11 @@ var flagsMap = map[string]cli.Flag{
 	},
 	serverIdResolve: cli.StringFlag{
 		Name:  serverIdResolve,
-		Usage: "[Optional] Artifactory server ID for resolution. The server should configured using the 'jfrog c add' command.` `",
+		Usage: "[Optional] Artifactory server ID for resolution. The server should be configured using the 'jfrog c add' command.` `",
 	},
 	serverIdDeploy: cli.StringFlag{
 		Name:  serverIdDeploy,
-		Usage: "[Optional] Artifactory server ID for deployment. The server should configured using the 'jfrog c add' command.` `",
+		Usage: "[Optional] Artifactory server ID for deployment. The server should be configured using the 'jfrog c add' command.` `",
 	},
 	repoResolveReleases: cli.StringFlag{
 		Name:  repoResolveReleases,
@@ -1140,7 +1140,7 @@ var flagsMap = map[string]cli.Flag{
 	},
 	grantAdmin: cli.BoolFlag{
 		Name:  grantAdmin,
-		Usage: "[Default: false] Set to true to provides admin privileges to the access token. This is only available for administrators.` `",
+		Usage: "[Default: false] Set to true to provide admin privileges to the access token. This is only available for administrators.` `",
 	},
 	expiry: cli.StringFlag{
 		Name:  expiry,
@@ -1156,11 +1156,11 @@ var flagsMap = map[string]cli.Flag{
 	},
 	usersCreateCsv: cli.StringFlag{
 		Name:  csv,
-		Usage: "[Mandatory] Path to a csv file with the users' details. The first row of the file is reserved for the cells' headers. It must include \"username\",\"password\",\"email\"` `",
+		Usage: "[Mandatory] Path to a CSV file with the users' details. The first row of the file is reserved for the cells' headers. It must include \"username\",\"password\",\"email\"` `",
 	},
 	usersDeleteCsv: cli.StringFlag{
 		Name:  csv,
-		Usage: "[Optional] Path to a csv file with the users' details. The first row of the file is reserved for the cells' headers. It must include \"username\"` `",
+		Usage: "[Optional] Path to a CSV file with the users' details. The first row of the file is reserved for the cells' headers. It must include \"username\"` `",
 	},
 	UsersGroups: cli.StringFlag{
 		Name:  UsersGroups,
@@ -1325,7 +1325,7 @@ var flagsMap = map[string]cli.Flag{
 	},
 	FixableOnly: cli.BoolFlag{
 		Name:  FixableOnly,
-		Usage: "[Optional] Set to true if you wish to display issues which have a fixed version only.` `",
+		Usage: "[Optional] Set to true if you wish to display issues that have a fixed version only.` `",
 	},
 	MinSeverity: cli.StringFlag{
 		Name:  MinSeverity,
@@ -1333,11 +1333,11 @@ var flagsMap = map[string]cli.Flag{
 	},
 	watches: cli.StringFlag{
 		Name:  watches,
-		Usage: "[Optional] A comma separated list of Xray watches, to determine Xray's violations creation.` `",
+		Usage: "[Optional] A comma-separated list of Xray watches, to determine Xray's violations creation.` `",
 	},
 	workingDirs: cli.StringFlag{
 		Name:  workingDirs,
-		Usage: "[Optional] A comma separated list of relative working directories, to determine audit targets locations.` `",
+		Usage: "[Optional] A comma-separated list of relative working directories, to determine audit targets locations.` `",
 	},
 	ExtendedTable: cli.BoolFlag{
 		Name:  ExtendedTable,
@@ -1393,7 +1393,7 @@ var flagsMap = map[string]cli.Flag{
 	},
 	Yarn: cli.BoolFlag{
 		Name:  Yarn,
-		Usage: "[Default: false] Set to true to request audit for a Yarn 2+ project.` `",
+		Usage: "[Default: false] Set to true to request audit for a Yarn project.` `",
 	},
 	Nuget: cli.BoolFlag{
 		Name:  Nuget,
@@ -1449,7 +1449,7 @@ var flagsMap = map[string]cli.Flag{
 	licenseCount: cli.StringFlag{
 		Name:  licenseCount,
 		Value: "",
-		Usage: "[Default: " + strconv.Itoa(DefaultLicenseCount) + "] The number of licenses to deploy. Minimum value is 1.` `",
+		Usage: "[Default: " + strconv.Itoa(DefaultLicenseCount) + "] The number of licenses to deploy. The minimum value is 1.` `",
 	},
 	imageFile: cli.StringFlag{
 		Name:  imageFile,
@@ -1519,19 +1519,19 @@ var flagsMap = map[string]cli.Flag{
 	},
 	IncludeRepos: cli.StringFlag{
 		Name:  IncludeRepos,
-		Usage: "[Optional] A list of semicolon separated repositories to include in the transfer. You can use wildcards to specify patterns for the repositories' names.` `",
+		Usage: "[Optional] A list of semicolon-separated repositories to include in the transfer. You can use wildcards to specify patterns for the repositories' names.` `",
 	},
 	ExcludeRepos: cli.StringFlag{
 		Name:  ExcludeRepos,
-		Usage: "[Optional] A list of semicolon separated repositories to exclude from the transfer. You can use wildcards to specify patterns for the repositories' names.` `",
+		Usage: "[Optional] A list of semicolon-separated repositories to exclude from the transfer. You can use wildcards to specify patterns for the repositories' names.` `",
 	},
 	IncludeProjects: cli.StringFlag{
 		Name:  IncludeProjects,
-		Usage: "[Optional] A list of semicolon separated JFrog Project keys to include in the transfer. You can use wildcards to specify patterns for the JFrog Project keys.` `",
+		Usage: "[Optional] A list of semicolon-separated JFrog Project keys to include in the transfer. You can use wildcards to specify patterns for the JFrog Project keys.` `",
 	},
 	ExcludeProjects: cli.StringFlag{
 		Name:  ExcludeProjects,
-		Usage: "[Optional] A list of semicolon separated JFrog Projects to exclude from the transfer. You can use wildcards to specify patterns for the project keys.` `",
+		Usage: "[Optional] A list of semicolon-separated JFrog Projects to exclude from the transfer. You can use wildcards to specify patterns for the project keys.` `",
 	},
 	IgnoreState: cli.BoolFlag{
 		Name:  IgnoreState,
@@ -1583,7 +1583,7 @@ var flagsMap = map[string]cli.Flag{
 	},
 	PreChecks: cli.BoolFlag{
 		Name:  PreChecks,
-		Usage: "[Default: false] Set to true to run pre transfer checks.` `",
+		Usage: "[Default: false] Set to true to run pre-transfer checks.` `",
 	},
 	lcUrl: cli.StringFlag{
 		Name:  url,


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
