### PR TITLE
Integrate the chmod command into the copy to avoid additional layer size

### DIFF
--- a/build/docker/full/Dockerfile
+++ b/build/docker/full/Dockerfile
@@ -10,7 +10,6 @@ FROM releases-docker.jfrog.io/jfrog-ecosystem-integration-env:latest
 ARG image_name=jfrog-cli-full
 ARG cli_executable_name
 ENV CI true
-COPY --from=builder /${image_name}/${cli_executable_name} /usr/local/bin/${cli_executable_name}
-RUN chmod +x /usr/local/bin/${cli_executable_name}
+COPY --chmod=755 --from=builder /${image_name}/${cli_executable_name} /usr/local/bin/${cli_executable_name}
 # Install bash completion
 RUN ${cli_executable_name} completion bash >> /etc/bash_completion

--- a/build/docker/slim/Dockerfile
+++ b/build/docker/slim/Dockerfile
@@ -12,5 +12,4 @@ ARG image_name=jfrog-cli
 ARG cli_executable_name
 ENV CI true
 RUN apk add --no-cache bash tzdata ca-certificates curl jq
-COPY --from=builder /${image_name}/${cli_executable_name} /usr/local/bin/${cli_executable_name}
-RUN chmod +x /usr/local/bin/${cli_executable_name}
+COPY --chmod=755 --from=builder /${image_name}/${cli_executable_name} /usr/local/bin/${cli_executable_name}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
