### PR TITLE
Add jq to the slim Docker image

### DIFF
--- a/build/docker/slim/Dockerfile
+++ b/build/docker/slim/Dockerfile
@@ -11,6 +11,6 @@ FROM ${repo_name_21}/jfrog-docker/alpine:3
 ARG image_name=jfrog-cli
 ARG cli_executable_name
 ENV CI true
-RUN apk add --no-cache bash tzdata ca-certificates curl
+RUN apk add --no-cache bash tzdata ca-certificates curl jq
 COPY --from=builder /${image_name}/${cli_executable_name} /usr/local/bin/${cli_executable_name}
 RUN chmod +x /usr/local/bin/${cli_executable_name}


### PR DESCRIPTION
No application code changes to test. Just adding an jq to the `apk add` command that installs curl.

Closes #2251 