### PR TITLE
Adding 'operation' flag for release bundle promote command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -191,10 +191,14 @@ require (
 
 replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.1.13-0.20250212084027-746cc7ae6a63
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250212021126-e5223ab616af
+//replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250212021126-e5223ab616af
 
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250205140905-08198f526976
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20241220065541-91828d43d8b9
 
 // replace github.com/jfrog/gofrog => github.com/jfrog/gofrog dev
+
+replace github.com/jfrog/jfrog-cli-core/v2 => ../jfrog-cli-core
+
+replace github.com/jfrog/jfrog-client-go => ../jfrog-client-go

--- a/go.sum
+++ b/go.sum
@@ -187,14 +187,10 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-artifactory v0.1.13-0.20250212084027-746cc7ae6a63 h1:OaDd/sz00/89jzrrTnCePnjFj0qzPUy5INXSEyR/3Zg=
 github.com/jfrog/jfrog-cli-artifactory v0.1.13-0.20250212084027-746cc7ae6a63/go.mod h1:llrtIDDeRoO0MmyT9shlBA74rTlaU0aJYS9JXj72F2Q=
-github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250212021126-e5223ab616af h1:XnyhhyARP1YCzYGdhk8ovpyZV+hSchiTGVTuejrZXsI=
-github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250212021126-e5223ab616af/go.mod h1:Hx2houXADsNv0eRh4w5XCS2uSsPNPn1OmiSDdwGFB7g=
 github.com/jfrog/jfrog-cli-platform-services v1.7.0 h1:u0AOyG4JX3VT7xhEeA9gDpBgW8tYILONpQURtzR3FkI=
 github.com/jfrog/jfrog-cli-platform-services v1.7.0/go.mod h1:u3lMRG7XC8MeUy/OPkHkZnsgCMIi0br4sjk2/W1Pm8I=
 github.com/jfrog/jfrog-cli-security v1.15.0 h1:TYNIID231X/AivYtptDCF25JyH8qTQht6ISHRfwejL8=
 github.com/jfrog/jfrog-cli-security v1.15.0/go.mod h1:WyXj2D0zBfF6gbdufgt/DWGTA0Qr2dyRMwIqr21t0bc=
-github.com/jfrog/jfrog-client-go v1.50.0 h1:t7v/zpLkPomHR6ZjVbPQ1WPQJd9IFKESK9Tt6phZz3k=
-github.com/jfrog/jfrog-client-go v1.50.0/go.mod h1:xHxwKBjPSUBd/FyCWgusfHmSWKUZTkfOZkTmntC2F5Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jszwec/csvutil v1.10.0 h1:upMDUxhQKqZ5ZDCs/wy+8Kib8rZR8I8lOR34yJkdqhI=

--- a/lifecycle/cli.go
+++ b/lifecycle/cli.go
@@ -254,7 +254,8 @@ func promote(c *cli.Context) error {
 	promoteCmd := lifecycle.NewReleaseBundlePromoteCommand().SetServerDetails(lcDetails).SetReleaseBundleName(c.Args().Get(0)).
 		SetReleaseBundleVersion(c.Args().Get(1)).SetEnvironment(c.Args().Get(2)).SetSigningKeyName(c.String(cliutils.SigningKey)).
 		SetSync(c.Bool(cliutils.Sync)).SetReleaseBundleProject(cliutils.GetProject(c)).
-		SetIncludeReposPatterns(splitRepos(c, cliutils.IncludeRepos)).SetExcludeReposPatterns(splitRepos(c, cliutils.ExcludeRepos))
+		SetIncludeReposPatterns(splitRepos(c, cliutils.IncludeRepos)).SetExcludeReposPatterns(splitRepos(c, cliutils.ExcludeRepos)).
+		SetPromotionType(c.String(cliutils.PromotionType))
 	return commands.Exec(promoteCmd)
 }
 

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -581,6 +581,7 @@ const (
 	lcIncludeRepos       = lifecyclePrefix + IncludeRepos
 	lcExcludeRepos       = lifecyclePrefix + ExcludeRepos
 	setupRepo            = repo
+	PromotionType        = "promotion-type"
 )
 
 var flagsMap = map[string]cli.Flag{
@@ -1721,6 +1722,10 @@ var flagsMap = map[string]cli.Flag{
 		Name:  repo,
 		Usage: "[Optional] Specifies the Artifactory repository name for the selected package manager, replacing the interactive repository selection.` `",
 	},
+	PromotionType: cli.StringFlag{
+		Name:  PromotionType,
+		Usage: "[Default: copy] Specifies promotion type. [Valid values: move / copy]` `",
+	},
 }
 
 var commandFlags = map[string][]string{
@@ -2001,7 +2006,7 @@ var commandFlags = map[string][]string{
 		specFlag, specVars, BuildName, BuildNumber,
 	},
 	ReleaseBundlePromote: {
-		platformUrl, user, password, accessToken, serverId, lcSigningKey, lcSync, lcProject, lcIncludeRepos, lcExcludeRepos,
+		platformUrl, user, password, accessToken, serverId, lcSigningKey, lcSync, lcProject, lcIncludeRepos, lcExcludeRepos, PromotionType,
 	},
 	ReleaseBundleDistribute: {
 		platformUrl, user, password, accessToken, serverId, lcProject, DistRules, site, city, countryCodes,


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---

Adding a new flag for release bundle promote (RBP) command named 'operation'.