### PR TITLE
Enhancements to Release Bundle Create Command.

### DIFF
--- a/lifecycle/cli.go
+++ b/lifecycle/cli.go
@@ -2,9 +2,11 @@ package lifecycle
 
 import (
 	"errors"
+	"fmt"
 	commonCliUtils "github.com/jfrog/jfrog-cli-core/v2/common/cliutils"
 	"github.com/jfrog/jfrog-cli-core/v2/common/commands"
 	"github.com/jfrog/jfrog-cli-core/v2/common/spec"
+	speccore "github.com/jfrog/jfrog-cli-core/v2/common/spec"
 	coreCommon "github.com/jfrog/jfrog-cli-core/v2/docs/common"
 	"github.com/jfrog/jfrog-cli-core/v2/lifecycle"
 	coreConfig "github.com/jfrog/jfrog-cli-core/v2/utils/config"
@@ -24,6 +26,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/urfave/cli"
+	"os"
 	"strings"
 )
 
@@ -131,19 +134,54 @@ func validateCreateReleaseBundleContext(c *cli.Context) error {
 }
 
 func assertValidCreationMethod(c *cli.Context) error {
+	// Determine the methods provided
 	methods := []bool{
-		c.IsSet("spec"), c.IsSet(cliutils.Builds), c.IsSet(cliutils.ReleaseBundles)}
-	if coreutils.SumTrueValues(methods) > 1 {
-		return errorutils.CheckErrorf("exactly one creation source must be supplied: --%s, --%s or --%s.\n"+
-			"Opt to use the --%s option as the --%s and --%s are deprecated",
-			"spec", cliutils.Builds, cliutils.ReleaseBundles,
-			"spec", cliutils.Builds, cliutils.ReleaseBundles)
+		c.IsSet("spec"),
+		c.IsSet(cliutils.Builds),
+		c.IsSet(cliutils.ReleaseBundles),
 	}
-	// If the user did not provide a source, we suggest only the recommended spec approach.
-	if coreutils.SumTrueValues(methods) == 0 {
-		return errorutils.CheckErrorf("the --spec option is mandatory")
+	methodCount := coreutils.SumTrueValues(methods)
+
+	// Validate that only one creation method is provided
+	if err := validateSingleCreationMethod(methodCount); err != nil {
+		return err
+	}
+
+	if err := validateCreationValuesPresence(c, methodCount); err != nil {
+		return err
 	}
 	return nil
+}
+
+func validateSingleCreationMethod(methodCount int) error {
+	if methodCount > 1 {
+		return errorutils.CheckErrorf(
+			"exactly one creation source must be supplied: --%s, --%s, or --%s.\n"+
+				"Opt to use the --%s option as the --%s and --%s are deprecated",
+			"spec", cliutils.Builds, cliutils.ReleaseBundles,
+			"spec", cliutils.Builds, cliutils.ReleaseBundles,
+		)
+	}
+	return nil
+}
+
+func validateCreationValuesPresence(c *cli.Context, methodCount int) error {
+	if methodCount == 0 {
+		if !areBuildFlagsSet(c) && !areBuildEnvVarsSet() {
+			return errorutils.CheckErrorf("Either --build-name or JFROG_CLI_BUILD_NAME, and --build-number or JFROG_CLI_BUILD_NUMBER must be defined")
+		}
+	}
+	return nil
+}
+
+// areBuildFlagsSet checks if build-name or build-number flags are set.
+func areBuildFlagsSet(c *cli.Context) bool {
+	return c.IsSet(cliutils.BuildName) || c.IsSet(cliutils.BuildNumber)
+}
+
+// areBuildEnvVarsSet checks if build environment variables are set.
+func areBuildEnvVarsSet() bool {
+	return os.Getenv("JFROG_CLI_BUILD_NUMBER") != "" && os.Getenv("JFROG_CLI_BUILD_NAME") != ""
 }
 
 func create(c *cli.Context) (err error) {
@@ -169,10 +207,34 @@ func create(c *cli.Context) (err error) {
 }
 
 func getReleaseBundleCreationSpec(c *cli.Context) (*spec.SpecFiles, error) {
+	// Checking if the "builds" or "release-bundles" flags are set - if so, the spec flag should be ignored
+	if c.IsSet(cliutils.Builds) || c.IsSet(cliutils.ReleaseBundles) {
+		return nil, nil
+	}
+
+	// Check if the "spec" flag is set - if so, return the spec
 	if c.IsSet("spec") {
 		return cliutils.GetSpec(c, true, false)
 	}
-	return nil, nil
+
+	// Else - create a spec from the buildName and buildnumber flags or env vars
+	buildName := getStringFlagOrEnv(c, cliutils.BuildName, coreutils.BuildName)
+	buildNumber := getStringFlagOrEnv(c, cliutils.BuildNumber, coreutils.BuildNumber)
+
+	if buildName != "" && buildNumber != "" {
+		return speccore.CreateSpecFromBuildNameAndNumber(buildName, buildNumber)
+	}
+
+	return nil, fmt.Errorf("either the --spec flag must be provided, " +
+		"or both --build-name and --build-number flags (or their corresponding environment variables " +
+		"JFROG_CLI_BUILD_NAME and JFROG_CLI_BUILD_NUMBER) must be set")
+}
+
+func getStringFlagOrEnv(c *cli.Context, flag string, envVar string) string {
+	if c.IsSet(flag) {
+		return c.String(flag)
+	}
+	return os.Getenv(envVar)
 }
 
 func promote(c *cli.Context) error {

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -167,7 +167,6 @@ func TestLifecycleFullFlow(t *testing.T) {
 		// Verify the artifacts were distributed correctly by the provided path mappings.
 		assertExpectedArtifacts(t, tests.SearchAllDevRepo, tests.GetExpectedLifecycleDistributedArtifacts())
 	*/
-
 }
 
 // Import bundles only work on onPerm platforms
@@ -206,30 +205,58 @@ func uploadBuilds(t *testing.T) func() {
 func createRbBackwardCompatible(t *testing.T, specName, sourceOption, rbName, rbVersion string, sync bool) {
 	specFile, err := getSpecFile(specName)
 	assert.NoError(t, err)
-	createRb(t, specFile, sourceOption, rbName, rbVersion, sync, false)
+	createRbWithFlags(t, specFile, sourceOption, "", "", rbName, rbVersion, sync, false)
 }
 
 func createRbFromSpec(t *testing.T, specName, rbName, rbVersion string, sync bool, withoutSigningKey bool) {
 	specFile, err := tests.CreateSpec(specName)
 	assert.NoError(t, err)
-	createRb(t, specFile, "spec", rbName, rbVersion, sync, withoutSigningKey)
+	createRbWithFlags(t, specFile, "spec", "", "", rbName, rbVersion, sync, withoutSigningKey)
 }
 
-func createRb(t *testing.T, specFilePath, sourceOption, rbName, rbVersion string, sync bool, withoutSigningKey bool) {
+func TestCreateBundleWithoutSpec(t *testing.T) {
+	cleanCallback := initLifecycleTest(t, signingKeyOptionalArtifactoryMinVersion)
+	defer cleanCallback()
+
+	lcManager := getLcServiceManager(t)
+
+	deleteBuilds := uploadBuilds(t)
+	defer deleteBuilds()
+
+	createRbWithFlags(t, "", "", tests.LcBuildName1, number1, tests.LcRbName1, number1, false, false)
+	assertStatusCompleted(t, lcManager, tests.LcRbName1, number1, "")
+	defer deleteReleaseBundle(t, lcManager, tests.LcRbName1, number1)
+
+	createRbWithFlags(t, "", "", tests.LcBuildName2, number2, tests.LcRbName2, number2, false, true)
+	assertStatusCompleted(t, lcManager, tests.LcRbName2, number2, "")
+	defer deleteReleaseBundle(t, lcManager, tests.LcRbName2, number2)
+}
+
+func createRbWithFlags(t *testing.T, specFilePath, sourceOption, buildName, buildNumber, rbName, rbVersion string,
+	sync, withoutSigningKey bool) {
 	argsAndOptions := []string{
 		"rbc",
 		rbName,
 		rbVersion,
-		getOption(sourceOption, specFilePath),
+	}
+
+	if specFilePath != "" {
+		argsAndOptions = append(argsAndOptions, getOption(sourceOption, specFilePath))
+	}
+
+	if buildName != "" && buildNumber != "" {
+		argsAndOptions = append(argsAndOptions, getOption(cliutils.BuildName, buildName))
+		argsAndOptions = append(argsAndOptions, getOption(cliutils.BuildNumber, buildNumber))
 	}
 
 	if !withoutSigningKey {
 		argsAndOptions = append(argsAndOptions, getOption(cliutils.SigningKey, gpgKeyPairName))
 	}
-	// Add the --sync option only if requested, to test the default value.
+
 	if sync {
 		argsAndOptions = append(argsAndOptions, getOption(cliutils.Sync, "true"))
 	}
+
 	assert.NoError(t, lcCli.Exec(argsAndOptions...))
 }
 

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -164,8 +164,8 @@ const (
 	specVars = "spec-vars"
 
 	// Build info flags
-	buildName   = "build-name"
-	buildNumber = "build-number"
+	BuildName   = "build-name"
+	BuildNumber = "build-number"
 	module      = "module"
 
 	// Generic commands flags
@@ -664,12 +664,12 @@ var flagsMap = map[string]cli.Flag{
 		Name:  specVars,
 		Usage: "[Optional] List of semicolon-separated(;) variables in the form of \"key1=value1;key2=value2;...\" (wrapped by quotes) to be replaced in the File Spec. In the File Spec, the variables should be used as follows: ${key1}.` `",
 	},
-	buildName: cli.StringFlag{
-		Name:  buildName,
+	BuildName: cli.StringFlag{
+		Name:  BuildName,
 		Usage: "[Optional] Providing this option will collect and record build info for this build name. Build number option is mandatory when this option is provided.` `",
 	},
-	buildNumber: cli.StringFlag{
-		Name:  buildNumber,
+	BuildNumber: cli.StringFlag{
+		Name:  BuildNumber,
 		Usage: "[Optional] Providing this option will collect and record build info for this build number. Build name option is mandatory when this option is provided.` `",
 	},
 	module: cli.StringFlag{
@@ -1739,14 +1739,14 @@ var commandFlags = map[string][]string{
 	},
 	Upload: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath, uploadTargetProps,
-		ClientCertKeyPath, specFlag, specVars, buildName, buildNumber, module, uploadExclusions, deb,
+		ClientCertKeyPath, specFlag, specVars, BuildName, BuildNumber, module, uploadExclusions, deb,
 		uploadRecursive, uploadFlat, uploadRegexp, retries, retryWaitTime, dryRun, uploadExplode, symlinks, includeDirs,
 		failNoOp, threads, uploadSyncDeletes, syncDeletesQuiet, InsecureTls, detailedSummary, Project,
 		uploadAnt, uploadArchive, uploadMinSplit, uploadSplitCount, ChunkSize,
 	},
 	Download: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, ClientCertPath,
-		ClientCertKeyPath, specFlag, specVars, buildName, buildNumber, module, exclusions, sortBy,
+		ClientCertKeyPath, specFlag, specVars, BuildName, BuildNumber, module, exclusions, sortBy,
 		sortOrder, limit, offset, downloadRecursive, downloadFlat, build, includeDeps, excludeArtifacts, downloadMinSplit, downloadSplitCount,
 		retries, retryWaitTime, dryRun, downloadExplode, bypassArchiveInspection, validateSymlinks, bundle, publicGpgKey, includeDirs,
 		downloadProps, downloadExcludeProps, failNoOp, threads, archiveEntries, downloadSyncDeletes, syncDeletesQuiet, InsecureTls, detailedSummary, Project,
@@ -1800,11 +1800,11 @@ var commandFlags = map[string][]string{
 		Project,
 	},
 	BuildDockerCreate: {
-		buildName, buildNumber, module, url, user, password, accessToken, sshPassphrase, sshKeyPath,
+		BuildName, BuildNumber, module, url, user, password, accessToken, sshPassphrase, sshKeyPath,
 		serverId, imageFile, Project,
 	},
 	OcStartBuild: {
-		buildName, buildNumber, module, Project, serverId, ocStartBuildRepo,
+		BuildName, BuildNumber, module, Project, serverId, ocStartBuildRepo,
 	},
 	BuildScanLegacy: {
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, fail, InsecureTls,
@@ -1836,21 +1836,21 @@ var commandFlags = map[string][]string{
 		deployIvyDesc, ivyDescPattern, ivyArtifactsPattern,
 	},
 	Mvn: {
-		buildName, buildNumber, deploymentThreads, InsecureTls, Project, detailedSummary, xrayScan, xrOutput,
+		BuildName, BuildNumber, deploymentThreads, InsecureTls, Project, detailedSummary, xrayScan, xrOutput,
 	},
 	Gradle: {
-		buildName, buildNumber, deploymentThreads, Project, detailedSummary, xrayScan, xrOutput,
+		BuildName, BuildNumber, deploymentThreads, Project, detailedSummary, xrayScan, xrOutput,
 	},
 	Docker: {
-		buildName, buildNumber, module, Project,
+		BuildName, BuildNumber, module, Project,
 		serverId, skipLogin, threads, detailedSummary, watches, repoPath, licenses, xrOutput, fail, ExtendedTable, BypassArchiveLimits, MinSeverity, FixableOnly, vuln,
 	},
 	DockerPush: {
-		buildName, buildNumber, module, Project,
+		BuildName, BuildNumber, module, Project,
 		serverId, skipLogin, threads, detailedSummary,
 	},
 	DockerPull: {
-		buildName, buildNumber, module, Project,
+		BuildName, BuildNumber, module, Project,
 		serverId, skipLogin,
 	},
 	DockerPromote: {
@@ -1858,21 +1858,21 @@ var commandFlags = map[string][]string{
 		serverId,
 	},
 	ContainerPush: {
-		buildName, buildNumber, module, url, user, password, accessToken, sshPassphrase, sshKeyPath,
+		BuildName, BuildNumber, module, url, user, password, accessToken, sshPassphrase, sshKeyPath,
 		serverId, skipLogin, threads, Project, detailedSummary,
 	},
 	ContainerPull: {
-		buildName, buildNumber, module, url, user, password, accessToken, sshPassphrase, sshKeyPath,
+		BuildName, BuildNumber, module, url, user, password, accessToken, sshPassphrase, sshKeyPath,
 		serverId, skipLogin, Project,
 	},
 	NpmConfig: {
 		global, serverIdResolve, serverIdDeploy, repoResolve, repoDeploy,
 	},
 	NpmInstallCi: {
-		buildName, buildNumber, module, Project,
+		BuildName, BuildNumber, module, Project,
 	},
 	NpmPublish: {
-		buildName, buildNumber, module, Project, npmDetailedSummary, xrayScan, xrOutput,
+		BuildName, BuildNumber, module, Project, npmDetailedSummary, xrayScan, xrOutput,
 	},
 	PnpmConfig: {
 		global, serverIdResolve, repoResolve,
@@ -1881,38 +1881,38 @@ var commandFlags = map[string][]string{
 		global, serverIdResolve, repoResolve,
 	},
 	Yarn: {
-		buildName, buildNumber, module, Project,
+		BuildName, BuildNumber, module, Project,
 	},
 	NugetConfig: {
 		global, serverIdResolve, repoResolve, nugetV2,
 	},
 	Nuget: {
-		buildName, buildNumber, module, Project, allowInsecureConnections,
+		BuildName, BuildNumber, module, Project, allowInsecureConnections,
 	},
 	DotnetConfig: {
 		global, serverIdResolve, repoResolve, nugetV2,
 	},
 	Dotnet: {
-		buildName, buildNumber, module, Project,
+		BuildName, BuildNumber, module, Project,
 	},
 	GoConfig: {
 		global, serverIdResolve, serverIdDeploy, repoResolve, repoDeploy,
 	},
 	GoPublish: {
-		url, user, password, accessToken, buildName, buildNumber, module, Project, detailedSummary, goPublishExclusions,
+		url, user, password, accessToken, BuildName, BuildNumber, module, Project, detailedSummary, goPublishExclusions,
 	},
 	Go: {
-		buildName, buildNumber, module, Project, noFallback,
+		BuildName, BuildNumber, module, Project, noFallback,
 	},
 	TerraformConfig: {
 		global, serverIdDeploy, repoDeploy,
 	},
 	Terraform: {
 		namespace, provider, tag, exclusions,
-		buildName, buildNumber, module, Project,
+		BuildName, BuildNumber, module, Project,
 	},
 	Twine: {
-		buildName, buildNumber, module, Project,
+		BuildName, BuildNumber, module, Project,
 	},
 	TransferConfig: {
 		Force, Verbose, IncludeRepos, ExcludeRepos, SourceWorkingDir, TargetWorkingDir, PreChecks,
@@ -1931,19 +1931,19 @@ var commandFlags = map[string][]string{
 		global, serverIdResolve, serverIdDeploy, repoResolve, repoDeploy,
 	},
 	PipInstall: {
-		buildName, buildNumber, module, Project,
+		BuildName, BuildNumber, module, Project,
 	},
 	PipenvConfig: {
 		global, serverIdResolve, serverIdDeploy, repoResolve, repoDeploy,
 	},
 	PipenvInstall: {
-		buildName, buildNumber, module, Project,
+		BuildName, BuildNumber, module, Project,
 	},
 	PoetryConfig: {
 		global, serverIdResolve, repoResolve,
 	},
 	Poetry: {
-		buildName, buildNumber, module, Project,
+		BuildName, BuildNumber, module, Project,
 	},
 	ReleaseBundleV1Create: {
 		distUrl, user, password, accessToken, serverId, specFlag, specVars, targetProps,
@@ -2020,7 +2020,7 @@ var commandFlags = map[string][]string{
 	},
 	ReleaseBundleCreate: {
 		platformUrl, user, password, accessToken, serverId, lcSigningKey, lcSync, lcProject, lcBuilds, lcReleaseBundles,
-		specFlag, specVars,
+		specFlag, specVars, BuildName, BuildNumber,
 	},
 	ReleaseBundlePromote: {
 		platformUrl, user, password, accessToken, serverId, lcSigningKey, lcSync, lcProject, lcIncludeRepos, lcExcludeRepos,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
---

Enhanced behavior of the release bundle create command:

1. The spec flag is now optional, with the build-name and build-number flags serving as replacements.
2. Support has been added for the JFROG_CLI_BUILD_NAME and JFROG_CLI_BUILD_NUMBER environment variables as fallback options when the build-name and build-number flags are omitted.

documentation:  https://github.com/jfrog/documentation/pull/173  

