### PR TITLE
Updated dependency for Replace AQL to API for build download.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/jfrog/jfrog-cli-evidence v0.8.3-0.20260202100913-d9ee9476845a
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b0000e
 	github.com/jfrog/jfrog-cli-security v1.26.0
-	github.com/jfrog/jfrog-client-go v1.55.1-0.20260203140014-21fa138b604e
+	github.com/jfrog/jfrog-client-go v1.55.1-0.20260213090013-a6c661abbd76
 	github.com/jszwec/csvutil v1.10.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/viper v1.21.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/jfrog/jfrog-cli-evidence v0.8.3-0.20260202100913-d9ee9476845a
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b0000e
 	github.com/jfrog/jfrog-cli-security v1.26.0
-	github.com/jfrog/jfrog-client-go v1.55.1-0.20260216041508-65104b13c150
+	github.com/jfrog/jfrog-client-go v1.55.1-0.20260216113529-cd38beac1b98
 	github.com/jszwec/csvutil v1.10.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/viper v1.21.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/jfrog/jfrog-cli-evidence v0.8.3-0.20260202100913-d9ee9476845a
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b0000e
 	github.com/jfrog/jfrog-cli-security v1.26.0
-	github.com/jfrog/jfrog-client-go v1.55.1-0.20260216113529-cd38beac1b98
+	github.com/jfrog/jfrog-client-go v1.55.1-0.20260218080908-312e63d0c3fc
 	github.com/jszwec/csvutil v1.10.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/viper v1.21.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/jfrog/jfrog-cli-evidence v0.8.3-0.20260202100913-d9ee9476845a
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b0000e
 	github.com/jfrog/jfrog-cli-security v1.26.0
-	github.com/jfrog/jfrog-client-go v1.55.1-0.20260213090013-a6c661abbd76
+	github.com/jfrog/jfrog-client-go v1.55.1-0.20260216041508-65104b13c150
 	github.com/jszwec/csvutil v1.10.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/viper v1.21.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/jfrog/jfrog-cli-evidence v0.8.3-0.20260202100913-d9ee9476845a
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b0000e
 	github.com/jfrog/jfrog-cli-security v1.26.0
