### PR TITLE
RBv2 enable properties

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -127,15 +127,16 @@ import (
 )
 
 const (
-	filesCategory    = "Files Management"
-	buildCategory    = "Build Info"
-	repoCategory     = "Repository Management"
-	replicCategory   = "Replication"
-	permCategory     = "Permission Targets"
-	userCategory     = "User Management"
-	transferCategory = "Transfer Between Artifactory Instances"
-	otherCategory    = "Other"
-	releaseBundlesV2 = "release-bundles-v2"
+	filesCategory          = "Files Management"
+	buildCategory          = "Build Info"
+	repoCategory           = "Repository Management"
+	replicCategory         = "Replication"
+	permCategory           = "Permission Targets"
+	userCategory           = "User Management"
+	transferCategory       = "Transfer Between Artifactory Instances"
+	otherCategory          = "Other"
+	releaseBundlesV2       = "release-bundles-v2"
+	bundleManifestFileName = "release-bundle.json"
 )
 
 func GetCommands() []cli.Command {
@@ -2607,8 +2608,16 @@ func createDefaultPropertiesSpec(c *cli.Context) (*spec.SpecFiles, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	sourcePattern := getSourcePattern(c)
+	if strings.Contains(sourcePattern, releaseBundlesV2) {
+		sourcePattern += bundleManifestFileName
+	} else {
+		sourcePattern = c.Args().Get(0)
+	}
+
 	return spec.NewBuilder().
-		Pattern(c.Args().Get(0)).
+		Pattern(sourcePattern).
 		Props(c.String("props")).
 		ExcludeProps(c.String("exclude-props")).
 		Build(c.String("build")).

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -243,7 +243,7 @@ func TestReleaseBundleImportOnPrem(t *testing.T) {
 	assert.NoError(t, lcCli.Exec("rbi", testFilePath))
 }
 
-func TestReleaseBundleV2Download(t *testing.T) {
+func TestReleaseBundleV2DownloadAndSettingProperties(t *testing.T) {
 	buildNumber := "5"
 	defer func() {
 		deleteReceivedReleaseBundle(t, deleteReleaseBundleV2ApiUrl, tests.LcRbName1, buildNumber)
@@ -258,6 +258,10 @@ func TestReleaseBundleV2Download(t *testing.T) {
 
 	// Create RBV2
 	err := lcCli.Exec("rbc", tests.LcRbName1, buildNumber, "--build-name="+tests.RtBuildName1, "--build-number="+buildNumber)
+	assert.NoError(t, err)
+
+	// Attaching properties to rbv2
+	runRt(t, "sp", "--bundle", tests.LcRbName1+"/"+buildNumber, "\"*\"", "key=value")
 	assert.NoError(t, err)
 
 	runRt(t, "download", "--bundle="+tests.LcRbName1+"/"+buildNumber)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
Adding the ability to add properties on the bundle manifest file for RBV2