### PR TITLE
Added e2e tests for new release bundle finalize command

### DIFF
--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -752,17 +752,13 @@ func finalizeRbWithFlags(t *testing.T, rbName, rbVersion, project, signingKey st
 		rbName,
 		rbVersion,
 	}
-
 	if signingKey != "" {
 		argsAndOptions = append(argsAndOptions, getOption(cliutils.SigningKey, signingKey))
 	}
-
 	if project != "" {
 		argsAndOptions = append(argsAndOptions, getOption(cliutils.Project, project))
 	}
-
 	argsAndOptions = append(argsAndOptions, getOption(cliutils.Sync, strconv.FormatBool(sync)))
-
 	assert.NoError(t, lcCli.Exec(argsAndOptions...))
 }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
Added e2e tests for new release bundle finalize command