### PR TITLE
Fix npm native workspace

### DIFF
--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -1107,7 +1107,10 @@ func NpmPublishCmd(c *cli.Context) (err error) {
 	err = commands.Exec(npmCmd)
 	result := npmCmd.Result()
 	defer cliutils.CleanupResult(result, &err)
-	err = cliutils.PrintCommandSummary(npmCmd.Result(), detailedSummary, printDeploymentView, false, err)
+	// command summary and deployment view are not available for native npm commands
+	if !npmCmd.UseNative() {
+		err = cliutils.PrintCommandSummary(npmCmd.Result(), detailedSummary, printDeploymentView, false, err)
+	}
 	return
 }
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
Problem - npm native workspaces failed due to printing deployment view and command summary

Solution - added check for run native