### PR TITLE
Fix npm scripts tests

### DIFF
--- a/.github/workflows/scriptTests.yml
+++ b/.github/workflows/scriptTests.yml
@@ -72,14 +72,24 @@ jobs:
           ./jf${{ matrix.suite.osSuffix }} --version
         if: ${{ matrix.suite.os == 'windows' }}
 
+      # Get the most recent tag to ensure that the npm tests won't download a CLI version that doesn't exist.
+      - name: "Get latest release"
+        id: latest-release
+        run: |
+         export LATEST_RELEASE=`curl https://api.github.com/repos/jfrog/jfrog-cli/releases/latest -s | jq .name -r | cut -c 2-`
+         echo "LATEST_RELEASE=$LATEST_RELEASE" >> "$GITHUB_OUTPUT"
+        shell: bash
+
       - name: Test install npm - v2
         working-directory: build/npm/v2
         run: |
+          npm version ${{ steps.latest-release.outputs.LATEST_RELEASE }} --allow-same-version
           npm install
           ./bin/jfrog${{ matrix.suite.osSuffix }} --version
 
       - name: Test install npm - v2-jf
         working-directory: build/npm/v2-jf
         run: |
+          npm version ${{ steps.latest-release.outputs.LATEST_RELEASE }} --allow-same-version
           npm install
           ./bin/jf${{ matrix.suite.osSuffix }} --version    

--- a/.github/workflows/scriptTests.yml
+++ b/.github/workflows/scriptTests.yml
@@ -72,7 +72,9 @@ jobs:
           ./jf${{ matrix.suite.osSuffix }} --version
         if: ${{ matrix.suite.os == 'windows' }}
 
-      # Get the most recent tag to ensure that the npm tests won't download a CLI version that doesn't exist.
+      # Prior to the release, we set the new version in the package.json files, introducing the prereleased version. 
+      # This adjustment may result in an attempt to download a version that hasn't been published to releases.jfrog.io yet. 
+      # As part of this process, we fetch the most recent JFrog CLI release and store it in the LATEST_RELEASE step output.
       - name: "Get latest release"
         id: latest-release
         run: |


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---

When you update the JFrog CLI version in the package.json and package-lock.json files just before the release, you might encounter the following error in Scripts Tests:
> Downloading JFrog CLI 2.50.4
Unexpected status code 404 during JFrog CLI download

Example - https://github.com/jfrog/jfrog-cli/actions/runs/6615539545/job/17967922834

To address this problem, this PR resolves it by downloading the latest released JFrog CLI version during the test.