### PR TITLE
Use CI flag for hidding survey

### DIFF
--- a/utils/cliutils/utils.go
+++ b/utils/cliutils/utils.go
@@ -750,8 +750,8 @@ func GetJFrogApplicationKey(c *cli.Context) string {
 	return applicationKey
 }
 
-// ShouldHideSurveyLink checks if the survey should be hidden based on the JFROG_CLI_HIDE_SURVEY environment variable
-// Returns true if the survey should be hidden (env var is "true"), false otherwise
+// ShouldHideSurveyLink checks if the survey should be hidden based on the JFROG_CLI_HIDE_SURVEY and CI environment variables
+// Returns true if the survey should be hidden, false otherwise
 func ShouldHideSurveyLink() bool {
-	return os.Getenv(JfrogCliHideSurvey) == "true"
+	return getCiValue() || os.Getenv(JfrogCliHideSurvey) == "true"
 }

--- a/utils/cliutils/utils_test.go
+++ b/utils/cliutils/utils_test.go
@@ -14,6 +14,7 @@ import (
 
 	biutils "github.com/jfrog/build-info-go/utils"
 	configtests "github.com/jfrog/jfrog-cli-core/v2/utils/config/tests"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	clientTestUtils "github.com/jfrog/jfrog-client-go/utils/tests"
 	"github.com/urfave/cli"
 
@@ -417,4 +418,10 @@ func TestGetHasDisplayedSurveyLink(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSettingCIFlagRemovesSurvey(t *testing.T) {
+	t.Setenv(coreutils.CI, "true")
+	shouldHide := ShouldHideSurveyLink()
+	assert.True(t, shouldHide, "Expected survey to be hidden when CI flag is set")
 }

--- a/utils/cliutils/utils_test.go
+++ b/utils/cliutils/utils_test.go
@@ -404,7 +404,7 @@ func TestGetHasDisplayedSurveyLink(t *testing.T) {
 			shouldHide: false,
 		},
 	}
-
+	t.Setenv(coreutils.CI, "")
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(JfrogCliHideSurvey, tc.envValue)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
