### PR TITLE
Fix go help

### DIFF
--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -653,6 +653,9 @@ func extractThreadsFlag(args []string) (cleanArgs []string, threadsCount int, er
 }
 
 func GoCmd(c *cli.Context) error {
+	if show, err := cliutils.ShowCmdHelpIfNeeded(c, c.Args()); show || err != nil {
+		return err
+	}
 	configFilePath, err := goCmdVerification(c)
 	if err != nil {
 		return err
@@ -664,6 +667,9 @@ func GoCmd(c *cli.Context) error {
 }
 
 func GoPublishCmd(c *cli.Context) (err error) {
+	if show, err := cliutils.ShowCmdHelpIfNeeded(c, c.Args()); show || err != nil {
+		return err
+	}
 	configFilePath, err := goCmdVerification(c)
 	if err != nil {
 		return err
@@ -684,9 +690,6 @@ func GoPublishCmd(c *cli.Context) (err error) {
 }
 
 func goCmdVerification(c *cli.Context) (string, error) {
-	if show, err := cliutils.ShowCmdHelpIfNeeded(c, c.Args()); show || err != nil {
-		return "", err
-	}
 	if c.NArg() < 1 {
 		return "", cliutils.WrongNumberOfArgumentsHandler(c)
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
Prevents an error from being thrown on `jf go -h`