### PR TITLE
Add GitHub Actions summary section for the create evidence command

### DIFF
--- a/general/summary/cli.go
+++ b/general/summary/cli.go
@@ -24,6 +24,7 @@ const (
 	Security  MarkdownSection = "security"
 	BuildInfo MarkdownSection = "build-info"
 	Upload    MarkdownSection = "upload"
+	Evidence  MarkdownSection = "evidence"
 )
 
 const (
@@ -31,7 +32,7 @@ const (
 	finalSarifFileName = "final.sarif"
 )
 
-var markdownSections = []MarkdownSection{Security, BuildInfo, Upload}
+var markdownSections = []MarkdownSection{Security, BuildInfo, Upload, Evidence}
 
 func (ms MarkdownSection) String() string {
 	return string(ms)
@@ -185,6 +186,8 @@ func invokeSectionMarkdownGeneration(section MarkdownSection) error {
 		return generateBuildInfoMarkdown()
 	case Upload:
 		return generateUploadMarkdown()
+	case Evidence:
+		return generateEvidenceMarkdown()
 	default:
 		return fmt.Errorf("unknown section: %s", section)
 	}
@@ -207,6 +210,14 @@ func generateBuildInfoMarkdown() error {
 		return fmt.Errorf("error mapping scan results: %w", err)
 	}
 	return buildInfoSummary.GenerateMarkdown()
+}
+
+func generateEvidenceMarkdown() error {
+	evidenceSummary, err := commandsummary.NewEvidenceSummary()
+	if err != nil {
+		return fmt.Errorf("error generating evidence markdown: %w", err)
+	}
+	return evidenceSummary.GenerateMarkdown()
 }
 
 func generateUploadMarkdown() error {

--- a/go.mod
+++ b/go.mod
@@ -245,7 +245,8 @@ require (
 
 // replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.4.1-0.20250718083259-4a60768eb51b
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.59.2-0.20250717045550-6e019038f578
+// will be replaced after merging the PR in jfrog-cli-core
+ replace github.com/jfrog/jfrog-cli-core/v2 => github.com/mnsboev/jfrog-cli-core/v2 v2.0.0-20250727082212-a54b8a4c4ab3
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250717041744-d3ea4d99f4e7
 

--- a/go.sum
+++ b/go.sum
@@ -364,6 +364,7 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-artifactory v0.5.1 h1:C1H8x6ldg7VmKIb4F8OZKm0PJbBrlA73y2tmoy/s9m8=
 github.com/jfrog/jfrog-cli-artifactory v0.5.1/go.mod h1:RXz0AZ5qVEOhanXRGmC4+atqr29ZtIeV5kUCbNGtVj4=
+github.com/jfrog/jfrog-cli-core/v2 v2.59.2-0.20250717045550-6e019038f578/go.mod h1:Jz0ZQqrarcryOo+v1IvVujPCtNZH/UHiDjb/FJkPjmA=
 github.com/jfrog/jfrog-cli-core/v2 v2.59.3 h1:AlFC9l3Cwvx2FzuAP0txxEjZPDjv5bpO7YPTOjHp7HA=
 github.com/jfrog/jfrog-cli-core/v2 v2.59.3/go.mod h1:Itfva9wqPMkUVBuNpKw0Oe4qoPlt0PdXfmWqf7fBebU=
 github.com/jfrog/jfrog-cli-platform-services v1.10.0 h1:O+N/VAF+QjFvq9xkHpmzKLcdl9aJu3IP204Su0L14rw=
@@ -452,6 +453,7 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mnsboev/jfrog-cli-core/v2 v2.0.0-20250727082212-a54b8a4c4ab3/go.mod h1:Itfva9wqPMkUVBuNpKw0Oe4qoPlt0PdXfmWqf7fBebU=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
**Description**
Add evidence summary section  for Create Evidence Command

This PR is part of a series of three that enhances the documentation for the "create evidence" command by introducing a summary markdown table.
https://github.com/jfrog/jfrog-cli-core/pull/1423

**Summary**
This addition aims to improve the user experience by providing a clear and concise overview of the evidence being created. The markdown table includes the following columns:

Evidence Subject: Links to the relevant evidence files, allowing users to easily access them.
Evidence Type: Specifies the type of evidence being recorded (e.g., in-toto).
Verification Status: Indicates whether the evidence has been verified, complete with visual status indicators (e.g., ✅ Verified).
**Example Output**
When the create evidence command is executed, users will see a collapsible section that looks like this:
<details open>

<summary> <h3> 🔎 Evidence </h3></summary><p></p>

<table><thead><tr><th>Evidence Subject</th><th>Evidence Type</th><th>Verification Status</th></tr></thead><tbody>
<tr><td>📄 <a href="https://evidencetrial.jfrog.io/ui/repos/tree/Evidence/cli-sigstore-test/commons-1.0.0.txt?clearFilter=true">cli-sigstore-test/commons-1.0.0.txt</a></td><td>in-toto</td><td>✅ Verified</td></tr>
</tbody></table>



</details>
