### PR TITLE
fix: help command for generating markdown summary

### DIFF
--- a/docs/general/summary/help.go
+++ b/docs/general/summary/help.go
@@ -1,6 +1,6 @@
 package summary
 
-var Usage = []string{"csm"}
+var Usage = []string{"gsm"}
 
 func GetDescription() string {
 	return `Generates a Summary of recorded CLI commands there were executed on the current machine. The report is generated in Markdown format and saved in the directory stored in the JFROG_CLI_COMMAND_SUMMARY_OUTPUT_DIR environment variable.`


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---

Fixes the help command referenced when doing `jf generate-summary-markdown --help`. Previously would reference an invalid `csm` short command instead of the correct `gsm` command.