### PR TITLE
Do not wrap base64 command output or auth header will be corrupt

### DIFF
--- a/build/gitlab/v2/.setup-jfrog-unix.yml
+++ b/build/gitlab/v2/.setup-jfrog-unix.yml
@@ -31,7 +31,7 @@
         if [ -n "${JF_ACCESS_TOKEN}" ]; then
             AUTH_HEADER="Authorization: Bearer ${JF_ACCESS_TOKEN}"
         else
-            AUTH_HEADER="Authorization: Basic $(printf ${JF_USER}:${JF_PASSWORD} | base64)"
+            AUTH_HEADER="Authorization: Basic $(printf ${JF_USER}:${JF_PASSWORD} | base64 -w0)"
         fi
         echo "Downloading from remote repository '${JF_RELEASES_REPO}'..."
     fi


### PR DESCRIPTION
Feeding a long username:password pair into just "base64" will generate enough output that the base64 will perform automatic wrapping at 76 characters of output. That effectively truncates the output as only the first line is considered. The proper way to get base64 data is to turn off wrapping via the `-w0` flag which is added here.

Without this fix, authentication via `JF_USER:JF_PASSWORD` will not work for a lot of people using this template.

EXAMPLE (short does not wrap):
```
% echo jblaine:XXXXXXXXXXXXXXXXX | base64
amJsYWluZTpYWFhYWFhYWFhYWFhYWFhYWAo=
```
EXAMPLE (long, wraps to 2 lines and therefore truncates!):
```
% echo jblaine:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX | base64
amJsYWluZTpYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY
WAo=
```

- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
