### PR TITLE
Support running npm install without package.json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -129,9 +129,9 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-// replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20230928084830-478bd49f5d3e
+replace github.com/jfrog/build-info-go => github.com/yahavi/build-info-go v0.1.2-0.20231018133333-57b465514ad6
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 dev
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20231018133615-30757f6073ac
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.2.6-0.20230418122323-2bf299dd6d27
 

--- a/go.mod
+++ b/go.mod
@@ -129,9 +129,9 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/jfrog/build-info-go => github.com/yahavi/build-info-go v0.1.2-0.20231019082748-bbe62f4160d9
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20231019085746-e1b192457664
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20231019084346-8daafcad3d60
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20231019090648-a85aaa5fe352
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.2.6-0.20230418122323-2bf299dd6d27
 

--- a/go.mod
+++ b/go.mod
@@ -129,9 +129,9 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/jfrog/build-info-go => github.com/yahavi/build-info-go v0.1.2-0.20231018133333-57b465514ad6
+replace github.com/jfrog/build-info-go => github.com/yahavi/build-info-go v0.1.2-0.20231019082748-bbe62f4160d9
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20231018133615-30757f6073ac
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20231019084346-8daafcad3d60
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog v1.2.6-0.20230418122323-2bf299dd6d27
 

--- a/go.sum
+++ b/go.sum
@@ -413,10 +413,10 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofm
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
-github.com/yahavi/build-info-go v0.1.2-0.20231018133333-57b465514ad6 h1:g2eo1DDjU8ZL1NMq2ipZKotIPPBW8ewYHlsG+LIzz9A=
-github.com/yahavi/build-info-go v0.1.2-0.20231018133333-57b465514ad6/go.mod h1:ujJ8XQZMdT2tMkLSMJNyDd1pCY+duwHdjV+9or9FLIg=
-github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20231018133615-30757f6073ac h1:b4Itpeec1W1FU2oKZMX1tffxPmy/T8yRfn/bJL1DCcM=
-github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20231018133615-30757f6073ac/go.mod h1:RNRyOLg0XMNOfnUE4NrW1+54WCR0rT6Ng2Gg41yQnLQ=
+github.com/yahavi/build-info-go v0.1.2-0.20231019082748-bbe62f4160d9 h1:CUQ2aFAWAwl/NjtLgqL4FGtzndbM/qtv+T52SbZqL5s=
+github.com/yahavi/build-info-go v0.1.2-0.20231019082748-bbe62f4160d9/go.mod h1:ujJ8XQZMdT2tMkLSMJNyDd1pCY+duwHdjV+9or9FLIg=
+github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20231019084346-8daafcad3d60 h1:gYfvwJsYf9Jon89JqNVGyUVVSJZBT5qcUVYMZYBkb1Q=
+github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20231019084346-8daafcad3d60/go.mod h1:5nTbFL46ykoXg22EOVnAPP3khBQkYgvjH/oSVTvBY1g=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -237,14 +237,10 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jedib0t/go-pretty/v6 v6.4.8 h1:HiNzyMSEpsBaduKhmK+CwcpulEeBrTmxutz4oX/oWkg=
 github.com/jedib0t/go-pretty/v6 v6.4.8/go.mod h1:Ndk3ase2CkQbXLLNf5QDHoYb6J9WtVfmHZu9n8rk2xs=
-github.com/jfrog/build-info-go v1.9.13 h1:OeoGzPVK/O4TOUYk35uL4bXg/hleyqMrjGjjmyLOYrg=
-github.com/jfrog/build-info-go v1.9.13/go.mod h1:ujJ8XQZMdT2tMkLSMJNyDd1pCY+duwHdjV+9or9FLIg=
 github.com/jfrog/gofrog v1.3.1 h1:QqAwQXCVReT724uga1AYqG/ZyrNQ6f+iTxmzkb+YFQk=
 github.com/jfrog/gofrog v1.3.1/go.mod h1:IFMc+V/yf7rA5WZ74CSbXe+Lgf0iApEQLxRZVzKRUR0=
 github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYLipdsOFMY=
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
-github.com/jfrog/jfrog-cli-core/v2 v2.45.3 h1:Umh+TvSJCaxBC/nV5pHGq80pGNdldwqFLeX8vqxgvsQ=
-github.com/jfrog/jfrog-cli-core/v2 v2.45.3/go.mod h1:Gkua13G8aYPmv7cZgGhAwcyjqejvxwK5q8pEutvL0TI=
 github.com/jfrog/jfrog-client-go v1.34.3 h1:kDfw3FUQQvOsTKFqonIgLlziez6CSX80xCYZIH9YYcg=
 github.com/jfrog/jfrog-client-go v1.34.3/go.mod h1:fuxhYzWEkA16+ZV5cP/BJUGjA3SXVKbBoDmb8ZS6J4g=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -417,6 +413,10 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofm
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
+github.com/yahavi/build-info-go v0.1.2-0.20231018133333-57b465514ad6 h1:g2eo1DDjU8ZL1NMq2ipZKotIPPBW8ewYHlsG+LIzz9A=
+github.com/yahavi/build-info-go v0.1.2-0.20231018133333-57b465514ad6/go.mod h1:ujJ8XQZMdT2tMkLSMJNyDd1pCY+duwHdjV+9or9FLIg=
+github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20231018133615-30757f6073ac h1:b4Itpeec1W1FU2oKZMX1tffxPmy/T8yRfn/bJL1DCcM=
+github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20231018133615-30757f6073ac/go.mod h1:RNRyOLg0XMNOfnUE4NrW1+54WCR0rT6Ng2Gg41yQnLQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -237,10 +237,14 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jedib0t/go-pretty/v6 v6.4.8 h1:HiNzyMSEpsBaduKhmK+CwcpulEeBrTmxutz4oX/oWkg=
 github.com/jedib0t/go-pretty/v6 v6.4.8/go.mod h1:Ndk3ase2CkQbXLLNf5QDHoYb6J9WtVfmHZu9n8rk2xs=
