### PR TITLE
Update IDE tests with new command structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/jfrog/build-info-go v1.12.0
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-application v1.0.1
-	github.com/jfrog/jfrog-cli-artifactory v0.7.3-0.20251015051724-72d111a3d107
+	github.com/jfrog/jfrog-cli-artifactory v0.7.3-0.20251015052652-84ea3afaf439
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20251015045218-1a38c9e47097
 	github.com/jfrog/jfrog-cli-platform-services v1.10.0
 	github.com/jfrog/jfrog-cli-security v1.21.8

--- a/go.sum
+++ b/go.sum
@@ -365,8 +365,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.1 h1:PiiSVKFFs8VLAwjCe2JrIKlX7LmARFt+r8BLTupWIDc=
 github.com/jfrog/jfrog-cli-application v1.0.1/go.mod h1:gjV6Q2hhoMe3FF77GFiTyIRLSHokpDrkVj0GvYM+1Y4=
-github.com/jfrog/jfrog-cli-artifactory v0.7.3-0.20251015051724-72d111a3d107 h1:0VVFI1AHzMKyr/Nwxmu/Jhg3U1Rq725AQPKpSTtk7XU=
-github.com/jfrog/jfrog-cli-artifactory v0.7.3-0.20251015051724-72d111a3d107/go.mod h1:nT050Wb18tTlfcQHefyMENzFOz9Vdym6WP0Z3Nc2qHc=
+github.com/jfrog/jfrog-cli-artifactory v0.7.3-0.20251015052652-84ea3afaf439 h1:3B3JGujNYFpHQ69pjaPpRf0Ugny0UCU35whkcmGqaHc=
+github.com/jfrog/jfrog-cli-artifactory v0.7.3-0.20251015052652-84ea3afaf439/go.mod h1:nT050Wb18tTlfcQHefyMENzFOz9Vdym6WP0Z3Nc2qHc=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20251015045218-1a38c9e47097 h1:+W6BPxJ0nPtlQ6l6nmypW1eEANoVPiN8HDR4kQJA8uI=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20251015045218-1a38c9e47097/go.mod h1:UOeOwEEmRIi57cRwghN5OBVoqkJieYQQfLpeqw8Yv38=
 github.com/jfrog/jfrog-cli-platform-services v1.10.0 h1:O+N/VAF+QjFvq9xkHpmzKLcdl9aJu3IP204Su0L14rw=

