### PR TITLE
Add Conan tests workflow

### DIFF
--- a/.github/workflows/conanTests.yml
+++ b/.github/workflows/conanTests.yml
@@ -4,19 +4,14 @@ on:
   push:
     branches:
       - "master"
-  # Triggers the workflow on PRs to master branch only.
   pull_request_target:
     types: [labeled]
     branches:
       - "master"
 
-# Ensures that only the latest commit is running for each PR at a time.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
   cancel-in-progress: true
-permissions:
-  id-token: write
-  contents: read
 jobs:
   Conan-Tests:
     name: Conan tests (${{ matrix.os.name }})
@@ -33,31 +28,35 @@ jobs:
             version: 14
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
     steps:
+      - name: Skip macOS - JGC-413
+        if: matrix.os.name == 'macos'
+        run: |
+          echo "::warning::JGC-413 - Skip until artifactory bootstrap in osx is fixed"
+          exit 0
+
       - name: Checkout code
+        if: matrix.os.name != 'macos'
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Go with cache
+        if: matrix.os.name != 'macos'
         uses: jfrog/.github/actions/install-go-with-cache@main
 
       - name: Install Conan
+        if: matrix.os.name != 'macos'
         uses: turtlebrowser/get-conan@main
         with:
           version: '2.10.2'
 
       - name: Install local Artifactory
+        if: matrix.os.name != 'macos'
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
 
-      - name: Get ID Token and Exchange Token
-        shell: bash
-        run: |
-          ID_TOKEN=$(curl -sLS -H "User-Agent: actions/oidc-client" -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
-          echo "JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID=${ID_TOKEN}" >> $GITHUB_ENV
-
       - name: Run Conan tests
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.conan --jfrog.url=http://127.0.0.1:8082 --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}
+        if: matrix.os.name != 'macos'
+        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.conan


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
- Added workflow to trigger the conan e2e tests