### PR TITLE
use jf evd as separate embedded plugin

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	coreconfig "github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/log"
+	evidenceCLI "github.com/jfrog/jfrog-cli-evidence/evidence/cli"
 	platformServicesCLI "github.com/jfrog/jfrog-cli-platform-services/cli"
 	securityCLI "github.com/jfrog/jfrog-cli-security/cli"
 	"github.com/jfrog/jfrog-cli/artifactory"
@@ -525,6 +526,10 @@ func getCommands() ([]cli.Command, error) {
 	if err != nil {
 		return nil, err
 	}
+	evidenceCmds, err := ConvertEmbeddedPlugin(evidenceCLI.GetJfrogCliEvidenceApp())
+	if err != nil {
+		return nil, err
+	}
 	platformServicesCmds, err := ConvertEmbeddedPlugin(platformServicesCLI.GetPlatformServicesApp())
 	if err != nil {
 		return nil, err
@@ -532,6 +537,7 @@ func getCommands() ([]cli.Command, error) {
 
 	allCommands := append(slices.Clone(cliNameSpaces), securityCmds...)
 	allCommands = mergeCommands(allCommands, artifactoryCmds)
+	allCommands = mergeCommands(allCommands, evidenceCmds)
 	allCommands = append(allCommands, platformServicesCmds...)
 	allCommands = append(allCommands, utils.GetPlugins()...)
 	allCommands = append(allCommands, buildtools.GetCommands()...)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
