### PR TITLE
Make JFROG_RUN_NATIVE environment variable take precedence over maven.yaml config

### DIFF
--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/python"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/setup"
 	artutils "github.com/jfrog/jfrog-cli-artifactory/artifactory/utils"
+	buildinfoflexpack "github.com/jfrog/build-info-go/flexpack"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/ioutils"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
@@ -582,8 +583,12 @@ func MvnCmd(c *cli.Context) (err error) {
 		return err
 	}
 
-	// FlexPack bypasses all config file requirements (only when no config exists)
-	if artutils.ShouldRunNative(configFilePath) && !configExists {
+	// Check if FlexPack (native mode) is enabled via JFROG_RUN_NATIVE environment variable
+	// If enabled, use native Maven implementation regardless of config file presence
+	if buildinfoflexpack.IsFlexPackEnabled() {
+		if configExists {
+			log.Warn("Found maven.yaml config at " + configFilePath + " but JFROG_RUN_NATIVE=true is set - using native Maven mode")
+		}
 		log.Debug("Routing to Maven native implementation")
 		// Extract build configuration for FlexPack
 		args := cliutils.ExtractCommand(c)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
# Fix: Make JFROG_RUN_NATIVE environment variable take precedence over maven.yaml config

## Problem

When `JFROG_RUN_NATIVE=true` is set to enable native Maven mode (FlexPack), the JFrog CLI silently ignores this environment variable if a `maven.yaml` configuration file exists anywhere in:
- The project directory (`.jfrog/projects/maven.yaml`)
- Any parent directory (searched via `FindUpstream`)
- The home directory (`~/.jfrog/projects/maven.yaml`)

This causes:
1. Native Maven mode fails to activate despite explicit user intent
2. Snapshot artifacts are deployed **without timestamps** (using JFrog Build Extractor instead of native Maven)
3. Maven's deploy plugin is skipped with "Skipping artifact deployment" message
4. No warning or error is shown to the user about the environment variable being ignored

## Root Cause

The condition in `jfrog-cli/buildtools/cli.go` line 586 required BOTH conditions to be true:
```go
if artutils.ShouldRunNative(configFilePath) && !configExists {
```

This meant `JFROG_RUN_NATIVE=true` was only honored when NO config file existed, violating the principle that environment variables should override config files.

## Solution

Changed the logic to check `JFROG_RUN_NATIVE` directly and give it precedence over config files:

```go
if buildinfoflexpack.IsFlexPackEnabled() {
    if configExists {
        log.Warn("Found maven.yaml config at " + configFilePath + " but JFROG_RUN_NATIVE=true is set - using native Maven mode")
    }
    log.Debug("Routing to Maven native implementation")
    // ... proceed with native mode
}
```

## Changes Made

**File**: `jfrog-cli/buildtools/cli.go`

1. Added import: `buildinfoflexpack "github.com/jfrog/build-info-go/flexpack"`
2. Modified `MvnCmd()` function to check `buildinfoflexpack.IsFlexPackEnabled()` directly instead of requiring `!configExists`
3. Added warning message when config file is found but being overridden
