### PR TITLE
Bump version from 2.77.0 to 2.78.0

### DIFF
--- a/build/npm/v2-jf/package-lock.json
+++ b/build/npm/v2-jf/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "jfrog-cli-v2-jf",
-  "version": "2.77.0",
+  "version": "2.78.0",
   "lockfileVersion": 1
 }

--- a/build/npm/v2-jf/package.json
+++ b/build/npm/v2-jf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jfrog-cli-v2-jf",
-  "version": "2.77.0",
+  "version": "2.78.0",
   "description": "🐸 Command-line interface for JFrog Artifactory, Xray, Distribution, Pipelines and Mission Control 🐸",
   "homepage": "https://github.com/jfrog/jfrog-cli",
   "preferGlobal": true,

--- a/build/npm/v2/package-lock.json
+++ b/build/npm/v2/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "jfrog-cli-v2",
-  "version": "2.77.0",
+  "version": "2.78.0",
   "lockfileVersion": 2
 }

--- a/build/npm/v2/package.json
+++ b/build/npm/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jfrog-cli-v2",
-  "version": "2.77.0",
+  "version": "2.78.0",
   "description": "🐸 Command-line interface for JFrog Artifactory, Xray, Distribution, Pipelines and Mission Control 🐸",
   "homepage": "https://github.com/jfrog/jfrog-cli",
   "preferGlobal": true,

--- a/utils/cliutils/cli_consts.go
+++ b/utils/cliutils/cli_consts.go
@@ -4,7 +4,7 @@ import "time"
 
 const (
 	// General CLI constants
-	CliVersion  = "2.77.0"
+	CliVersion  = "2.78.0"
 	ClientAgent = "jfrog-cli-go"
 
 	// CLI base commands constants:


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
