### PR TITLE
JFrog CLI Build - Upgrade Go to v1.23.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ node("docker-xxlarge") {
     repo = 'jfrog-cli'
     sh 'rm -rf temp'
     sh 'mkdir temp'
-    def goRoot = tool 'go-1.23.1'
+    def goRoot = tool 'go-1.23.2'
     env.GOROOT="$goRoot"
     env.PATH+=":${goRoot}/bin:/tmp/node-${nodeVersion}-linux-x64/bin"
     env.GO111MODULE="on"

--- a/build/docker/slim/Dockerfile
+++ b/build/docker/slim/Dockerfile
@@ -1,6 +1,6 @@
 ARG repo_name_21
 # Remove ${repo_name_21} to pull from Docker Hub.
-FROM ${repo_name_21}/jfrog-docker/golang:1.23.1-alpine as builder
+FROM ${repo_name_21}/jfrog-docker/golang:1.23.2-alpine as builder
 ARG image_name=jfrog-cli
 ARG cli_executable_name
 WORKDIR /${image_name}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jfrog/jfrog-cli
 
-go 1.23.1
+go 1.23.2
 
 replace (
 	// Should not be updated to 0.2.6 due to a bug (https://github.com/jfrog/jfrog-cli-core/pull/372)


### PR DESCRIPTION
Depends on https://github.com/jfrog/.github/pull/5 for the **Static Analysis / Go-Sec ubuntu-latest (pull_request)** check to pass.