### PR TITLE
Deprecate the 'jf rt atc' command

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -885,6 +885,7 @@ func GetCommands() []cli.Command {
 		},
 		{
 			Name:         "access-token-create",
+			Hidden:       true,
 			Aliases:      []string{"atc"},
 			Flags:        cliutils.GetCommandFlags(cliutils.ArtifactoryAccessTokenCreate),
 			Usage:        accesstokencreate.GetDescription(),
@@ -892,7 +893,9 @@ func GetCommands() []cli.Command {
 			UsageText:    accesstokencreate.GetArguments(),
 			ArgsUsage:    common.CreateEnvVars(),
 			BashComplete: corecommon.CreateBashCompletionFunc(),
-			Action:       artifactoryAccessTokenCreateCmd,
+			Action: func(c *cli.Context) error {
+				return cliutils.RunCmdWithDeprecationWarning("atc", "rt", c, artifactoryAccessTokenCreateCmd)
+			},
 		},
 		{
 			Name:         "transfer-settings",


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---

The `/artifactory/api/security/token` endpoint is deprecated in Artifactory.
Deprecate `jf rt atc` and suggest using `jf atc` instead. `jf atc` is using the `/access/api/v1/tokens` API.

```
./jf rt atc
10:54:27 [🟠Warn] You are using a deprecated syntax of the command.
	Instead of:
	$ jf rt atc ...
	Use:
	$ jf atc ...
```

Downside - The `jf atc` does not support basic auth:
```
./jf atc
10:55:03 [🚨Error] authenticating with access token is currently mandatory for creating access tokens
```