### PR TITLE
Updated testdata docker base image to bookworm

### DIFF
--- a/testdata/docker/artifactory/Dockerfile
+++ b/testdata/docker/artifactory/Dockerfile
@@ -1,11 +1,14 @@
 # Wrap jfrog-testing-infra in a contaner for the docker tests.
 # We run a container with Artifactory since docker tests may need to spin up a contaner to build images inside.
+FROM golang:bookworm
 
-FROM golang:buster
 RUN go install github.com/jfrog/jfrog-testing-infra/local-rt-setup@latest
+
 ENV JFROG_HOME=/jfrog_home
 WORKDIR /jfrog_home
+
 EXPOSE 8082
 EXPOSE 8081
+
 # Temporarily use version 7.84.17 due to an issue with the automatic token generation mechanism in 7.90
 CMD ["sh","-c","local-rt-setup --rt-version 7.84.17; sleep infinity"]


### PR DESCRIPTION
- [X ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ X] The pull request is targeting the `dev` branch.
- [ X] The code has been validated to compile successfully by running `go vet ./...`.
- [X ] The code has been formatted properly using `go fmt ./...`.

---

Updating from old Buster Debian release to Bookworm to make sure tests are done on relevant systems.