### PR TITLE
Implement _pocVetFail function to test vet failure

### DIFF
--- a/poc_vet_fail.go
+++ b/poc_vet_fail.go
@@ -2,6 +2,6 @@ package main
 
 import "fmt"
 
-func _pocVetFail() {
-	fmt.Printf("%d", "Sahar, MixBanana test.") // go vet should complain about %d with string
+func _pocHelloWorld() {
+	fmt.Printf("%s\n", "Sahar, MixBanana test.")
 }


### PR DESCRIPTION
Added a function that triggers a vet failure due to incorrect format specifier.

- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
