### PR TITLE
Fix Maven tests

### DIFF
--- a/.github/workflows/mavenTests.yml
+++ b/.github/workflows/mavenTests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go with cache
         uses: jfrog/.github/actions/install-go-with-cache@main
 
-      # Maven 3.9 includes breaking changes
+      # Fixed Maven version to avoid updating to 3.9, which includes breaking changes.
       - name: Setup Maven v3.8.8
         uses: stCarolas/setup-maven@v4.5
         with:

--- a/.github/workflows/mavenTests.yml
+++ b/.github/workflows/mavenTests.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Setup Go with cache
         uses: jfrog/.github/actions/install-go-with-cache@main
 
-      - name: Setup Maven v3.8.8 for macOS
+      # Maven 3.9 includes breaking changes
+      - name: Setup Maven v3.8.8
         uses: stCarolas/setup-maven@v4.5
         with:
           maven-version: 3.8.8
-        if: runner.os == 'macos'
 
       - name: Install local Artifactory
         uses: jfrog/.github/actions/install-local-artifactory@main

--- a/.github/workflows/mavenTests.yml
+++ b/.github/workflows/mavenTests.yml
@@ -34,7 +34,6 @@ jobs:
         uses: stCarolas/setup-maven@v4.5
         with:
           maven-version: 3.8.8
-        if: runner.os == 'macOS'
 
       - name: Install local Artifactory
         uses: jfrog/.github/actions/install-local-artifactory@main

--- a/.github/workflows/mavenTests.yml
+++ b/.github/workflows/mavenTests.yml
@@ -30,17 +30,10 @@ jobs:
       - name: Setup Go with cache
         uses: jfrog/.github/actions/install-go-with-cache@main
 
-      - name: Setup Maven v3.8.8 for macOS
+      - name: Setup Maven v3.8.8
         uses: stCarolas/setup-maven@v4.5
         with:
           maven-version: 3.8.8
-        if: runner.os == 'macOS'
-
-      - name: Setup Maven v3.8.0 for windows
-        uses: stCarolas/setup-maven@v4.5
-        with:
-          maven-version: 3.8.0
-        if: runner.os == 'windows'
 
       - name: Install local Artifactory
         uses: jfrog/.github/actions/install-local-artifactory@main

--- a/.github/workflows/mavenTests.yml
+++ b/.github/workflows/mavenTests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Maven v3.8.0 for windows
         uses: stCarolas/setup-maven@v4.5
         with:
-          maven-version: 3.8.8
+          maven-version: 3.8.0
         if: runner.os == 'windows'
 
       - name: Install local Artifactory

--- a/.github/workflows/mavenTests.yml
+++ b/.github/workflows/mavenTests.yml
@@ -30,10 +30,11 @@ jobs:
       - name: Setup Go with cache
         uses: jfrog/.github/actions/install-go-with-cache@main
 
-      - name: Setup Maven v3.8.8
+      - name: Setup Maven v3.8.8 for macOS
         uses: stCarolas/setup-maven@v4.5
         with:
           maven-version: 3.8.8
+        if: runner.os == 'macos'
 
       - name: Install local Artifactory
         uses: jfrog/.github/actions/install-local-artifactory@main

--- a/.github/workflows/mavenTests.yml
+++ b/.github/workflows/mavenTests.yml
@@ -34,6 +34,13 @@ jobs:
         uses: stCarolas/setup-maven@v4.5
         with:
           maven-version: 3.8.8
+        if: runner.os == 'macOS'
+
+      - name: Setup Maven v3.8.0 for windows
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.8.8
+        if: runner.os == 'windows'
 
       - name: Install local Artifactory
         uses: jfrog/.github/actions/install-local-artifactory@main


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---

This PR sets the fixed maven version of 3.8.8 to avoid unwanted upgrades.
Instead of only for macOS we now want for all images to run with a fixed version of maven until fixed.

Base images updated their maven version to 3.9.x which cause breaking changes.



https://github.com/actions/runner-images/issues/11093