### PR TITLE
Command results reader close error is ignored

### DIFF
--- a/access_test.go
+++ b/access_test.go
@@ -175,9 +175,9 @@ const (
 )
 
 var atcTestCases = []struct {
-	name                string
-	args                []string
-	shouldExpire        bool
+	name         string
+	args         []string
+	shouldExpire bool
 	// The expected expiry or -1 if we use the default expiry value
 	expectedExpiry      int
 	expectedScope       string

--- a/utils/cliutils/utils.go
+++ b/utils/cliutils/utils.go
@@ -776,12 +776,9 @@ func isEnvFailNoOp() bool {
 	return strings.ToLower(os.Getenv(coreutils.FailNoOp)) == "true"
 }
 
-func CleanupResult(result *commandUtils.Result, originError *error) {
+func CleanupResult(result *commandUtils.Result, err *error) {
 	if result != nil && result.Reader() != nil {
-		e := result.Reader().Close()
-		if originError == nil {
-			*originError = e
-		}
+		*err = errors.Join(*err, result.Reader().Close())
 	}
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
`originError` is always guaranteed to be non-nil since it inherently serves as a pointer to an error, even if the error it references happens to be nil. Furthermore, introducing the possibility of it being nil would lead to a panic in the code within the "if" block.
```go
if originError == nil {
	*originError = e
}
```