### PR TITLE
Bump AppTrust plugin version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jfrog/archiver/v3 v3.6.1
 	github.com/jfrog/build-info-go v1.12.4
 	github.com/jfrog/gofrog v1.7.6
-	github.com/jfrog/jfrog-cli-application v1.0.1
+	github.com/jfrog/jfrog-cli-application v1.0.2-0.20251118120147-added119c209
 	github.com/jfrog/jfrog-cli-artifactory v0.7.3-0.20251114091016-341890e1669f
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20251114091511-68e2c162c1af
 	github.com/jfrog/jfrog-cli-evidence v0.8.3-0.20251116083852-12dc534b4d13

--- a/go.sum
+++ b/go.sum
@@ -1159,6 +1159,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.1 h1:PiiSVKFFs8VLAwjCe2JrIKlX7LmARFt+r8BLTupWIDc=
 github.com/jfrog/jfrog-cli-application v1.0.1/go.mod h1:gjV6Q2hhoMe3FF77GFiTyIRLSHokpDrkVj0GvYM+1Y4=
+github.com/jfrog/jfrog-cli-application v1.0.2-0.20251118120147-added119c209 h1:lW8UJdG20EIU25VJXrcVs85qY7gGtHQIbTs2xmh2V0M=
+github.com/jfrog/jfrog-cli-application v1.0.2-0.20251118120147-added119c209/go.mod h1:mBvgtVcGVjRAqc0b+TPmpYNz70nlXJqt1aitL0RGapA=
 github.com/jfrog/jfrog-cli-artifactory v0.7.3-0.20251114091016-341890e1669f h1:MmNSEGH9GDPczj14fALRV4C49zSf2wrNFItKPEOQDFY=
 github.com/jfrog/jfrog-cli-artifactory v0.7.3-0.20251114091016-341890e1669f/go.mod h1:OJD6v+Mn5wqu/qV83rpggs3r3LLwzttrDv2wvxUUD/4=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20251114091511-68e2c162c1af h1:w9anttwgxjplTbuqGauuoFI/HnvjUHWuK9+y2U8mxpU=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
