### PR TITLE
JGC-448 - Add explicit GITHUB_TOKEN permissions to CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,12 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, synchronize]
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: write # this can be 'read' if the signatures are in remote repository
+  pull-requests: write
+  statuses: write
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds an explicit `permissions` block to the CLA workflow so the GITHUB_TOKEN has the required scopes when repository workflow permissions are set to read-only.

## Changes
- Added top-level `permissions` in `.github/workflows/cla.yml`:
  - `actions: write`
  - `contents: write`
  - `pull-requests: write`
  - `statuses: write`

Jira: JGC-448

Made with [Cursor](https://cursor.com)