### PR TITLE
Fix for mismatching cpu type for macos arm64 architecture

### DIFF
--- a/build/apple_release/scripts/download-signed-mac-OS-binaries.sh
+++ b/build/apple_release/scripts/download-signed-mac-OS-binaries.sh
@@ -70,7 +70,7 @@ downloadSignedMacOSBinaries() {
     apt-get install unzip
 
     # Extract the artifact and clean up
-    unzip artifact.zip
+    unzip -o artifact.zip
     rm -rf artifact.zip
 
     # Check if the executable exists


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
## 🐛 Problem Statement
The execution of binary jf on macos arm64 is causing `Bad CPU type in executable`

## 🔍 Root Cause
The unzip command, by default, prompts the user when it encounters existing files. In non-interactive environments (like shell scripts or CI/CD runners), there is no stdin to provide an answer. This leads to a read error, causing unzip to default to [N]one, meaning it skips overwriting existing files silently. This PR should also fix #2960 

![image](https://github.com/user-attachments/assets/b6d6997e-1a31-42be-a4e9-a466451d703f)

## ✅ Fix Implemented
Added the -o flag to the unzip command to force overwrite of existing files without user interaction. As an alternative approach the binary can be deleted as well once upload is successful https://github.com/jfrog/jfrog-cli/blob/eee4967a301919b00cddde69eee272579e8935c2/Jenkinsfile#L547

## 📌 Notes
This is happening on jenkins release pipeline, CI script is packing from github uploading as artifact and jenkins pipelines is downloading the bin and uploading to `releases.jfrog.io` even though jfrog-cli binary is build properly for arm64 because of similar steps for x86 and arm64 binaries the artifact created as artifact.zip is with same name for arm64 and x86. Since x86 happens first and then arm64, unzip binary for arm64 fails since it is with same name. It should work even on arm64 with Rosetta installed.

below screen shot should show the difference from 2.73.2 this issue has started
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/b801a193-45f5-43bd-b0f1-fcaedfd56e9e" />
 