### PR TITLE
Added e2e for DeleteCommand returns 0 for SuccessCount and FailCount …

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -285,7 +285,8 @@ replace github.com/gfleury/go-bitbucket-v1 => github.com/gfleury/go-bitbucket-v1
 //replace github.com/jfrog/jfrog-cli-core/v2 => ../jfrog-cli-core
 
 // replace github.com/jfrog/jfrog-cli-artifactory => github.com/fluxxBot/jfrog-cli-artifactory v0.0.0-20260105073552-ae4f86048a11
-//
+replace github.com/jfrog/jfrog-cli-artifactory => github.com/bhanurp/jfrog-cli-artifactory v0.1.12-0.20260108075108-b5389ca4d380
+
 //replace github.com/jfrog/build-info-go => github.com/fluxxBot/build-info-go v1.10.10-0.20260105070825-d3f36f619ba5
 //
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/fluxxBot/jfrog-cli-core/v2 v2.58.1-0.20260105065921-c6488910f44c

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/jfrog/build-info-go v1.13.1-0.20260107080257-82671efa69a2
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-application v1.0.2-0.20251231144110-a68c3ac11c7a
-	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260107090044-56a45e5c560e
+	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260113000842-12090b43088f
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260106204841-744f3f71817b
 	github.com/jfrog/jfrog-cli-evidence v0.8.3-0.20251225153025-9d8ac181d615
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b0000e
@@ -285,7 +285,6 @@ replace github.com/gfleury/go-bitbucket-v1 => github.com/gfleury/go-bitbucket-v1
 //replace github.com/jfrog/jfrog-cli-core/v2 => ../jfrog-cli-core
 
 // replace github.com/jfrog/jfrog-cli-artifactory => github.com/fluxxBot/jfrog-cli-artifactory v0.0.0-20260105073552-ae4f86048a11
-replace github.com/jfrog/jfrog-cli-artifactory => github.com/bhanurp/jfrog-cli-artifactory v0.1.12-0.20260108075108-b5389ca4d380
 
 //replace github.com/jfrog/build-info-go => github.com/fluxxBot/build-info-go v1.10.10-0.20260105070825-d3f36f619ba5
 //

--- a/go.sum
+++ b/go.sum
@@ -729,6 +729,8 @@ github.com/beevik/etree v1.6.0 h1:u8Kwy8pp9D9XeITj2Z0XtA5qqZEmtJtuXZRQi+j03eE=
 github.com/beevik/etree v1.6.0/go.mod h1:bh4zJxiIr62SOf9pRzN7UUYaEDa9HEKafK25+sLc0Gc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bhanurp/jfrog-cli-artifactory v0.1.12-0.20260108075108-b5389ca4d380 h1:cj4idl/pC+WMSqj5jddYgrdFfaoWudzpjn0/Zt7ba8U=
+github.com/bhanurp/jfrog-cli-artifactory v0.1.12-0.20260108075108-b5389ca4d380/go.mod h1:U/1q7jEO0YGSAWZEZiEmo0lZHI48xBorsFuL/F8C1fU=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -1216,8 +1218,6 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20251231144110-a68c3ac11c7a h1:XoJ3w2AFi7zniimALNK3idw9bzY9MwB/FM45TMgxYAY=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20251231144110-a68c3ac11c7a/go.mod h1:xum2HquWO5uExa/A7MQs3TgJJVEeoqTR+6Z4mfBr1Xw=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260107090044-56a45e5c560e h1:+qB6eWbzeSOh5i6Pc0sC9arG8r5f6GLZm722jDyQ6nI=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260107090044-56a45e5c560e/go.mod h1:U/1q7jEO0YGSAWZEZiEmo0lZHI48xBorsFuL/F8C1fU=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260106204841-744f3f71817b h1:gGGmYXuYvcNns1BnLQI13lC+pgMxrmenx+ramtolQuA=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260106204841-744f3f71817b/go.mod h1:+Hnaikp/xCSPD/q7txxRy4Zc0wzjW/usrCSf+6uONSQ=
 github.com/jfrog/jfrog-cli-evidence v0.8.3-0.20251225153025-9d8ac181d615 h1:y5an0bojHL00ipHP1QuBUrVcP+XK+yZHHOJ/r1I0RUM=

--- a/go.sum
+++ b/go.sum
@@ -729,8 +729,6 @@ github.com/beevik/etree v1.6.0 h1:u8Kwy8pp9D9XeITj2Z0XtA5qqZEmtJtuXZRQi+j03eE=
 github.com/beevik/etree v1.6.0/go.mod h1:bh4zJxiIr62SOf9pRzN7UUYaEDa9HEKafK25+sLc0Gc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bhanurp/jfrog-cli-artifactory v0.1.12-0.20260108075108-b5389ca4d380 h1:cj4idl/pC+WMSqj5jddYgrdFfaoWudzpjn0/Zt7ba8U=
