### PR TITLE
Mention the removal of the `--archive-entries` option since version 7.90.5 of Artifactory in the embedded help

### DIFF
--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -728,7 +728,7 @@ var flagsMap = map[string]cli.Flag{
 	},
 	archiveEntries: cli.StringFlag{
 		Name:  archiveEntries,
-		Usage: "[Optional] If specified, only archive artifacts containing entries matching this pattern are matched. You can use wildcards to specify multiple artifacts. This option stopped being supported since version 7.90.5 for Artifactory.` `",
+		Usage: "[Optional] This option is no longer supported since version 7.90.5 of Artifactory. If specified, only archive artifacts containing entries matching this pattern are matched. You can use wildcards to specify multiple artifacts.` `",
 	},
 	detailedSummary: cli.BoolFlag{
 		Name:  detailedSummary,


### PR DESCRIPTION
Mention the removal of the --archive-entries option since version 7.90.5 of Artifactory in the embedded help, by slightly modifying the previous change made in https://github.com/jfrog/jfrog-cli/pull/2730/commits/49b28e7860fac7fee273ac0ff604ac323706a679.
