### PR TITLE
Remove remaining temp file after Artifactory download

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -3695,8 +3695,28 @@ func TestArtifactorySortAndLimit(t *testing.T) {
 	err := tests.ValidateListsIdentical(tests.GetSortAndLimit(), paths)
 	assert.NoError(t, err)
 
+	// Download commands that include options like --sort-by create temp files during the download,
+	// which are expected to be deleted after the download.
+	testTempDirCleanFromTempFiles(t)
+
 	// Cleanup
 	cleanArtifactoryTest()
+}
+
+func testTempDirCleanFromTempFiles(t *testing.T) {
+	tempDirBase := fileutils.GetTempDirBase()
+	// prefix := fileutils.GetTempFilePrefix()
+	prefix := ""
+
+	files, err := os.ReadDir(tempDirBase)
+	assert.NoError(t, err, "Failed to read directory %s", tempDirBase)
+
+	for _, file := range files {
+		if !file.IsDir() {
+			assert.False(t, strings.HasPrefix(file.Name(), prefix),
+				"Found a file with a name starting with the prefix '%s': %s", prefix, file.Name())
+		}
+	}
 }
 
 func TestArtifactorySortByCreated(t *testing.T) {

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -3679,8 +3679,19 @@ func TestArtifactoryCopyByBuildPatternAllUsingSpec(t *testing.T) {
 	cleanArtifactoryTest()
 }
 
+// //////
 func TestArtifactorySortAndLimit(t *testing.T) {
 	initArtifactoryTest(t, "")
+
+	// We're changing the temp directory, to ensure it is unique for this test,
+	// and doesn't include temp files from other tests.
+	// This is for the "testTempDirCleanFromTempFiles" performed towards the end
+	// of this function.
+	originalTempDirBase := fileutils.GetTempDirBase()
+	defer func() {
+		fileutils.SetTempDirBase(originalTempDirBase)
+	}()
+	fileutils.SetTempDirBase("TestArtifactorySortAndLimit")
 
 	// Upload all testdata/a/ files
 	runRt(t, "upload", "testdata/a/(*)", tests.RtRepo1+"/data/{1}")
@@ -3713,7 +3724,7 @@ func testTempDirCleanFromTempFiles(t *testing.T) {
 
 	for _, file := range files {
 		if !file.IsDir() {
-			assert.False(t, strings.HasPrefix(file.Name(), prefix),
+			require.False(t, strings.HasPrefix(file.Name(), prefix),
 				"Found a file with a name starting with the prefix '%s': %s", prefix, file.Name())
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -167,11 +167,11 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20241010143722-75cc82c172d3
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eyalbe4/jfrog-cli-core/v2 v2.31.1-0.20241031203012-15c0362902e4
 
 // replace github.com/jfrog/jfrog-cli-security => github.com/attiasas/jfrog-cli-security v0.0.0-20240904061406-f368939ce3a0
 
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20240918081224-1c584cc334c7
+replace github.com/jfrog/jfrog-client-go => github.com/eyalbe4/jfrog-client-go v1.28.1-0.20241031201944-628309d03181
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20240918150101-ad5b10435a12
 

--- a/go.mod
+++ b/go.mod
@@ -167,11 +167,11 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eyalbe4/jfrog-cli-core/v2 v2.31.1-0.20241031203012-15c0362902e4
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eyalbe4/jfrog-cli-core/v2 v2.31.1-0.20241103084123-98c063cbdd1c
 
 // replace github.com/jfrog/jfrog-cli-security => github.com/attiasas/jfrog-cli-security v0.0.0-20240904061406-f368939ce3a0
 
-replace github.com/jfrog/jfrog-client-go => github.com/eyalbe4/jfrog-client-go v1.28.1-0.20241031201944-628309d03181
+replace github.com/jfrog/jfrog-client-go => github.com/eyalbe4/jfrog-client-go v1.28.1-0.20241103083749-45c13ff7fe16
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20240918150101-ad5b10435a12
 

--- a/go.sum
+++ b/go.sum
@@ -87,10 +87,10 @@ github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcej
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/eyalbe4/jfrog-cli-core/v2 v2.31.1-0.20241031203012-15c0362902e4 h1:CxQ45zNOd3aZANIrBq+SGdGD4SqaNxBuomZixcIM8SM=
-github.com/eyalbe4/jfrog-cli-core/v2 v2.31.1-0.20241031203012-15c0362902e4/go.mod h1:kzqZICRkMtld4AhvytFH2MyWEHBDl15+P57LxBLKYAk=
-github.com/eyalbe4/jfrog-client-go v1.28.1-0.20241031201944-628309d03181 h1:wpT4OO+JxTSP6ga3lTzf+N0fg1k3SMyS6DvRarEvZEE=
-github.com/eyalbe4/jfrog-client-go v1.28.1-0.20241031201944-628309d03181/go.mod h1:NepfaidmK/xiKsVC+0Ur9sANOqL6io8Y7pSaCau7J6o=
+github.com/eyalbe4/jfrog-cli-core/v2 v2.31.1-0.20241103084123-98c063cbdd1c h1:MipI52SkGtfsl0Dq01MsqYUCOHMAAaCnOsr+kHy7+HI=
+github.com/eyalbe4/jfrog-cli-core/v2 v2.31.1-0.20241103084123-98c063cbdd1c/go.mod h1:7oHMWVSnX+l9Pj3IkyibQrGnrdkBVD2bf1pBbUAgv/k=
+github.com/eyalbe4/jfrog-client-go v1.28.1-0.20241103083749-45c13ff7fe16 h1:k4/H6bm/XMB89KJp4b0+bpu9N0UojmAEFr5GiZDJ+wI=
+github.com/eyalbe4/jfrog-client-go v1.28.1-0.20241103083749-45c13ff7fe16/go.mod h1:NepfaidmK/xiKsVC+0Ur9sANOqL6io8Y7pSaCau7J6o=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,10 @@ github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcej
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/eyalbe4/jfrog-cli-core/v2 v2.31.1-0.20241031203012-15c0362902e4 h1:CxQ45zNOd3aZANIrBq+SGdGD4SqaNxBuomZixcIM8SM=
+github.com/eyalbe4/jfrog-cli-core/v2 v2.31.1-0.20241031203012-15c0362902e4/go.mod h1:kzqZICRkMtld4AhvytFH2MyWEHBDl15+P57LxBLKYAk=
+github.com/eyalbe4/jfrog-client-go v1.28.1-0.20241031201944-628309d03181 h1:wpT4OO+JxTSP6ga3lTzf+N0fg1k3SMyS6DvRarEvZEE=
+github.com/eyalbe4/jfrog-client-go v1.28.1-0.20241031201944-628309d03181/go.mod h1:NepfaidmK/xiKsVC+0Ur9sANOqL6io8Y7pSaCau7J6o=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -173,14 +177,10 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-artifactory v0.1.6 h1:bMfJsrLQJw0dZp4nqUf1xOmtY0rpCatW/I5q88x+fhQ=
 github.com/jfrog/jfrog-cli-artifactory v0.1.6/go.mod h1:jbNb22ebtupcjdhrdGq0VBew2vWG6VUK04xxGNDfynE=
-github.com/jfrog/jfrog-cli-core/v2 v2.56.4 h1:LqByz2FmVTDQm/u2xGeTL6O8Hs9JadaTj3QMpel9ZwY=
-github.com/jfrog/jfrog-cli-core/v2 v2.56.4/go.mod h1:AwQ9WuOA64g3torX9K5kP0xFAAbchfRInhZwbufoW+Q=
 github.com/jfrog/jfrog-cli-platform-services v1.4.0 h1:g6A30+tOfXd1h6VASeNwH+5mhs5bPQJ0MFzZs/4nlvs=
 github.com/jfrog/jfrog-cli-platform-services v1.4.0/go.mod h1:Ky4SDXuMeaiNP/5zMT1YSzIuXG+cNYYOl8BaEA7Awbc=
 github.com/jfrog/jfrog-cli-security v1.12.2 h1:eO0R15jR7vIYyQZfHMDZUb7bOOLG/VpUw33RYFKo4qw=
 github.com/jfrog/jfrog-cli-security v1.12.2/go.mod h1:BJLwfVZAxsi2iQQ60UYR0os2c23owPwhaRbQUfD8/h4=
-github.com/jfrog/jfrog-client-go v1.47.3 h1:99/JSSgU0rvnM2zWYos2n+Gz1IYLCUoIorE4Xco+Dew=
-github.com/jfrog/jfrog-client-go v1.47.3/go.mod h1:NepfaidmK/xiKsVC+0Ur9sANOqL6io8Y7pSaCau7J6o=
 github.com/jszwec/csvutil v1.10.0 h1:upMDUxhQKqZ5ZDCs/wy+8Kib8rZR8I8lOR34yJkdqhI=
 github.com/jszwec/csvutil v1.10.0/go.mod h1:/E4ONrmGkwmWsk9ae9jpXnv9QT8pLHEPcCirMFhxG9I=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=


### PR DESCRIPTION
Fix a bug where after a file is downloaded from Artifactory, there's one temporary file that remains in the OS temp dir. This fix removes this temporary file.
Depends on https://github.com/jfrog/jfrog-client-go/pull/1036 and https://github.com/jfrog/jfrog-client-go/pull/1036