### PR TITLE
Add --tar flag to support docker scan of .tar files without docker engine installed

### DIFF
--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -1383,7 +1383,7 @@ var flagsMap = map[string]cli.Flag{
 	},
 	useTar: cli.BoolFlag{
 		Name:  useTar,
-		Usage: "[Default: false] In a docker scan use a tar file directly without saving an existing image` `",
+		Usage: "[Default: false] Set to true to force request docker scan on a .tar file instead of an image.` `",
 	},
 	vuln: cli.BoolFlag{
 		Name:  vuln,

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -483,6 +483,7 @@ const (
 	ExclusionsAudit              = auditPrefix + exclusions
 	repoPath                     = "repo-path"
 	licenses                     = "licenses"
+	useTar                       = "tar"
 	vuln                         = "vuln"
 	ExtendedTable                = "extended-table"
 	MinSeverity                  = "min-severity"
@@ -1380,6 +1381,10 @@ var flagsMap = map[string]cli.Flag{
 		Name:  licenses,
 		Usage: "[Default: false] Set to true if you'd like to receive licenses from Xray scanning.` `",
 	},
+	useTar: cli.BoolFlag{
+		Name:  useTar,
+		Usage: "[Default: false] In a docker scan use a tar file directly without saving an existing image` `",
+	},
 	vuln: cli.BoolFlag{
 		Name:  vuln,
 		Usage: "[Default: false] Set to true if you'd like to receive an additional view of all vulnerabilities, regardless of the policy configured in Xray. Ignored if provided 'format' is 'sarif'.` `",
@@ -1818,7 +1823,7 @@ var commandFlags = map[string][]string{
 	},
 	Docker: {
 		buildName, buildNumber, module, Project,
-		serverId, skipLogin, threads, detailedSummary, watches, repoPath, licenses, xrOutput, fail, ExtendedTable, BypassArchiveLimits, MinSeverity, FixableOnly,
+		serverId, skipLogin, threads, detailedSummary, watches, repoPath, licenses, useTar, xrOutput, fail, ExtendedTable, BypassArchiveLimits, MinSeverity, FixableOnly,
 	},
 	DockerPush: {
 		buildName, buildNumber, module, Project,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

Part of https://github.com/jfrog/jfrog-cli-security/pull/30
---
