### PR TITLE
feat: Validate Config Existence in config rm

### DIFF
--- a/config/cli.go
+++ b/config/cli.go
@@ -163,6 +163,12 @@ func deleteCmd(c *cli.Context) error {
 
 	// Delete single configuration
 	serverId := c.Args()[0]
+
+	// Check if the configuration exists
+	if err := validateServerExistence(serverId, editOperation); err != nil {
+		return err
+	}
+
 	if !quiet && !coreutils.AskYesNo("Are you sure you want to delete \""+serverId+"\" configuration?", false) {
 		return nil
 	}


### PR DESCRIPTION
Enhanced the config rm command to check if the specified configuration exists before attempting to remove it. 
Modified the deleteCmd function in config/cli.go to include a call to validateServerExistence, ensuring the configuration is present.
If the configuration does not exist, the command now returns an error, preventing further execution and improving user feedback.

This change addresses user concerns about the lack of feedback when removing non-existent configurations, providing a clearer and more robust user experience.

- [ x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x ] The pull request is targeting the `dev` branch.
- [x ] The code has been validated to compile successfully by running `go vet ./...`.
- [x ] The code has been formatted properly using `go fmt ./...`.

---
