### PR TITLE
[Release Phase] - Update Signing Keys

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -257,7 +257,7 @@ def cleanupRepo21() {
 
 def buildRpmAndDeb(version, architectures) {
     boolean built = false
-    withCredentials([file(credentialsId: 'rpm-gpg-key2', variable: 'rpmGpgKeyFile'), string(credentialsId: 'rpm-sign-passphrase', variable: 'rpmSignPassphrase')]) {
+    withCredentials([file(credentialsId: 'rpm-gpg-key3', variable: 'rpmGpgKeyFile'), string(credentialsId: 'rpm-sign-passphrase', variable: 'rpmSignPassphrase')]) {
         def dirPath = "${pwd()}/jfrog-cli/build/deb_rpm/${identifier}/pkg"
         def gpgPassphraseFilePath = "$dirPath/RPM-GPG-PASSPHRASE-jfrog-cli"
         writeFile(file: gpgPassphraseFilePath, text: "$rpmSignPassphrase")


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---

### Description:

This pull request updates the private key used to sign RPM executables, in line with the recent updates to the GetCLI scripts for both `Debian` and `RPM`.

This change is part of the ongoing efforts to resolve signing issues for both `RPM` and `Debian`. Since some of the work has not been documented, this PR aims to provide all necessary information for future reference.


The scripts have been updated via the Frontend and are already live. The following changes were made:

---

### **Debian:**

The key has been updated in releases.

Updated script:

```diff
#!/bin/bash

# Create the keyrings directory if it doesn't exist
sudo mkdir -p /usr/share/keyrings;

# Download and save the JFrog GPG key to a keyring file
-wget -qO - https://releases.jfrog.io/artifactory/jfrog-gpg-public/jfrog_public_gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/jfrog.gpg;
+wget -qO - https://releases.jfrog.io/artifactory/api/v2/repositories/jfrog-debs/keyPairs/primary/public | sudo gpg --dearmor -o /usr/share/keyrings/jfrog.gpg

# Add the JFrog repository to your APT sources with the signed-by option
-echo "deb [signed-by=/usr/share/keyrings/jfrog.gpg] https://releases.jfrog.io/artifactory/jfrog-debs xenial contrib" | sudo tee /etc/apt/sources.list.d/jfrog.list;
+echo "deb [signed-by=/usr/share/keyrings/jfrog.gpg] https://releases.jfrog.io/artifactory/jfrog-debs focal contrib" | sudo tee /etc/apt/sources.list.d/jfrog.list

# Update the package list
sudo apt update;

# Install the JFrog CLI
sudo apt install -y jfrog-cli-v2-jf;

# Run the JFrog CLI intro command
jf intro;
```

#### Key Changes:
1. The GPG key URL has been updated from:
   - `https://releases.jfrog.io/artifactory/jfrog-gpg-public/jfrog_public_gpg.key`
   - to: `https://releases.jfrog.io/artifactory/api/v2/repositories/jfrog-debs/keyPairs/primary/public`
   
2. The repository URL has been updated from:
   - `xenial` to `focal`.

---

### **RPM:**

A new signing key was generated.

Updated script:

```diff
echo "[jfrog-cli]" > jfrog-cli.repo &&
echo "name=jfrog-cli" >> jfrog-cli.repo &&
echo "baseurl=https://releases.jfrog.io/artifactory/jfrog-rpms" >> jfrog-cli.repo &&
echo "enabled=1" >> jfrog-cli.repo &&
- rpm --import https://releases.jfrog.io/artifactory/jfrog-gpg-public/jfrog_public_gpg.key &&
+rpm --import https://releases.jfrog.io/artifactory/api/v2/repositories/jfrog-rpms/keyPairs/primary/public &&
+rpm --import https://releases.jfrog.io/artifactory/api/v2/repositories/jfrog-rpms/keyPairs/secondary/public &&

# Move the repository file to the YUM configuration directory
sudo mv jfrog-cli.repo /etc/yum.repos.d/ &&


# Install the JFrog CLI package
yum install -y jfrog-cli-v2-jf &&

# Display an introductory message for JFrog CLI
jf intro
```

#### Key Changes:
1. The GPG key URL has changed:
   - From `https://releases.jfrog.io/artifactory/jfrog-gpg-public/jfrog_public_gpg.key`
   - To two separate URLs for backward compatibility: 
     - `https://releases.jfrog.io/artifactory/api/v2/repositories/jfrog-rpms/keyPairs/primary/public`
     - `https://releases.jfrog.io/artifactory/api/v2/repositories/jfrog-rpms/keyPairs/secondary/public`

---

#### Checklist:

- [x] Update GetCLI scripts
- [x] Switch primary and secondary keys in `jfrog-debs`
- [x] Sign RPM with new key ( will happen after this PR is merged, upon next release )

---
