### PR TITLE
Fix Xray curation tests

### DIFF
--- a/xray_test.go
+++ b/xray_test.go
@@ -914,6 +914,12 @@ func curationServer(t *testing.T, expectedRequest map[string]bool, requestToFail
 			}
 		}
 		if r.Method == http.MethodGet {
+			if r.RequestURI == "/api/system/version" {
+				w.Write([]byte(`{"version": "7.0.0"}`))
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+
 			if _, exist := requestToFail[r.RequestURI]; exist {
 				w.WriteHeader(http.StatusForbidden)
 				_, err := w.Write([]byte("{\n    \"errors\": [\n        {\n            \"status\": 403,\n            " +

--- a/xray_test.go
+++ b/xray_test.go
@@ -915,8 +915,9 @@ func curationServer(t *testing.T, expectedRequest map[string]bool, requestToFail
 		}
 		if r.Method == http.MethodGet {
 			if r.RequestURI == "/api/system/version" {
-				w.Write([]byte(`{"version": "7.0.0"}`))
+				_, err := w.Write([]byte(`{"version": "7.0.0"}`))
 				w.WriteHeader(http.StatusOK)
+				require.NoError(t, err)
 				return
 			}
 

--- a/xray_test.go
+++ b/xray_test.go
@@ -916,8 +916,8 @@ func curationServer(t *testing.T, expectedRequest map[string]bool, requestToFail
 		if r.Method == http.MethodGet {
 			if r.RequestURI == "/api/system/version" {
 				_, err := w.Write([]byte(`{"version": "7.0.0"}`))
-				w.WriteHeader(http.StatusOK)
 				require.NoError(t, err)
+				w.WriteHeader(http.StatusOK)
 				return
 			}
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
