### PR TITLE
Adding tests for SHFITLEFT docker scan.

### DIFF
--- a/xray_test.go
+++ b/xray_test.go
@@ -648,6 +648,10 @@ func verifyAdvancedSecurityScanResults(t *testing.T, content string) {
 		}
 	}
 	assert.True(t, applicableStatusExists)
+
+	// Verify that secretes detection succeeded.
+	assert.NotEqual(t, 0, len(results.Secrets))
+
 }
 
 func TestXrayCurl(t *testing.T) {
@@ -709,7 +713,7 @@ func TestDockerScan(t *testing.T) {
 func TestAdvancedSecurityDockerScan(t *testing.T) {
 	cleanup := initNativeDockerWithXrayTest(t)
 	defer cleanup()
-	runAdvancedSecurityDockerScan(t, "bitnami/minio:2022")
+	runAdvancedSecurityDockerScan(t, "jfrog/demo-security:latest")
 }
 
 func TestDockerScanWithProgressBar(t *testing.T) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---

Test for this [PR](https://github.com/jfrog/jfrog-cli-core/pull/1052).