### PR TITLE
Bump platform-services v1.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-artifactory v0.2.1
 	github.com/jfrog/jfrog-cli-core/v2 v2.58.2
-	github.com/jfrog/jfrog-cli-platform-services v1.8.0
+	github.com/jfrog/jfrog-cli-platform-services v1.9.0
 	github.com/jfrog/jfrog-cli-security v1.16.2
 	github.com/jfrog/jfrog-client-go v1.51.1
 	github.com/jszwec/csvutil v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/jfrog/jfrog-cli-artifactory v0.2.2-0.20250407070644-685ca4be29b6 h1:4
 github.com/jfrog/jfrog-cli-artifactory v0.2.2-0.20250407070644-685ca4be29b6/go.mod h1:Mj2Nrz4xGH7ahFu4SOwCRnhwE3DA0BXY+6yArEAEMZ0=
 github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250407070140-5f4344d30fe4 h1:niRyAkZVcGm7jOUJ2+/5ZtTzkuNBjWmsvB/EJCQaDKs=
 github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20250407070140-5f4344d30fe4/go.mod h1:4S7yztLwWq4yA+k9j9s5gvIqr7xC/6EjJQ+0ENCHTFc=
-github.com/jfrog/jfrog-cli-platform-services v1.8.0 h1:7p0StDwVjPfz9W1UslHvRGQTZenM4BujmbP/d2vBcr4=
-github.com/jfrog/jfrog-cli-platform-services v1.8.0/go.mod h1:sG5ASzRU9otA77iXSFX3Ermt4d6mL6WgG4VtwCGiz7o=
+github.com/jfrog/jfrog-cli-platform-services v1.9.0 h1:r/ETgJuMUOUu12w20ydsF6paqEaj0khH6bxMRsdNz1Y=
+github.com/jfrog/jfrog-cli-platform-services v1.9.0/go.mod h1:pMZMSwhj7yA4VKyj0Skr2lObIyGpZUxNJ40DSLKXU38=
 github.com/jfrog/jfrog-cli-security v1.16.3-0.20250402121228-12cce9f88504 h1:mnU8PtDaCmU1ZC8Wcy0VKj1gJEZnnyjgAc3rJLCcMjs=
 github.com/jfrog/jfrog-cli-security v1.16.3-0.20250402121228-12cce9f88504/go.mod h1:tJyLh4KI4qoF/AVBy0wC9s8DVxV/hoyKK4LIzpxL590=
 github.com/jfrog/jfrog-client-go v1.28.1-0.20250406105605-ee90d11546f9 h1:pEBTHYeyuDa+w0oJNCYFq1wD2O2NqWdDTAtDRFy7s3w=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---

Release notes:

* New command `jf worker execution-history` 