### PR TITLE
Replacing jfrog-cli-artifactory to galusben

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -281,3 +281,5 @@ replace github.com/docker/docker => github.com/docker/docker v27.5.1+incompatibl
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250812100044-b52afcc698c1
 
 //replace github.com/jfrog/jfrog-cli-security => github.com/jfrog/jfrog-cli-security v1.17.2-0.20250511132918-d9cc4cd50020
+
+replace github.com/jfrog/jfrog-cli-artifactory => github.com/galusben/jfrog-cli-artifactory v0.0.0-20251120140414-5b53aa6dd6d2

--- a/go.sum
+++ b/go.sum
@@ -867,6 +867,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/galusben/jfrog-cli-artifactory v0.0.0-20251120140414-5b53aa6dd6d2 h1:o2P2+JebPUshTt/JlEt539xrymB6G/2e85NVygiP4OQ=
+github.com/galusben/jfrog-cli-artifactory v0.0.0-20251120140414-5b53aa6dd6d2/go.mod h1:l9orAXG293Sx8pyk8nwZyHtnMXmPoVehUKZATIAy14U=
 github.com/gfleury/go-bitbucket-v1 v0.0.0-20230825095122-9bc1711434ab h1:+7KwW/yy/ThnRXW9khailFFncxJiiFpxyk5BI9GK9pI=
 github.com/gfleury/go-bitbucket-v1 v0.0.0-20230825095122-9bc1711434ab/go.mod h1:IqOZzks2wlWCIai0esXnZPdPwxF2yOz0HcCYw5I4pCg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -1159,8 +1161,6 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20251118120147-added119c209 h1:lW8UJdG20EIU25VJXrcVs85qY7gGtHQIbTs2xmh2V0M=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20251118120147-added119c209/go.mod h1:mBvgtVcGVjRAqc0b+TPmpYNz70nlXJqt1aitL0RGapA=
-github.com/jfrog/jfrog-cli-artifactory v0.7.3-0.20251118100843-ac34330a70d3 h1:sIjwBWBmyb7UEqP0IhQ22CWOedOPlNetyHzECS3sUyA=
-github.com/jfrog/jfrog-cli-artifactory v0.7.3-0.20251118100843-ac34330a70d3/go.mod h1:3hLZrM2xT+PkIevIGret4x1xDFTaVoNu3h374QnrKyc=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20251119112003-e336a0d82a52 h1:DC92LCtJjR8tuv7Ge2J9l2GTyD7ljTeERxdyaznz370=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20251119112003-e336a0d82a52/go.mod h1:vhtJbIAfElpZTirHs7qwyaBdq2P10Cu+TFKiV8IekWE=
 github.com/jfrog/jfrog-cli-evidence v0.8.3-0.20251116083852-12dc534b4d13 h1:V9KRanq6ulMMLLwJcnbN2+UlDa0/+sWrUEC2Dex48+E=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