+github.com/jfrog/build-info-go v1.8.9-0.20231019085746-e1b192457664 h1:6DIV7SpTEBD3xmOuUy9MoOaOw4bFhX0F3FgSyTTtgYQ=
+github.com/jfrog/build-info-go v1.8.9-0.20231019085746-e1b192457664/go.mod h1:ujJ8XQZMdT2tMkLSMJNyDd1pCY+duwHdjV+9or9FLIg=
 github.com/jfrog/gofrog v1.3.1 h1:QqAwQXCVReT724uga1AYqG/ZyrNQ6f+iTxmzkb+YFQk=
 github.com/jfrog/gofrog v1.3.1/go.mod h1:IFMc+V/yf7rA5WZ74CSbXe+Lgf0iApEQLxRZVzKRUR0=
 github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYLipdsOFMY=
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
+github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20231019090648-a85aaa5fe352 h1:DgOvo6c/hWRqbqEnuIHaJRD49dXpe6FPNB3aiBfhU9Q=
+github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20231019090648-a85aaa5fe352/go.mod h1:mI6Ein5JpHSHJw8Mx1cYUYW3zUz80chnLJQsnRglS5U=
 github.com/jfrog/jfrog-client-go v1.34.3 h1:kDfw3FUQQvOsTKFqonIgLlziez6CSX80xCYZIH9YYcg=
 github.com/jfrog/jfrog-client-go v1.34.3/go.mod h1:fuxhYzWEkA16+ZV5cP/BJUGjA3SXVKbBoDmb8ZS6J4g=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -413,10 +417,6 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofm
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
-github.com/yahavi/build-info-go v0.1.2-0.20231019082748-bbe62f4160d9 h1:CUQ2aFAWAwl/NjtLgqL4FGtzndbM/qtv+T52SbZqL5s=
-github.com/yahavi/build-info-go v0.1.2-0.20231019082748-bbe62f4160d9/go.mod h1:ujJ8XQZMdT2tMkLSMJNyDd1pCY+duwHdjV+9or9FLIg=
-github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20231019084346-8daafcad3d60 h1:gYfvwJsYf9Jon89JqNVGyUVVSJZBT5qcUVYMZYBkb1Q=
-github.com/yahavi/jfrog-cli-core/v2 v2.0.0-20231019084346-8daafcad3d60/go.mod h1:5nTbFL46ykoXg22EOVnAPP3khBQkYgvjH/oSVTvBY1g=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/npm_test.go
+++ b/npm_test.go
@@ -135,7 +135,7 @@ func testNpm(t *testing.T, isLegacy bool) {
 }
 
 func readModuleId(t *testing.T, wd string, npmVersion *version.Version) string {
-	packageInfo, err := buildutils.ReadPackageInfoFromPackageJsonIfExist(filepath.Dir(wd), npmVersion)
+	packageInfo, err := buildutils.ReadPackageInfoFromPackageJsonIfExists(filepath.Dir(wd), npmVersion)
 	assert.NoError(t, err)
 	return packageInfo.BuildInfoModuleId()
 }

--- a/npm_test.go
+++ b/npm_test.go
@@ -135,7 +135,7 @@ func testNpm(t *testing.T, isLegacy bool) {
 }
 
 func readModuleId(t *testing.T, wd string, npmVersion *version.Version) string {
-	packageInfo, err := buildutils.ReadPackageInfoFromPackageJson(filepath.Dir(wd), npmVersion)
+	packageInfo, err := buildutils.ReadPackageInfoFromPackageJsonIfExist(filepath.Dir(wd), npmVersion)
 	assert.NoError(t, err)
 	return packageInfo.BuildInfoModuleId()
 }
@@ -163,6 +163,28 @@ func validateNpmLocalBuildInfo(t *testing.T, buildName, buildNumber, moduleName 
 		assert.Equal(t, moduleName, bi.Modules[0].Id)
 		assert.Equal(t, buildinfo.Npm, bi.Modules[0].Type)
 	}
+}
+
+func TestNpmWithoutPackageJson(t *testing.T) {
+	initNpmTest(t)
+	defer cleanNpmTest(t)
+
+	// Create temp dir that does not contain an npm project
+	tempDirPath, createTempDirCallback := coretests.CreateTempDirWithCallbackAndAssert(t)
+	defer createTempDirCallback()
+	wd, err := os.Getwd()
+	assert.NoError(t, err, "Failed to get current dir")
+	chdirCallback := clientTestUtils.ChangeDirWithCallback(t, wd, tempDirPath)
+	defer chdirCallback()
+
+	// Run config to allow resolution from Artifactory
+	err = createConfigFileForTest([]string{tempDirPath}, tests.NpmRemoteRepo, "", t, utils.Npm, false)
+	assert.NoError(t, err)
+
+	// Run npm install and make sure that package.json and package-lock.json were created
+	runJfrogCli(t, "npm", "i", "json@9.0.6", "--save-exact")
+	assert.FileExists(t, filepath.Join(tempDirPath, "package.json"))
+	assert.FileExists(t, filepath.Join(tempDirPath, "package-lock.json"))
 }
 
 func TestNpmConditionalUpload(t *testing.T) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---

Depends on:
* https://github.com/jfrog/jfrog-cli-core/pull/1002
* https://github.com/jfrog/build-info-go/pull/206

Allow running `jf npm install <package-name>` when there is no package.json existing in the working directory.
