### PR TITLE
JGC-448 - Add explicit GITHUB_TOKEN permissions to CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,14 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, synchronize]
+    branches:
+      - master
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: write # this can be 'read' if the signatures are in remote repository
+  pull-requests: write
+  statuses: write
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Aligns `jfrog-cli` CLA Assistant workflow with `jfrog-cli-core` (see [jfrog/jfrog-cli-core#1523](https://github.com/jfrog/jfrog-cli-core/pull/1523)). Tracks **JGC-448**.

## Problem
When workflow default `GITHUB_TOKEN` permissions are read-only at org/repo level, the contributor-assistant action cannot comment on PRs or set commit statuses, so the CLA check fails.

## Changes
- Declare explicit workflow `permissions` (`actions`, `contents`, `pull-requests`, `statuses`).
- Limit `pull_request_target` to PRs targeting `master`.

Supersedes #3427 (duplicate Jira ticket removed).