### PR TITLE
Allow Build Publish with `overwrite` Flag When Build Number is New

### DIFF
--- a/.github/workflows/staleIssues.yml
+++ b/.github/workflows/staleIssues.yml
@@ -1,21 +1,35 @@
-name: Close inactive issues
+name: Monitor Issues
 on:
   workflow_dispatch:
-
+    inputs:
+      operations-per-run:
+        description: 'Number of operations per run'
+        required: false
+        default: '30'
+  schedule:
+    - cron: "0 */6 * * *"  # Runs every 6 hours
 jobs:
-  close-issues:
+  monitor-issues:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-issue-stale: 90
+          # Ignore issues with these labels
+          exempt-issue-labels: 'feature request,question'
+          # Days of inactivity before marking an issue as stale
+          days-before-issue-stale: 180
+          # Days of inactivity before closing an issue
           days-before-issue-close: 7
+          # Name of the stale label
           stale-issue-label: "stale"
-          stale-issue-message: "This issue has been marked as stale due to 90 days of inactivity. If you wish to keep it open, please remove the stale label or leave a comment; otherwise, it will be closed in 7 days."
+          stale-issue-message: "This issue has been marked as stale due to 6 months of inactivity. As part of our effort to address every issue properly, please feel free to remove the stale label or keep this issue active by leaving a comment. Otherwise, it will be closed in 7 days"
           close-issue-message: "This issue was closed due to 7 days of inactivity after being marked as stale. Feel free to reopen it if it remains relevant."
