### PR TITLE
Add issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: 🕵️ Audit & Scan
     url: https://github.com/jfrog/jfrog-cli-security/issues/new/choose
-    about: Report 'jf audit', 'jf curation-audit', 'jf build-scan', 'jf docker scan', and 'jf scan' issues under the jfrog-cli-security repository.
+    about: Report 'jf audit', 'jf scan', 'jf curation-audit', 'jf build-scan', 'jf docker scan' and 'jf xr' issues under the jfrog-cli-security repository.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Audit & Scan
+  - name: 🕵️ Audit & Scan
     url: https://github.com/jfrog/jfrog-cli-security/issues/new/choose
     about: Report 'jf audit', 'jf curation-audit', 'jf build-scan', 'jf docker scan', and 'jf scan' issues under the jfrog-cli-security repository.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Audit & Scan
+    url: https://github.com/jfrog/jfrog-cli-security/issues/new/choose
+    about: Report 'jf audit', 'jf build-scan', 'jf curation-audit', and 'jf scan' issues under the jfrog-cli-security repository.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Audit & Scan
     url: https://github.com/jfrog/jfrog-cli-security/issues/new/choose
-    about: Report 'jf audit', 'jf build-scan', 'jf curation-audit', and 'jf scan' issues under the jfrog-cli-security repository.
+    about: Report 'jf audit', 'jf curation-audit', 'jf build-scan', 'jf docker scan', and 'jf scan' issues under the jfrog-cli-security repository.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---

Add issue template chooser to allow reporting audit and scan issues in the jfrog-cli-security.
Example:
https://github.com/yahavi/jfrog-cli/issues/new/choose

![image](https://github.com/jfrog/jfrog-cli/assets/11367982/e92d7def-8a56-4569-ab2e-e1012192a0da)
