### PR TITLE
Bump jfrog-cli-evidence to v0.9.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jfrog/jfrog-cli-application v1.0.2-0.20260405065840-c930d515ef34
 	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260406055206-755b2b3eb84d
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260402104745-7a0bc2c11d63
-	github.com/jfrog/jfrog-cli-evidence v0.9.1
+	github.com/jfrog/jfrog-cli-evidence v0.9.2
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260306102152-984d60a80cec
 	github.com/jfrog/jfrog-cli-security v1.27.0
 	github.com/jfrog/jfrog-client-go v1.55.1-0.20260401130923-f5a15b584a0d

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260406055206-755b2b3eb84d h1:y
 github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260406055206-755b2b3eb84d/go.mod h1:KSJZO+tguFpGG4TE2Ut2rmOk1j03RrqHQ7E33FrsEt4=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260402104745-7a0bc2c11d63 h1:rvEiuETYgy7VbQFmf1QeYTcG0Sp4Lr+1QgrVQzLV58Q=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260402104745-7a0bc2c11d63/go.mod h1:RLLUO+oGDq88e5DPtP/KK2sVgMF32OuoRdVMxSFfb30=
-github.com/jfrog/jfrog-cli-evidence v0.9.1 h1:Epj2gwPv39qZrYfS2/N3AhCQ0ZG4t5C5ExHNgYlM4e4=
-github.com/jfrog/jfrog-cli-evidence v0.9.1/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
+github.com/jfrog/jfrog-cli-evidence v0.9.2 h1:huiBzQSI9z3OF3l2RphthdXl1aH9zBsvAt+zLsApORI=
+github.com/jfrog/jfrog-cli-evidence v0.9.2/go.mod h1:R9faPfyQESBmKrdZCmHvlpmYSHmffswjNnFeT3RMq8I=
 github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260306102152-984d60a80cec h1:d8CJ/LUGjNwPDPfYLJkAQJNmu+GCWxFsjZrmTcuV5wY=
 github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260306102152-984d60a80cec/go.mod h1:n18milUWaaWv6o0bWeEDuoweACoZHRTtQPZpyXBPjEs=
 github.com/jfrog/jfrog-cli-security v1.27.0 h1:0ol8T5xfgK5B2TUUjxeT8SbXqJxytLrHYpVsDs7Qg2Q=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
