### PR TITLE
Fix Zsh completion

### DIFF
--- a/docs/general/summary/help.go
+++ b/docs/general/summary/help.go
@@ -3,7 +3,5 @@ package summary
 var Usage = []string{"csm"}
 
 func GetDescription() string {
-	return `Generates a Summary of recorded CLI commands there were executed on the current machine.
-	The report is generated in Markdown format and saved in the directory stored in the JFROG_CLI_COMMAND_SUMMARY_OUTPUT_DIR environment variable.
-`
+	return `Generates a Summary of recorded CLI commands there were executed on the current machine. The report is generated in Markdown format and saved in the directory stored in the JFROG_CLI_COMMAND_SUMMARY_OUTPUT_DIR environment variable.`
 }

--- a/docs/general/token/help.go
+++ b/docs/general/token/help.go
@@ -3,8 +3,7 @@ package token
 var Usage = []string{"atc", "atc <username>"}
 
 func GetDescription() string {
-	return `Creates an access token. By default, an user-scoped token will be created. 
-	Administrator may provide the scope explicitly with '--scope', or implicitly with '--groups', '--grant-admin'.`
+	return `Creates an access token. By default, an user-scoped token will be created. Administrator may provide the scope explicitly with '--scope', or implicitly with '--groups', '--grant-admin'.`
 }
 
 func GetArguments() string {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---

Command descriptions must not contain tabs or newline characters. Before this pull request, the Zsh completion appeared as follows:
![image](https://github.com/user-attachments/assets/b49c467d-bc77-4360-b05b-46b2b5c0b792)