-github.com/bhanurp/jfrog-cli-artifactory v0.1.12-0.20260108075108-b5389ca4d380/go.mod h1:U/1q7jEO0YGSAWZEZiEmo0lZHI48xBorsFuL/F8C1fU=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -1218,6 +1216,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20251231144110-a68c3ac11c7a h1:XoJ3w2AFi7zniimALNK3idw9bzY9MwB/FM45TMgxYAY=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20251231144110-a68c3ac11c7a/go.mod h1:xum2HquWO5uExa/A7MQs3TgJJVEeoqTR+6Z4mfBr1Xw=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260113000842-12090b43088f h1:pTUm8bp2vjjKCZI8hqJgIrwEc6veb9FU4hSd7ly7zBs=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260113000842-12090b43088f/go.mod h1:U/1q7jEO0YGSAWZEZiEmo0lZHI48xBorsFuL/F8C1fU=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260106204841-744f3f71817b h1:gGGmYXuYvcNns1BnLQI13lC+pgMxrmenx+ramtolQuA=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260106204841-744f3f71817b/go.mod h1:+Hnaikp/xCSPD/q7txxRy4Zc0wzjW/usrCSf+6uONSQ=
 github.com/jfrog/jfrog-cli-evidence v0.8.3-0.20251225153025-9d8ac181d615 h1:y5an0bojHL00ipHP1QuBUrVcP+XK+yZHHOJ/r1I0RUM=

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -347,6 +347,68 @@ func DeleteFilesByPathsUsingCli(serverDetails *config.ServerDetails, artifactory
 	return deleteCmd.DeleteFiles(reader)
 }
 
+// CreateUserWithPassword creates a new user with the specified password.
+func CreateUserWithPassword(serverDetails *config.ServerDetails, username, password string) error {
+	servicesManager, err := artUtils.CreateServiceManager(serverDetails, -1, 0, false)
+	if err != nil {
+		return err
+	}
+	adminFalse := false
+	userParams := services.NewUserParams()
+	userParams.UserDetails.Name = username
+	userParams.UserDetails.Email = username + "@test.com"
+	userParams.UserDetails.Password = password
+	userParams.UserDetails.Admin = &adminFalse
+	return servicesManager.CreateUser(userParams)
+}
+
+// DeleteUser deletes a user.
+func DeleteUser(serverDetails *config.ServerDetails, username string) error {
+	servicesManager, err := artUtils.CreateServiceManager(serverDetails, -1, 0, false)
+	if err != nil {
+		return err
+	}
+	return servicesManager.DeleteUser(username)
+}
+
+// CreatePermissionTarget creates a permission target giving the specified user permissions on the specified repo.
+func CreatePermissionTarget(serverDetails *config.ServerDetails, permName, repoKey, username string, actions []string) error {
+	servicesManager, err := artUtils.CreateServiceManager(serverDetails, -1, 0, false)
+	if err != nil {
+		return err
+	}
+	params := services.NewPermissionTargetParams()
+	params.Name = permName
+	params.Repo = &services.PermissionTargetSection{
+		Repositories: []string{repoKey},
+		Actions: &services.Actions{
+			Users: map[string][]string{
+				username: actions,
+			},
+		},
+	}
+	return servicesManager.CreatePermissionTarget(params)
+}
+
+// DeletePermissionTarget deletes a permission target.
+func DeletePermissionTarget(serverDetails *config.ServerDetails, permName string) error {
+	servicesManager, err := artUtils.CreateServiceManager(serverDetails, -1, 0, false)
+	if err != nil {
+		return err
+	}
+	return servicesManager.DeletePermissionTarget(permName)
+}
+
+// CreateServerDetailsWithCredentials creates a copy of server details with different credentials.
+func CreateServerDetailsWithCredentials(original *config.ServerDetails, username, password string) *config.ServerDetails {
+	newDetails := *original
+	newDetails.SetUser(username)
+	newDetails.SetPassword(password)
+	// Clear access token if using username/password
+	newDetails.SetAccessToken("")
+	return &newDetails
+}
+
 // This function makes no assertion, caller is responsible to assert as needed.
 func GetBuildInfo(serverDetails *config.ServerDetails, buildName, buildNumber string) (pbi *buildinfo.PublishedBuildInfo, found bool, err error) {
 	servicesManager, err := artUtils.CreateServiceManager(serverDetails, -1, 0, false)

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -34,7 +35,6 @@ import (
 	coreTests "github.com/jfrog/jfrog-cli-core/v2/utils/tests"
 	"github.com/jfrog/jfrog-cli/utils/summary"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
-	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	serviceutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 	"github.com/jfrog/jfrog-client-go/auth"
 	"github.com/jfrog/jfrog-client-go/http/jfroghttpclient"
@@ -275,13 +275,14 @@ func DeleteFileDirect(serverDetails *config.ServerDetails, artifactoryPath strin
 	}
 
 	// Check response status
-	if resp.StatusCode == 204 {
+	switch resp.StatusCode {
+	case http.StatusNoContent:
 		// Successfully deleted
 		return true, nil
-	} else if resp.StatusCode == 404 {
+	case http.StatusNotFound:
 		// File not found
 		return false, nil
-	} else {
+	default:
 		// Other error
 		return false, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
 	}
@@ -723,7 +724,7 @@ func CreateSpec(fileName string) (string, error) {
 	return searchFilePath, err
 }
 
-func ConvertSliceToMap(props []utils.Property) map[string][]string {
+func ConvertSliceToMap(props []serviceutils.Property) map[string][]string {
 	propsMap := make(map[string][]string)
 	for _, item := range props {
 		propsMap[item.Key] = append(propsMap[item.Key], item.Value)


### PR DESCRIPTION
…when errors occur

- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
## Description
This PR fixes a bug where DeleteCommand.Result().SuccessCount() and Result().FailCount() return 0 when 404 errors (or other errors) occur during deletion, even though some files may have been successfully deleted.

When using DeleteCommand and encountering errors (e.g., 404 errors when items are already deleted by another process), both SuccessCount() and FailCount() returned 0

## solution
Changed to capture the deletion error separately and return actual counts regardless of whether an error occurred.

## Depends On
https://github.com/jfrog/jfrog-cli-artifactory/pull/342