### PR TITLE
Skip lifecycle tests

### DIFF
--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	artifactoryLifecycleMinVersion = "7.65.0"
+	artifactoryLifecycleMinVersion = "7.68.3"
 	gpgKeyPairName                 = "lc-tests-key-pair"
 	lcTestdataPath                 = "lifecycle"
 	releaseBundlesSpec             = "release-bundles-spec.json"


### PR DESCRIPTION
Skipping the tests till the distribution command becomes public, after the tests are stable against an E+ environment (expected at 7.68.3).