--- a/ide_test.go
+++ b/ide_test.go
@@ -48,7 +48,7 @@ func TestVscodeSetupCommand(t *testing.T) {
 	expectedServiceURL := serverDetails.ArtifactoryUrl + "api/aieditorextensions/" + repoName + "/_apis/public/gallery"
 
 	// Run the VSCode setup command
-	runJfrogCli(t, "vscode-config", expectedServiceURL, "--product-json-path", productPath)
+	runJfrogCli(t, "ide", "setup", "vscode", expectedServiceURL, "--product-json-path", productPath)
 
 	// Verify the configuration was applied
 	modifiedData, err := os.ReadFile(productPath)
@@ -126,7 +126,7 @@ func TestVscodeAutoDetection(t *testing.T) {
 	serviceURL := serverDetails.ArtifactoryUrl + "api/aieditorextensions/" + repoName + "/_apis/public/gallery"
 
 	// Test with an explicit path (simulating successful auto-detection)
-	runJfrogCli(t, "vscode-config", serviceURL, "--product-json-path", productPath)
+	runJfrogCli(t, "ide", "setup", "vscode", serviceURL, "--product-json-path", productPath)
 
 	// Verify configuration was applied
 	modifiedData, err := os.ReadFile(productPath)
@@ -172,10 +172,10 @@ func TestVscodeInvalidRepository(t *testing.T) {
 	if serverDetails != nil {
 		var err error
 		if serverDetails.AccessToken != "" {
-			err = execJfrogCli("vscode-config", "--repo-key", "non-existent-repo", "--product-json-path", productPath,
+			err = execJfrogCli("ide", "setup", "vscode", "--repo-key", "non-existent-repo", "--product-json-path", productPath,
 				"--url", serverDetails.ArtifactoryUrl, "--access-token", serverDetails.AccessToken)
 		} else {
-			err = execJfrogCli("vscode-config", "--repo-key", "non-existent-repo", "--product-json-path", productPath,
+			err = execJfrogCli("ide", "setup", "vscode", "--repo-key", "non-existent-repo", "--product-json-path", productPath,
 				"--url", serverDetails.ArtifactoryUrl, "--user", serverDetails.User, "--password", serverDetails.Password)
 		}
 		assert.Error(t, err, "Command should fail with invalid repository")
@@ -223,7 +223,7 @@ func TestVscodePermissionHandling(t *testing.T) {
 	serviceURL := serverDetails.ArtifactoryUrl + "api/aieditorextensions/" + repoName + "/_apis/public/gallery"
 
 	// Command should fail due to permission issues
-	err = execJfrogCli("vscode-config", serviceURL, "--product-json-path", productPath)
+	err = execJfrogCli("ide", "setup", "vscode", serviceURL, "--product-json-path", productPath)
 	assert.Error(t, err, "Command should fail due to permission issues")
 
 	// Restore permissions for cleanup
@@ -272,7 +272,7 @@ ide.system.path=${user.home}/.local/share/JetBrains/IntelliJIdea2023.3
 	require.NoError(t, err)
 
 	// Test JetBrains setup command
-	expectedRepositoryURL := serverDetails.ArtifactoryUrl + "api/jetbrainsplugins/" + repoName
+	expectedRepositoryURL := serverDetails.ArtifactoryUrl + "api/aieditorextensions/" + repoName
 
 	// Set environment variable to make the mock IDE detectable (OS-specific)
 	var envVar, envValue string
@@ -307,7 +307,7 @@ ide.system.path=${user.home}/.local/share/JetBrains/IntelliJIdea2023.3
 	}
 
 	// Run the JetBrains setup command
-	runJfrogCli(t, "jetbrains-config", expectedRepositoryURL)
+	runJfrogCli(t, "ide", "setup", "jetbrains", expectedRepositoryURL)
 
 	// Verify the configuration was applied
 	modifiedProperties, err := os.ReadFile(propertiesPath)
@@ -411,10 +411,10 @@ func TestJetbrainsAutoDetection(t *testing.T) {
 	}
 
 	// Test JetBrains auto-detection command
-	repositoryURL := serverDetails.ArtifactoryUrl + "api/jetbrainsplugins/" + repoName
+	repositoryURL := serverDetails.ArtifactoryUrl + "api/aieditorextensions/" + repoName
 
 	// Note: This will work if the auto-detection logic finds our mock IDEs
-	runJfrogCli(t, "jetbrains-config", repositoryURL)
+	runJfrogCli(t, "ide", "setup", "jetbrains", repositoryURL)
 
 	// Verify configuration was applied to detected IDEs
 	for _, ide := range ides {
@@ -472,10 +472,10 @@ ide.config.path=${user.home}/.config/JetBrains/IntelliJIdea2023.3
 	if serverDetails != nil {
 		var err error
 		if serverDetails.AccessToken != "" {
-			err = execJfrogCli("jetbrains-config", "--repo-key", "non-existent-repo",
+			err = execJfrogCli("ide", "setup", "jetbrains", "--repo-key", "non-existent-repo",
 				"--url", serverDetails.ArtifactoryUrl, "--access-token", serverDetails.AccessToken)
 		} else {
-			err = execJfrogCli("jetbrains-config", "--repo-key", "non-existent-repo",
+			err = execJfrogCli("ide", "setup", "jetbrains", "--repo-key", "non-existent-repo",
 				"--url", serverDetails.ArtifactoryUrl, "--user", serverDetails.User, "--password", serverDetails.Password)
 		}
 		assert.Error(t, err, "Command should fail with invalid repository")
@@ -536,10 +536,10 @@ ide.config.path=${user.home}/.config/JetBrains/IntelliJIdea2023.3
 		t.Fatalf("Failed to set XDG_CONFIG_HOME: %v", err)
 	}
 
-	repositoryURL := serverDetails.ArtifactoryUrl + "api/jetbrainsplugins/" + repoName
+	repositoryURL := serverDetails.ArtifactoryUrl + "api/aieditorextensions/" + repoName
 
 	// Command should fail due to permission issues
-	err = execJfrogCli("jetbrains-config", repositoryURL)
+	err = execJfrogCli("ide", "setup", "jetbrains", repositoryURL)
 	assert.Error(t, err, "Command should fail due to permission issues")
 
 	// Restore permissions for cleanup
@@ -647,7 +647,7 @@ func BenchmarkVscodeSetup(b *testing.B) {
 
 		// Run the setup command
 		jfrogCli := coreTests.NewJfrogCli(execMain, "jfrog", "")
-		err = jfrogCli.Exec("vscode-config", serviceURL, "--product-json-path", productPath)
+		err = jfrogCli.Exec("ide", "setup", "vscode", serviceURL, "--product-json-path", productPath)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -705,7 +705,7 @@ ide.config.path=${user.home}/.config/JetBrains/IntelliJIdea2023.3
 		t.Fatalf("Failed to set XDG_CONFIG_HOME: %v", err)
 	}
 
-	repositoryURL := serverDetails.ArtifactoryUrl + "api/jetbrainsplugins/" + repoName
+	repositoryURL := serverDetails.ArtifactoryUrl + "api/aieditorextensions/" + repoName
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -717,7 +717,7 @@ ide.config.path=${user.home}/.config/JetBrains/IntelliJIdea2023.3
 
 		// Run the setup command
 		jfrogCli := coreTests.NewJfrogCli(execMain, "jfrog", "")
-		err = jfrogCli.Exec("jetbrains-config", repositoryURL)
+		err = jfrogCli.Exec("ide", "setup", "jetbrains", repositoryURL)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -729,16 +729,12 @@ func TestIDECommandsRegistration(t *testing.T) {
 	// This test verifies that our IDE commands are properly registered in the CLI
 	// without requiring a running Artifactory server
 
-	// Test that VSCode command is available
+	// Test that IDE setup command is available
 	jfrogCli := coreTests.NewJfrogCli(execMain, "jfrog", "")
-	err := jfrogCli.Exec("vscode-config", "--help")
-	assert.NoError(t, err, "VSCode config command should be available")
+	err := jfrogCli.Exec("ide", "setup", "--help")
+	assert.NoError(t, err, "IDE setup command should be available")
 
-	// Test that JetBrains command is available
-	err = jfrogCli.Exec("jetbrains-config", "--help")
-	assert.NoError(t, err, "JetBrains config command should be available")
-
-	// Test that JetBrains alias is available
-	err = jfrogCli.Exec("jb", "--help")
-	assert.NoError(t, err, "JetBrains alias 'jb' should be available")
+	// Test that IDE command is available with alias
+	err = jfrogCli.Exec("ide", "s", "--help")
+	assert.NoError(t, err, "IDE setup alias 's' should be available")
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
The IDE commands have been refactored from separate commands to a unified structure:
- **Old:** `jf vscode-config` and `jf jetbrains-config` (with jb alias)
- **New:** `jf ide setup <ide-name>` where ide-name can be vscode or jetbrains
Updated all the IDE integration tests.