### PR TITLE
feat: add server id to login command

### DIFF
--- a/general/login/cli.go
+++ b/general/login/cli.go
@@ -10,5 +10,5 @@ func LoginCmd(c *cli.Context) error {
 	if c.NArg() > 0 {
 		return cliutils.WrongNumberOfArgumentsHandler(c)
 	}
-	return coreLogin.NewLoginCommand().Run()
+	return coreLogin.NewLoginCommand().SetServerId(c.String("server-id")).Run()
 }

--- a/general/login/cli_test.go
+++ b/general/login/cli_test.go
@@ -1,0 +1,54 @@
+package login
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
+)
+
+func TestLoginCmdRejectsExtraArguments(t *testing.T) {
+	app := cli.NewApp()
+	app.Commands = []cli.Command{
+		{
+			Name:   "login",
+			Action: LoginCmd,
+		},
+	}
+	err := app.Run([]string{"jf", "login", "extra-arg"})
+	assert.Error(t, err)
+}
+
+func TestLoginCmdPassesServerIdFlag(t *testing.T) {
+	const testServerId = "my-test-server"
+	var capturedServerId string
+
+	app := cli.NewApp()
+	app.Commands = []cli.Command{
+		{
+			Name: "login",
+			Flags: []cli.Flag{
+				cli.StringFlag{Name: "server-id"},
+			},
+			Action: func(c *cli.Context) error {
+				capturedServerId = c.String("server-id")
+				// Return early without running the actual login command.
+				return nil
+			},
+		},
+	}
+	err := app.Run([]string{"jf", "login", "--server-id", testServerId})
+	assert.NoError(t, err)
+	assert.Equal(t, testServerId, capturedServerId)
+}
+
+func TestLoginCmdNoArgsCallsLoginWithEmptyServerId(t *testing.T) {
+	set := flag.NewFlagSet("test", 0)
+	set.String("server-id", "", "")
+	c := cli.NewContext(nil, set, nil)
+
+	// Verify that the context has no arguments and server-id is empty.
+	assert.Equal(t, 0, c.NArg())
+	assert.Equal(t, "", c.String("server-id"))
+}

--- a/main.go
+++ b/main.go
@@ -361,6 +361,7 @@ func getCommands() ([]cli.Command, error) {
 			Usage:        corecommon.ResolveDescription(loginDocs.GetDescription(), loginDocs.GetAIDescription()),
 			HelpName:     corecommon.CreateUsage("login", corecommon.ResolveDescription(loginDocs.GetDescription(), loginDocs.GetAIDescription()), loginDocs.Usage),
 			BashComplete: corecommon.CreateBashCompletionFunc(),
+			Flags:        cliutils.GetCommandFlags(cliutils.Login),
 			Category:     otherCategory,
 			Action:       login.LoginCmd,
 		},

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -146,6 +146,9 @@ const (
 	PluginInstall = "plugin-install"
 	PluginPublish = "plugin-publish"
 
+	// Login command key
+	Login = "login"
+
 	// *** Artifactory Commands' flags ***
 	// Base flags
 	url                 = "url"
@@ -2379,6 +2382,9 @@ var commandFlags = map[string][]string{
 	},
 	Setup: {
 		serverId, url, user, password, accessToken, sshPassphrase, sshKeyPath, ClientCertPath, ClientCertKeyPath, Project, setupRepo,
+	},
+	Login: {
+		serverId,
 	},
 }
 

--- a/utils/cliutils/utils_test.go
+++ b/utils/cliutils/utils_test.go
@@ -429,3 +429,14 @@ func TestSettingCIFlagRemovesSurvey(t *testing.T) {
 	shouldHide := ShouldHideSurveyLink()
 	assert.True(t, shouldHide, "Expected survey to be hidden when CI flag is set")
 }
+
+func TestLoginCommandFlagsIncludeServerId(t *testing.T) {
+	flags := GetCommandFlags(Login)
+	assert.NotEmpty(t, flags, "Expected login command to have flags")
+
+	var flagNames []string
+	for _, f := range flags {
+		flagNames = append(flagNames, f.GetName())
+	}
+	assert.Contains(t, flagNames, "server-id", "Expected login command flags to include 'server-id'")
+}


### PR DESCRIPTION
this allows scripting the login without the modal prompt

merge after https://github.com/jfrog/jfrog-cli-core/pull/1529

- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
