### PR TITLE
Enhance pattern handling and prevent default envExclude value overrides for build publish

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -2649,10 +2649,7 @@ func createBuildInfoConfiguration(c *cli.Context) *buildinfocmd.Configuration {
 	if flags.EnvInclude == "" {
 		flags.EnvInclude = "*"
 	}
-	// Allow using `env-exclude=""` and get no filters
-	if flags.EnvExclude == "" {
-		flags.EnvExclude = "*password*;*psw*;*secret*;*key*;*token*;*auth*"
-	}
+	flags.EnvExclude = "*password*;*psw*;*secret*;*key*;*token*;*auth*;*proxy*;" + flags.EnvExclude
 	flags.Overwrite = c.Bool("overwrite")
 	return flags
 }

--- a/go.mod
+++ b/go.mod
@@ -193,6 +193,6 @@ require (
 
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250226094621-9317a4bcdfc4
 
-//replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20250226102210-d57860372195
+replace github.com/jfrog/build-info-go => github.com/bhanurp/build-info-go v1.8.9-0.20250312090212-9b04ad27dceb
 
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250221062042-87cb5136765e

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beevik/etree v1.4.0 h1:oz1UedHRepuY3p4N5OjE0nK1WLCqtzHf25bxplKOHLs=
 github.com/beevik/etree v1.4.0/go.mod h1:cyWiXwGoasx60gHvtnEh5x8+uIjUVnjWqBvEnhnqKDA=
+github.com/bhanurp/build-info-go v1.8.9-0.20250312090212-9b04ad27dceb h1:S3GR9pv/Z0ibiztmDSFTIB85bpCMLxbdmCNsz6v0Z4U=
+github.com/bhanurp/build-info-go v1.8.9-0.20250312090212-9b04ad27dceb/go.mod h1:JcISnovFXKx3wWf3p1fcMmlPdt6adxScXvoJN4WXqIE=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
@@ -175,8 +177,6 @@ github.com/jedib0t/go-pretty/v6 v6.6.5 h1:9PgMJOVBedpgYLI56jQRJYqngxYAAzfEUua+3N
 github.com/jedib0t/go-pretty/v6 v6.6.5/go.mod h1:Uq/HrbhuFty5WSVNfjpQQe47x16RwVGXIveNGEyGtHs=
 github.com/jfrog/archiver/v3 v3.6.1 h1:LOxnkw9pOn45DzCbZNFV6K0+6dCsQ0L8mR3ZcujO5eI=
 github.com/jfrog/archiver/v3 v3.6.1/go.mod h1:VgR+3WZS4N+i9FaDwLZbq+jeU4B4zctXL+gL4EMzfLw=
-github.com/jfrog/build-info-go v1.10.10 h1:2nOFjV7SX1uisi2rQK7fb4Evm7YkSOdmssrm6Tf4ipc=
-github.com/jfrog/build-info-go v1.10.10/go.mod h1:JcISnovFXKx3wWf3p1fcMmlPdt6adxScXvoJN4WXqIE=
 github.com/jfrog/froggit-go v1.16.2 h1:F//S83iXH14qsCwYzv0zB2JtjS2pJVEsUoEmYA+37dQ=
 github.com/jfrog/froggit-go v1.16.2/go.mod h1:5VpdQfAcbuyFl9x/x8HGm7kVk719kEtW/8YJFvKcHPA=
 github.com/jfrog/go-mockhttp v0.3.1 h1:/wac8v4GMZx62viZmv4wazB5GNKs+GxawuS1u3maJH8=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
## Depends On

https://github.com/jfrog/build-info-go/pull/297
---
This pull request modifies the environment variable collection process. By default, the patterns `*password*`, `*psw*`, `*secret*`, `*key*`, `*token*`, `*auth*`, and `*proxy*` will always be excluded, regardless of whether the `--envExclude` flag or the `JFROG_CLI_ENV_EXCLUDE` variable is set. 

However, if users do specify additional patterns in either `--envExclude` or `JFROG_CLI_ENV_EXCLUDE`, those new patterns will be appended to the existing default list. This ensures that users can extend the exclusion criteria while maintaining the protection offered by the default patterns.