### PR TITLE
Bump ver from 2.62.0 to 2.62.1

### DIFF
--- a/build/npm/v2-jf/package-lock.json
+++ b/build/npm/v2-jf/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "jfrog-cli-v2-jf",
-  "version": "2.62.0",
+  "version": "2.62.1",
   "lockfileVersion": 1
 }

--- a/build/npm/v2-jf/package.json
+++ b/build/npm/v2-jf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jfrog-cli-v2-jf",
-  "version": "2.62.0",
+  "version": "2.62.1",
   "description": "🐸 Command-line interface for JFrog Artifactory, Xray, Distribution, Pipelines and Mission Control 🐸",
   "homepage": "https://github.com/jfrog/jfrog-cli",
   "preferGlobal": true,

--- a/build/npm/v2/package-lock.json
+++ b/build/npm/v2/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "jfrog-cli-v2",
-  "version": "2.62.0",
+  "version": "2.62.1",
   "lockfileVersion": 2
 }

--- a/build/npm/v2/package.json
+++ b/build/npm/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jfrog-cli-v2",
-  "version": "2.62.0",
+  "version": "2.62.1",
   "description": "🐸 Command-line interface for JFrog Artifactory, Xray, Distribution, Pipelines and Mission Control 🐸",
   "homepage": "https://github.com/jfrog/jfrog-cli",
   "preferGlobal": true,

--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ require (
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20240729055355-5b51bf71e756
 
-replace github.com/jfrog/jfrog-cli-security => github.com/jfrog/jfrog-cli-security v1.6.3-0.20240729081816-371509c205d6
+// replace github.com/jfrog/jfrog-cli-security => github.com/jfrog/jfrog-cli-security v1.6.3-0.20240729081816-371509c205d6
 
 // replace github.com/jfrog/build-info-go => github.com/eyalbe4/build-info-go v1.8.9-0.20240723132035-980d2c84b738
 

--- a/go.sum
+++ b/go.sum
@@ -950,8 +950,8 @@ github.com/jfrog/jfrog-cli-core/v2 v2.54.0 h1:vSVSADvuZ2vou4B5spfsUZ32oA/sl4mPVE
 github.com/jfrog/jfrog-cli-core/v2 v2.54.0/go.mod h1:ynAcz9jWDrcQi1/IkNLrIgfQnJO8LPLFwjLplgvY8KI=
 github.com/jfrog/jfrog-cli-platform-services v1.3.0 h1:IblSDZFBjL7WLRi37Ni2DmHrXJJ6ysSMxx7t41AvyDA=
 github.com/jfrog/jfrog-cli-platform-services v1.3.0/go.mod h1:Ky4SDXuMeaiNP/5zMT1YSzIuXG+cNYYOl8BaEA7Awbc=
-github.com/jfrog/jfrog-cli-security v1.6.3-0.20240729081816-371509c205d6 h1:U61knfgV/WZ4ZOhEEKKlnXQ8Y1BlKVPyVjTaERymIk0=
-github.com/jfrog/jfrog-cli-security v1.6.3-0.20240729081816-371509c205d6/go.mod h1:0m+jdJgsLF2QHl4f/t9JHuJ9E0Oqf9kK24UWsjAtvsE=
+github.com/jfrog/jfrog-cli-security v1.6.3 h1:qo0anXfz/5l8bMZY0GsnTWM+a/qjHsn7ZY0KAaLxY0o=
+github.com/jfrog/jfrog-cli-security v1.6.3/go.mod h1:rTaZ9yeSQiSbfVFkRG/0OLPjq8Fis3dHBUgCVnIbe+E=
 github.com/jfrog/jfrog-client-go v1.43.1 h1:KIauYofb7R02mGDc8XADEvu245BJjUryjtq+YQQIbY8=
 github.com/jfrog/jfrog-client-go v1.43.1/go.mod h1:J/Ketm4TkBudXG8gAGY74jtNUbKhXn1+XaRfJcJVkvA=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/utils/cliutils/cli_consts.go
+++ b/utils/cliutils/cli_consts.go
@@ -4,7 +4,7 @@ import "time"
 
 const (
 	// General CLI constants
-	CliVersion  = "2.62.0"
+	CliVersion  = "2.62.1"
 	ClientAgent = "jfrog-cli-go"
 
 	// CLI base commands constants:


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
