### PR TITLE
RTDEV-73424 - Set TestReleaseBundleCreationFromMultipleSourcesUsingSp…

### DIFF
--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -151,7 +151,6 @@ func TestReleaseBundleCreationFromMultipleBuildsAndBundlesUsingCommandFlags(t *t
 }
 
 func TestReleaseBundleCreationFromMultipleSourcesUsingSpec(t *testing.T) {
-	//t.Skip("JGC-412 - Skipping TestReleaseBundleCreationFromMultipleSourcesUsingSpec")
 
 	cleanCallback := initLifecycleTest(t, minMultiSourcesArtifactoryVersion)
 	defer cleanCallback()


### PR DESCRIPTION
…ec enabled

- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
