### PR TITLE
JGC-449 - Suppress gosec high severity findings for CLI context

### DIFF
--- a/general/ai/cli.go
+++ b/general/ai/cli.go
@@ -164,7 +164,7 @@ func sendRestAPI(apiType ApiType, content interface{}) (response string, err err
 		req.Header.Set(askRateLimitHeader, "true")
 	}
 	log.Debug(fmt.Sprintf("Sending HTTP %s request to: %s", req.Method, req.URL))
-	resp, err := client.GetClient().Do(req)
+	resp, err := client.GetClient().Do(req) // #nosec G704 -- CLI tool; URL from user/config, runs in user environment
 	if err != nil {
 		err = errorutils.CheckErrorf("CLI-AI server is not available. Please check your network or try again later.")
 		return

--- a/general/summary/cli.go
+++ b/general/summary/cli.go
@@ -131,7 +131,7 @@ func saveFile(content, filePath string) (err error) {
 	if content == "" {
 		return nil
 	}
-	file, err := os.Create(filePath)
+	file, err := os.Create(filePath) // #nosec G703 -- CLI runs in user environment
 	if err != nil {
 		return err
 	}
@@ -146,11 +146,11 @@ func saveFile(content, filePath string) (err error) {
 
 func getSectionMarkdownContent(section MarkdownSection) (string, error) {
 	sectionFilepath := filepath.Join(os.Getenv(coreutils.SummaryOutputDirPathEnv), commandsummary.OutputDirName, string(section), markdownFileName)
-	if _, err := os.Stat(sectionFilepath); os.IsNotExist(err) {
+	if _, err := os.Stat(sectionFilepath); os.IsNotExist(err) { // #nosec G703 -- CLI runs in user environment
 		return "", nil
 	}
 
-	contentBytes, err := os.ReadFile(sectionFilepath)
+	contentBytes, err := os.ReadFile(sectionFilepath) // #nosec G703 -- CLI runs in user environment
 	if err != nil {
 		return "", fmt.Errorf("error reading markdown file for section %s: %w", section, err)
 	}
@@ -280,7 +280,7 @@ func processScan(index commandsummary.Index, filePath string, scannedName string
 // shouldGenerateUploadSummary checks if upload summary should be generated.
 func shouldGenerateUploadSummary() (bool, error) {
 	buildInfoPath := filepath.Join(os.Getenv(coreutils.SummaryOutputDirPathEnv), commandsummary.OutputDirName, string(BuildInfo))
-	if _, err := os.Stat(buildInfoPath); os.IsNotExist(err) {
+	if _, err := os.Stat(buildInfoPath); os.IsNotExist(err) { // #nosec G703 -- CLI runs in user environment
 		return true, nil
 	}
 	dirEntries, err := os.ReadDir(buildInfoPath)

--- a/utils/cliutils/utils.go
+++ b/utils/cliutils/utils.go
@@ -668,7 +668,7 @@ func getLatestCliVersionFromGithubAPI() (githubVersionInfo githubResponse, err e
 func doHttpRequest(client *http.Client, req *http.Request) (resp *http.Response, body []byte, err error) {
 	const maxResponseSize = 10 * 1024 * 1024 // 10MB limit
 	req.Close = true
-	resp, err = client.Do(req)
+	resp, err = client.Do(req) // #nosec G704 -- CLI tool; URL from user/config, runs in user environment
 	if errorutils.CheckError(err) != nil {
 		return
 	}

--- a/utils/tests/proxy/server/server.go
+++ b/utils/tests/proxy/server/server.go
@@ -28,7 +28,7 @@ func handleReverseProxyHttps(reverseProxy *httputil.ReverseProxy) httpResponse {
 		clilog.Info("URI:     ", req.RequestURI)
 		clilog.Info("Agent:   ", req.UserAgent())
 		clilog.Info("*********************************************************")
-		reverseProxy.ServeHTTP(rw, req)
+		reverseProxy.ServeHTTP(rw, req) // #nosec G704 -- CLI tool; URL from user, runs in user environment
 	}
 }
 
@@ -47,7 +47,7 @@ func getReverseProxyHandler(targetUrl string) (*httputil.ReverseProxy, error) {
 		req.URL.Scheme = target.Scheme
 	}
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 -- test proxy; cert verification disabled on purpose
 	}
 	proxyErrLogger := log.New(os.Stdout, "PROXY-LOGGER", log.Ldate|log.Ltime|log.Lshortfile)
 	p := &httputil.ReverseProxy{Director: d, Transport: tr, ErrorLog: proxyErrLogger}
@@ -122,7 +122,7 @@ func (t *testProxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.
 	} else {
 		host := request.URL.Host
 		request.Host = "https://" + request.Host
-		targetSiteCon, err := net.Dial("tcp", host)
+		targetSiteCon, err := net.Dial("tcp", host) // #nosec G704 -- CLI tool; URL from user, runs in user environment
 		if err != nil {
 			clilog.Error(err)
 			return

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -591,7 +591,7 @@ func AddTimestampToGlobalVars() {
 	UserName1 += uniqueSuffix
 	UserName2 += uniqueSuffix
 
-	randomSequence := rand.New(rand.NewSource(time.Now().Unix()))
+	randomSequence := rand.New(rand.NewSource(time.Now().Unix())) // #nosec G404 -- test-only, not used for security
 	Password1 += uniqueSuffix + strconv.FormatFloat(randomSequence.Float64(), 'f', 2, 32)
 	Password2 += uniqueSuffix + strconv.FormatFloat(randomSequence.Float64(), 'f', 2, 32)
 
@@ -693,13 +693,13 @@ func GetCmdOutput(t *testing.T, jfrogCli *coreTests.JfrogCli, cmd ...string) ([]
 		os.Stdout = oldStdout
 		os.Stderr = oldStdErr
 		assert.NoError(t, temp.Close())
-		assert.NoError(t, os.Remove(temp.Name()))
+		assert.NoError(t, os.Remove(temp.Name())) // #nosec G703 -- CLI runs in user environment
 	}()
 	err = jfrogCli.Exec(cmd...)
 	assert.NoError(t, err)
-	content, err := os.ReadFile(temp.Name())
+	content, err := os.ReadFile(temp.Name())     // #nosec G703 -- CLI runs in user environment
 	assert.NoError(t, err)
-	errContent, err := os.ReadFile(tempErr.Name())
+	errContent, err := os.ReadFile(tempErr.Name()) // #nosec G703 -- CLI runs in user environment
 	return content, errContent, err
 }
 


### PR DESCRIPTION
## Summary
Suppresses gosec **HIGH** severity findings that are acceptable for a CLI running in the user's environment.

## Changes
- **G404** (weak RNG): `#nosec` in `utils/tests/utils.go` — test-only.
- **G402** (TLS InsecureSkipVerify): `#nosec` in test proxy server — cert verification disabled on purpose.
- **G704** (SSRF): `#nosec` in 4 places — CLI; URL from user/config, runs in user environment.
- **G703** (path traversal): `#nosec` in 7 places — CLI runs in user environment.

All suppressions include a short justification comment. No HIGH severity issues remain.

Made with [Cursor](https://cursor.com)