-	github.com/jfrog/jfrog-client-go v1.55.1-0.20260218080908-312e63d0c3fc
+	github.com/jfrog/jfrog-client-go v1.55.1-0.20260303161928-f893c4f18480
 	github.com/jszwec/csvutil v1.10.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/viper v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b000
 github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b0000e/go.mod h1:qbu4iqBST9x8LgD8HhzUm91iOB3vHqtoGmaxOnmw0ok=
 github.com/jfrog/jfrog-cli-security v1.26.0 h1:FcLshS1Ahm0++nV5q7UluFTCVRxH2wEIbqO7ZBag++I=
 github.com/jfrog/jfrog-cli-security v1.26.0/go.mod h1:r9E0BdlNy6mq6gkRGslZRZaYe6WeGhLkpUm8+oEUOvU=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260216113529-cd38beac1b98 h1:aAD3Sib7vRV9Bf79PzGHSNjPLQqwf8jZdFWbVbXJHfg=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260216113529-cd38beac1b98/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260218080908-312e63d0c3fc h1:VbRw6TseKBQCvNTFB7IQSI2pshimAPMRvjOaYCtJ/qE=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260218080908-312e63d0c3fc/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b000
 github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b0000e/go.mod h1:qbu4iqBST9x8LgD8HhzUm91iOB3vHqtoGmaxOnmw0ok=
 github.com/jfrog/jfrog-cli-security v1.26.0 h1:FcLshS1Ahm0++nV5q7UluFTCVRxH2wEIbqO7ZBag++I=
 github.com/jfrog/jfrog-cli-security v1.26.0/go.mod h1:r9E0BdlNy6mq6gkRGslZRZaYe6WeGhLkpUm8+oEUOvU=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260213090013-a6c661abbd76 h1:SL8+kyIqWOEvZU1gaKMbThJEbhBC/pGb/pqxtZmqgSY=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260213090013-a6c661abbd76/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260216041508-65104b13c150 h1:aTX1Ah9aDA2ks91lWlazrroKDJHOGZ+lRJYTiz9nvNs=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260216041508-65104b13c150/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b000
 github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b0000e/go.mod h1:qbu4iqBST9x8LgD8HhzUm91iOB3vHqtoGmaxOnmw0ok=
 github.com/jfrog/jfrog-cli-security v1.26.0 h1:FcLshS1Ahm0++nV5q7UluFTCVRxH2wEIbqO7ZBag++I=
 github.com/jfrog/jfrog-cli-security v1.26.0/go.mod h1:r9E0BdlNy6mq6gkRGslZRZaYe6WeGhLkpUm8+oEUOvU=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260216041508-65104b13c150 h1:aTX1Ah9aDA2ks91lWlazrroKDJHOGZ+lRJYTiz9nvNs=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260216041508-65104b13c150/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260216113529-cd38beac1b98 h1:aAD3Sib7vRV9Bf79PzGHSNjPLQqwf8jZdFWbVbXJHfg=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260216113529-cd38beac1b98/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b000
 github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b0000e/go.mod h1:qbu4iqBST9x8LgD8HhzUm91iOB3vHqtoGmaxOnmw0ok=
 github.com/jfrog/jfrog-cli-security v1.26.0 h1:FcLshS1Ahm0++nV5q7UluFTCVRxH2wEIbqO7ZBag++I=
 github.com/jfrog/jfrog-cli-security v1.26.0/go.mod h1:r9E0BdlNy6mq6gkRGslZRZaYe6WeGhLkpUm8+oEUOvU=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260203140014-21fa138b604e h1:BIQlRLDNcuZhoMctvktukmUFkeF2Uj2E1E/ucQMMKeg=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260203140014-21fa138b604e/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260213090013-a6c661abbd76 h1:SL8+kyIqWOEvZU1gaKMbThJEbhBC/pGb/pqxtZmqgSY=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260213090013-a6c661abbd76/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b000
 github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20251205121610-171eb9b0000e/go.mod h1:qbu4iqBST9x8LgD8HhzUm91iOB3vHqtoGmaxOnmw0ok=
 github.com/jfrog/jfrog-cli-security v1.26.0 h1:FcLshS1Ahm0++nV5q7UluFTCVRxH2wEIbqO7ZBag++I=
 github.com/jfrog/jfrog-cli-security v1.26.0/go.mod h1:r9E0BdlNy6mq6gkRGslZRZaYe6WeGhLkpUm8+oEUOvU=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260218080908-312e63d0c3fc h1:VbRw6TseKBQCvNTFB7IQSI2pshimAPMRvjOaYCtJ/qE=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260218080908-312e63d0c3fc/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260303161928-f893c4f18480 h1:G4dxmpH4zXr5eZpl5cfqaOsSxRM4A34e9jKzk+BidaI=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260303161928-f893c4f18480/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
# Fix Build Download Timeouts

## Problem
`jf rt dl --build` triggers AQL queries with expensive JOINs (`artifact.module.build.name`), causing **408 Request Timeout** on large builds.

## Solution
Replace JOIN-based AQL with the dedicated **Build Artifacts API** (`POST /api/builds/buildArtifacts`), which uses indexed lookups. Fall back to AQL when the API is unavailable or when sort/limit is needed.

## Flow

```
getBuildArtifactsForBuildSearch()
  │
  ├─ sort/limit specified? ──YES──► AQL (unchanged master logic)
  │
  └─ NO
      │
      ├─ Call Build Artifacts API ──OK──► minimal results (repo/path/name only)
      │                                     │
      │                                     ▼
      │                            filterBuildArtifactsAndDependencies()
      │                              peek first item → SHA1 missing?
      │                                     │
      │                                   YES → fetch metadata via property-based AQL
      │                                          (loadMissingProperties + updateProps)
      │                                     │
      │                                     ▼
      │                              merge, filter by SHA1, return
      │
      └─ API error ──► fall back to AQL (unchanged master logic)
```
## Related PR:
- **jfrog-client-go** - https://github.com/jfrog/jfrog-client-go/pull/1318
