### PR TITLE
Fix flaky npm latest version fetch

### DIFF
--- a/.github/workflows/scriptTests.yml
+++ b/.github/workflows/scriptTests.yml
@@ -100,14 +100,6 @@ jobs:
           ./jfrog.exe --version
         if: contains( matrix.suite.os, 'windows')
 
-
-      - name: "Get latest release"
-        id: latest-release
-        run: |
-         export LATEST_RELEASE=`curl https://api.github.com/repos/jfrog/jfrog-cli/releases/latest -s --retry 10 | jq .name -r | sed "s/^v//"`
-         echo "LATEST_RELEASE=$LATEST_RELEASE" >> "$GITHUB_OUTPUT"
-        shell: bash
-
       - name: Test install npm - v2
         working-directory: build/npm/v2
         # Prior to the release, we set the new version in the package.json files, introducing the pre-released version.
@@ -116,13 +108,16 @@ jobs:
         run: |
           latest_version=$(npm view jfrog-cli-v2 version)
           npm version $latest_version --allow-same-version
-          npm install
+          npm install --no-audit
           ./bin/jfrog${{ matrix.suite.osSuffix }} --version
 
       - name: Test install npm - v2-jf
         working-directory: build/npm/v2-jf
+        # Prior to the release, we set the new version in the package.json files, introducing the pre-released version.
+        # This adjustment may result in an attempt to download a version that hasn't been published to releases.jfrog.io yet.
+        # To handle it, we fetch the most recent JFrog CLI release and store it in the latest_version param.
         run: |
           latest_version=$(npm view jfrog-cli-v2-jf version)
           npm version $latest_version --allow-same-version
-          npm install
+          npm install --no-audit
           ./bin/jf${{ matrix.suite.osSuffix }} --version    

--- a/.github/workflows/scriptTests.yml
+++ b/.github/workflows/scriptTests.yml
@@ -100,9 +100,7 @@ jobs:
           ./jfrog.exe --version
         if: contains( matrix.suite.os, 'windows')
 
-      # Prior to the release, we set the new version in the package.json files, introducing the pre-released version. 
-      # This adjustment may result in an attempt to download a version that hasn't been published to releases.jfrog.io yet. 
-      # To handle it, we fetch the most recent JFrog CLI release and store it in the LATEST_RELEASE step output.
+
       - name: "Get latest release"
         id: latest-release
         run: |
@@ -112,14 +110,19 @@ jobs:
 
       - name: Test install npm - v2
         working-directory: build/npm/v2
+        # Prior to the release, we set the new version in the package.json files, introducing the pre-released version.
+        # This adjustment may result in an attempt to download a version that hasn't been published to releases.jfrog.io yet.
+        # To handle it, we fetch the most recent JFrog CLI release and store it in the latest_version param.
         run: |
-          npm version ${{ steps.latest-release.outputs.LATEST_RELEASE }} --allow-same-version
+          latest_version=$(npm view jfrog-cli-v2 version)
+          npm version $latest_version --allow-same-version
           npm install
           ./bin/jfrog${{ matrix.suite.osSuffix }} --version
 
       - name: Test install npm - v2-jf
         working-directory: build/npm/v2-jf
         run: |
-          npm version ${{ steps.latest-release.outputs.LATEST_RELEASE }} --allow-same-version
+          latest_version=$(npm view jfrog-cli-v2-jf version)
+          npm version $latest_version --allow-same-version
           npm install
           ./bin/jf${{ matrix.suite.osSuffix }} --version    


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---

fetch latest version with npm instead of curl github.
