### PR TITLE
Fail 'jf docker scan/push/pull' when a wrong flag is provided to the command

### DIFF
--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -3,6 +3,7 @@ package buildtools
 import (
 	"errors"
 	"fmt"
+	"github.com/jfrog/jfrog-cli-security/utils"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 	"os"
 	"strconv"
@@ -704,6 +705,11 @@ func goCmdVerification(c *cli.Context) (string, error) {
 
 func dockerCmd(c *cli.Context) error {
 	args := cliutils.ExtractCommand(c)
+	if len(args) > 2 {
+		// If a non-existing flag was provided - it will be captured as another argument.
+		// Since 'docker scan/pull/push' command expects only 2 arguments, we use this check to verify all provided flags are valid.
+		return cliutils.PrintHelpAndReturnError(utils.GetCliTooManyArgsErrorMessage(len(args)), c)
+	}
 	var cmd, image string
 	// We may have prior flags before push/pull commands for the docker client.
 	for _, arg := range args {

--- a/go.mod
+++ b/go.mod
@@ -173,7 +173,7 @@ require (
 
 // replace github.com/jfrog/jfrog-cli-core/v2 => github.com/RobiNino/jfrog-cli-core/v2 v2.0.0-20240904105726-775a1614224e
 
-// replace github.com/jfrog/jfrog-cli-security => github.com/attiasas/jfrog-cli-security v0.0.0-20240904061406-f368939ce3a0
+replace github.com/jfrog/jfrog-cli-security => github.com/eranturgeman/jfrog-cli-security v0.0.0-20240905122629-601bd0a567fd
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20240806162439-01bb7dcd43fc
 

--- a/go.sum
+++ b/go.sum
@@ -737,6 +737,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J6romD608Ba7Hij42vrOBCo=
 github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0++PMirau2/yoOwVac3AbF2w=
 github.com/envoyproxy/protoc-gen-validate v0.10.0/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
+github.com/eranturgeman/jfrog-cli-security v0.0.0-20240905122629-601bd0a567fd h1:g41id72k9s/BWKZHEmeXwgx9ROP21Rv34LQqG0zwSFU=
+github.com/eranturgeman/jfrog-cli-security v0.0.0-20240905122629-601bd0a567fd/go.mod h1:XwKj88I0ftqVlmnH/CyycD3ZDymg/KCSqC4SS/7//jQ=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -945,8 +947,6 @@ github.com/jfrog/jfrog-cli-core/v2 v2.55.7 h1:V4dO2FMNIH49lov3dMj3jYRg8KBTG7hyhH
 github.com/jfrog/jfrog-cli-core/v2 v2.55.7/go.mod h1:DPO5BfWAeOByahFMMy+PcjmbPlcyoRy7Bf2C5sGKVi0=
 github.com/jfrog/jfrog-cli-platform-services v1.3.0 h1:IblSDZFBjL7WLRi37Ni2DmHrXJJ6ysSMxx7t41AvyDA=
 github.com/jfrog/jfrog-cli-platform-services v1.3.0/go.mod h1:Ky4SDXuMeaiNP/5zMT1YSzIuXG+cNYYOl8BaEA7Awbc=
-github.com/jfrog/jfrog-cli-security v1.8.0 h1:jp/AVaQcItUNXRCud5PMyl8VVjPuzfrNHJWQvWAMnms=
-github.com/jfrog/jfrog-cli-security v1.8.0/go.mod h1:DjufYZpsTwILOFJlx7tR/y63oLBRmtPtFIz1WgiP/X4=
 github.com/jfrog/jfrog-client-go v1.46.1 h1:ExqOF8ClOG9LO3vbm6jTIwQHHhprbu8lxB2RrM6mMI0=
 github.com/jfrog/jfrog-client-go v1.46.1/go.mod h1:UCu2JNBfMp9rypEmCL84DCooG79xWIHVadZQR3Ab+BQ=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
When a wrong flag is provided to the command it is captured as an argument and therefore is not going through flags validations. This causes the flag to be ignored and without indications on anything wrong.
Since 'jf docker scan/push/pull' expects 2 arguments only: 'docker' + one of the commands, and extra argument indicates wrong usage.
I added a validation on the arguments number to capture this issue