-          any-of-issue-labels: 'bug'
-          debug-only: 'true'
+          # Ignore pull requests
+          days-before-pr-close: false
+          days-before-pr-stale: false
+          ascending: true
+          # Get from input or resolve to default
+          operations-per-run: ${{ github.event.inputs.operations-per-run || '30' }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/staleIssues.yml
+++ b/.github/workflows/staleIssues.yml
@@ -1,0 +1,21 @@
+name: Close inactive issues
+on:
+  workflow_dispatch:
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue has been marked as stale due to 90 days of inactivity. If you wish to keep it open, please remove the stale label or leave a comment; otherwise, it will be closed in 7 days."
+          close-issue-message: "This issue was closed due to 7 days of inactivity after being marked as stale. Feel free to reopen it if it remains relevant."
+          any-of-issue-labels: 'bug'
+          debug-only: 'true'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/staleIssues.yml
+++ b/.github/workflows/staleIssues.yml
@@ -7,7 +7,7 @@ on:
         required: false
         default: '30'
   schedule:
-    - cron: "0 */6 * * *"  # Runs every 6 hours
+    - cron: "0 0 * * *"  # Runs once a day at midnight
 jobs:
   monitor-issues:
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-artifactory v0.2.0
 	github.com/jfrog/jfrog-cli-core/v2 v2.58.1
-	github.com/jfrog/jfrog-cli-platform-services v1.7.0
+	github.com/jfrog/jfrog-cli-platform-services v1.8.0
 	github.com/jfrog/jfrog-cli-security v1.16.0
 	github.com/jfrog/jfrog-client-go v1.51.0
 	github.com/jszwec/csvutil v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -196,3 +196,5 @@ require (
 //replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20250226102210-d57860372195
 
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250221062042-87cb5136765e
+
+replace github.com/jfrog/jfrog-cli-artifactory => github.com/bhanurp/jfrog-cli-artifactory v0.1.12-0.20250317170730-149e2ab7add7

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beevik/etree v1.4.0 h1:oz1UedHRepuY3p4N5OjE0nK1WLCqtzHf25bxplKOHLs=
 github.com/beevik/etree v1.4.0/go.mod h1:cyWiXwGoasx60gHvtnEh5x8+uIjUVnjWqBvEnhnqKDA=
+github.com/bhanurp/jfrog-cli-artifactory v0.1.12-0.20250317170730-149e2ab7add7 h1:vPtRCtJQbdwB6s7xux3fFlYAGA9dlC44CYDupL5QnJc=
+github.com/bhanurp/jfrog-cli-artifactory v0.1.12-0.20250317170730-149e2ab7add7/go.mod h1:U9gkQhxSPv6tXYEdj0kdsCrmFUjcvYmizrh+DztDxXc=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
@@ -185,8 +187,6 @@ github.com/jfrog/gofrog v1.7.6 h1:QmfAiRzVyaI7JYGsB7cxfAJePAZTzFz0gRWZSE27c6s=
 github.com/jfrog/gofrog v1.7.6/go.mod h1:ntr1txqNOZtHplmaNd7rS4f8jpA5Apx8em70oYEe7+4=
 github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYLipdsOFMY=
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
-github.com/jfrog/jfrog-cli-artifactory v0.2.0 h1:4jEbIpJIeu8HsduZHr8L6e0bKQrhn6BLyq/aCRoKPQk=
-github.com/jfrog/jfrog-cli-artifactory v0.2.0/go.mod h1:U9gkQhxSPv6tXYEdj0kdsCrmFUjcvYmizrh+DztDxXc=
 github.com/jfrog/jfrog-cli-core/v2 v2.58.1 h1:ZktHuEVDBkM21JNp/0V3HGcMAMt7DLl1iQlbyBNKucE=
 github.com/jfrog/jfrog-cli-core/v2 v2.58.1/go.mod h1:75J6/Z5sMuRAloMAqJtMJIXqNTC1eFh/SulgLGm2fIY=
 github.com/jfrog/jfrog-cli-platform-services v1.8.0 h1:7p0StDwVjPfz9W1UslHvRGQTZenM4BujmbP/d2vBcr4=

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/jfrog/jfrog-cli-artifactory v0.2.0 h1:4jEbIpJIeu8HsduZHr8L6e0bKQrhn6B
 github.com/jfrog/jfrog-cli-artifactory v0.2.0/go.mod h1:U9gkQhxSPv6tXYEdj0kdsCrmFUjcvYmizrh+DztDxXc=
 github.com/jfrog/jfrog-cli-core/v2 v2.58.1 h1:ZktHuEVDBkM21JNp/0V3HGcMAMt7DLl1iQlbyBNKucE=
 github.com/jfrog/jfrog-cli-core/v2 v2.58.1/go.mod h1:75J6/Z5sMuRAloMAqJtMJIXqNTC1eFh/SulgLGm2fIY=
-github.com/jfrog/jfrog-cli-platform-services v1.7.0 h1:u0AOyG4JX3VT7xhEeA9gDpBgW8tYILONpQURtzR3FkI=
-github.com/jfrog/jfrog-cli-platform-services v1.7.0/go.mod h1:u3lMRG7XC8MeUy/OPkHkZnsgCMIi0br4sjk2/W1Pm8I=
+github.com/jfrog/jfrog-cli-platform-services v1.8.0 h1:7p0StDwVjPfz9W1UslHvRGQTZenM4BujmbP/d2vBcr4=
+github.com/jfrog/jfrog-cli-platform-services v1.8.0/go.mod h1:sG5ASzRU9otA77iXSFX3Ermt4d6mL6WgG4VtwCGiz7o=
 github.com/jfrog/jfrog-cli-security v1.16.0 h1:bwue3BrracjVC1XGn1MD44LWH1T+zE0bUk3vCVjHRSE=
 github.com/jfrog/jfrog-cli-security v1.16.0/go.mod h1:bxnXhMT3F5adKW+ZOObSe44PmW4XSQPXisxQwZVa2Bg=
 github.com/jfrog/jfrog-client-go v1.51.0 h1:O9sgpgEDBW9t05brGYwNR/NMqJ/e3WZY9G8Wge2xR+Q=
@@ -428,8 +428,8 @@ go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/mock v0.5.0 h1:KAMbZvZPyBPWgD14IrIQ38QCyjwpvVVV6K/bHl1IwQU=
-go.uber.org/mock v0.5.0/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
+go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
+go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
## Depends On
https://github.com/jfrog/jfrog-cli-artifactory/pull/55

---
## **Fix: Allow Build Publish with `overwrite` Flag When Build Number is New**

### **Issue**
When attempting to publish a build with the `overwrite` flag, the process fails if the `buildName` already exists in Artifactory but the `buildNumber` is new. The failure occurs due to a missing build number in Artifactory.

### **Current Behavior**
- Publishing fails with an error stating that the build number is not available.

### **Solution**
- Ensure that the build info is pushed even if the specified `buildNumber` is not yet available in Artifactory.
