### PR TITLE
Feature/rteco 1003 external artifactory support

### DIFF
--- a/.github/actions/install-local-artifactory/action.yml
+++ b/.github/actions/install-local-artifactory/action.yml
@@ -1,0 +1,55 @@
+name: "Setup Local Artifactory"
+description: "Setup Local Artifactory or connect to an external JFrog Platform instance"
+inputs:
+  RTLIC:
+    description: "Local Artifactory License. Not required when JFROG_URL is provided."
+    required: false
+  JFROG_HOME:
+    description: "JFrog Home."
+    required: false
+  VERSION:
+    description: "Artifactory Version. Default is latest."
+    required: false
+  RT_SETUP_VERSION:
+    description: "Version of the local-rt-setup tool. Default is latest."
+    required: false
+    default: "1.3.9"
+  RT_CONNECTION_TIMEOUT_SECONDS:
+    description: "Connection timeout for the local Artifactory to be up."
+    required: false
+    default: "1200"
+  JFROG_URL:
+    description: "External JFrog Platform URL. If provided, skip local Artifactory install and use this instance instead."
+    required: false
+  JFROG_ADMIN_TOKEN:
+    description: "Admin token for external JFrog Platform. Required when JFROG_URL is set."
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Artifactory
+      run: |
+        if [ -n "${JFROG_URL}" ]; then
+          echo "Using external Artifactory at: ${JFROG_URL}"
+          echo "JFROG_TESTS_LOCAL_ACCESS_TOKEN=${JFROG_ADMIN_TOKEN}" >> $GITHUB_ENV
+          echo "JFROG_TESTS_URL=${JFROG_URL}" >> $GITHUB_ENV
+          echo "JFROG_TESTS_IS_EXTERNAL=true" >> $GITHUB_ENV
+        else
+          go install github.com/jfrog/jfrog-testing-infra/local-rt-setup@${RT_SETUP_VERSION}
+          if [ -n "${VERSION}" ]; then
+            ~/go/bin/local-rt-setup --rt-version "${VERSION}" --connection-timeout-seconds "${RT_CONNECTION_TIMEOUT_SECONDS}"
+          else
+            ~/go/bin/local-rt-setup --connection-timeout-seconds "${RT_CONNECTION_TIMEOUT_SECONDS}"
+          fi
+          echo "JFROG_TESTS_URL=http://127.0.0.1:8082" >> $GITHUB_ENV
+        fi
+      shell: bash
+      env:
+        RTLIC: ${{ inputs.RTLIC }}
+        JFROG_HOME: ${{ inputs.JFROG_HOME }}
+        VERSION: ${{ inputs.VERSION }}
+        RT_SETUP_VERSION: ${{ inputs.RT_SETUP_VERSION }}
+        RT_CONNECTION_TIMEOUT_SECONDS: ${{ inputs.RT_CONNECTION_TIMEOUT_SECONDS }}
+        JFROG_URL: ${{ inputs.JFROG_URL }}
+        JFROG_ADMIN_TOKEN: ${{ inputs.JFROG_ADMIN_TOKEN }}

--- a/.github/workflows/accessTests.yml
+++ b/.github/workflows/accessTests.yml
@@ -1,6 +1,17 @@
 name: Access Tests
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -75,6 +86,8 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Get ID Token and Exchange Token
@@ -87,4 +100,7 @@ jobs:
 
       - name: Run Access tests
         if: matrix.os.name != 'macos'
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.access --jfrog.url=http://127.0.0.1:8082 --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.access
+          --jfrog.url=${{ env.JFROG_TESTS_URL || 'http://127.0.0.1:8082' }}
+          --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}

--- a/.github/workflows/artifactoryTests.yml
+++ b/.github/workflows/artifactoryTests.yml
@@ -1,6 +1,17 @@
 name: Artifactory Tests
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -75,12 +86,20 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run Artifactory tests
         if: ${{ matrix.suite == 'artifactory' && matrix.os.name != 'macos' }}
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.artifactory --jfrog.url=http://127.0.0.1:8082 --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.artifactory
+          --jfrog.url=${{ env.JFROG_TESTS_URL || 'http://127.0.0.1:8082' }}
+          --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}
 
       - name: Run Artifactory projects tests
         if: ${{ matrix.suite == 'artifactoryProject' && matrix.os.name != 'macos' }}
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.artifactoryProject --ci.runId=${{ runner.os }}-${{ matrix.suite }}
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.artifactoryProject
+          --ci.runId=${{ runner.os }}-${{ matrix.suite }}
+          ${{ env.JFROG_TESTS_IS_EXTERNAL == 'true' && format('--jfrog.url={0} --jfrog.adminToken={1}', env.JFROG_TESTS_URL, env.JFROG_TESTS_LOCAL_ACCESS_TOKEN) || '' }}

--- a/.github/workflows/conanTests.yml
+++ b/.github/workflows/conanTests.yml
@@ -1,6 +1,17 @@
 name: Conan Tests
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -62,8 +73,12 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
 
       - name: Run Conan tests
         if: matrix.os.name != 'macos'
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.conan
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.conan
+          ${{ env.JFROG_TESTS_IS_EXTERNAL == 'true' && format('--jfrog.url={0} --jfrog.adminToken={1}', env.JFROG_TESTS_URL, env.JFROG_TESTS_LOCAL_ACCESS_TOKEN) || '' }}

--- a/.github/workflows/gradleTests.yml
+++ b/.github/workflows/gradleTests.yml
@@ -1,6 +1,17 @@
 name: Gradle Tests
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -88,8 +99,12 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run Gradle tests
         if: matrix.os.name != 'macos'
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.gradle
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.gradle
+          ${{ env.JFROG_TESTS_IS_EXTERNAL == 'true' && format('--jfrog.url={0} --jfrog.adminToken={1}', env.JFROG_TESTS_URL, env.JFROG_TESTS_LOCAL_ACCESS_TOKEN) || '' }}

--- a/.github/workflows/helmTests.yml
+++ b/.github/workflows/helmTests.yml
@@ -1,6 +1,17 @@
 name: Helm Tests
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -81,6 +92,8 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Get ID Token and Exchange Token
@@ -93,5 +106,8 @@ jobs:
 
       - name: Run Helm tests
         if: matrix.os.name != 'macos'
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.helm --jfrog.url=http://127.0.0.1:8082 --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.helm
+          --jfrog.url=${{ env.JFROG_TESTS_URL || 'http://127.0.0.1:8082' }}
+          --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}
 

--- a/.github/workflows/huggingfaceTests.yml
+++ b/.github/workflows/huggingfaceTests.yml
@@ -1,6 +1,17 @@
 name: HuggingFace Tests
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -86,6 +97,8 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Get ID Token and Exchange Token
@@ -98,5 +111,8 @@ jobs:
 
       - name: Run HuggingFace tests
         if: matrix.os.name != 'macos'
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.huggingface --jfrog.url=http://127.0.0.1:8082 --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.huggingface
+          --jfrog.url=${{ env.JFROG_TESTS_URL || 'http://127.0.0.1:8082' }}
+          --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}
 

--- a/.github/workflows/lifecycleTests.yml
+++ b/.github/workflows/lifecycleTests.yml
@@ -3,6 +3,17 @@ env:
   JFROG_CLI_LOG_LEVEL: DEBUG
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -74,8 +85,14 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run Lifecycle tests
         if: matrix.os.name != 'macos'
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.lifecycle --jfrog.url=http://127.0.0.1:8082 --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }} --ci.runId=${{ runner.os }}-lifecycle
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.lifecycle
+          --jfrog.url=${{ env.JFROG_TESTS_URL || 'http://127.0.0.1:8082' }}
+          --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}
+          --ci.runId=${{ runner.os }}-lifecycle

--- a/.github/workflows/mavenTests.yml
+++ b/.github/workflows/mavenTests.yml
@@ -1,6 +1,17 @@
 name: Maven Tests
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -79,8 +90,12 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run Maven tests
         if: matrix.os.name != 'macos'
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.maven
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.maven
+          ${{ env.JFROG_TESTS_IS_EXTERNAL == 'true' && format('--jfrog.url={0} --jfrog.adminToken={1}', env.JFROG_TESTS_URL, env.JFROG_TESTS_LOCAL_ACCESS_TOKEN) || '' }}

--- a/.github/workflows/npmTests.yml
+++ b/.github/workflows/npmTests.yml
@@ -1,6 +1,17 @@
 name: npm Tests
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -78,10 +89,14 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run npm tests
         if: matrix.os.name != 'macos'
         env:
           YARN_IGNORE_NODE: 1
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.npm
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.npm
+          ${{ env.JFROG_TESTS_IS_EXTERNAL == 'true' && format('--jfrog.url={0} --jfrog.adminToken={1}', env.JFROG_TESTS_URL, env.JFROG_TESTS_LOCAL_ACCESS_TOKEN) || '' }}

--- a/.github/workflows/nugetTests.yml
+++ b/.github/workflows/nugetTests.yml
@@ -2,6 +2,17 @@ name: NuGet Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -102,8 +113,12 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run NuGet tests
         if: matrix.os.name != 'macos'
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.nuget
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.nuget
+          ${{ env.JFROG_TESTS_IS_EXTERNAL == 'true' && format('--jfrog.url={0} --jfrog.adminToken={1}', env.JFROG_TESTS_URL, env.JFROG_TESTS_LOCAL_ACCESS_TOKEN) || '' }}

--- a/.github/workflows/pluginsTests.yml
+++ b/.github/workflows/pluginsTests.yml
@@ -1,6 +1,17 @@
 name: Plugins Tests
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -72,8 +83,12 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run plugins tests
         if: matrix.os.name != 'macos'
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.plugins
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.plugins
+          ${{ env.JFROG_TESTS_IS_EXTERNAL == 'true' && format('--jfrog.url={0} --jfrog.adminToken={1}', env.JFROG_TESTS_URL, env.JFROG_TESTS_LOCAL_ACCESS_TOKEN) || '' }}

--- a/.github/workflows/pnpmTests.yml
+++ b/.github/workflows/pnpmTests.yml
@@ -1,6 +1,17 @@
 name: pnpm Tests
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -80,10 +91,14 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run pnpm tests
         if: matrix.os.name != 'macos'
         env:
           YARN_IGNORE_NODE: 1
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.pnpm
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.pnpm
+          ${{ env.JFROG_TESTS_IS_EXTERNAL == 'true' && format('--jfrog.url={0} --jfrog.adminToken={1}', env.JFROG_TESTS_URL, env.JFROG_TESTS_LOCAL_ACCESS_TOKEN) || '' }}

--- a/.github/workflows/pythonTests.yml
+++ b/.github/workflows/pythonTests.yml
@@ -1,6 +1,17 @@
 name: Python Tests
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -88,8 +99,12 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run Python tests
         if: matrix.os.name != 'macos'
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.${{ matrix.suite }}
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.${{ matrix.suite }}
+          ${{ env.JFROG_TESTS_IS_EXTERNAL == 'true' && format('--jfrog.url={0} --jfrog.adminToken={1}', env.JFROG_TESTS_URL, env.JFROG_TESTS_LOCAL_ACCESS_TOKEN) || '' }}

--- a/.github/workflows/transferTests.yml
+++ b/.github/workflows/transferTests.yml
@@ -1,6 +1,17 @@
 name: Transfer Tests
 on:
   workflow_dispatch:
+    inputs:
+      jfrog_url:
+        description: "External JFrog Platform URL. Leave empty for local Artifactory."
+        type: string
+        required: false
+        default: ""
+      jfrog_admin_token:
+        description: "Admin token for external JFrog Platform."
+        type: string
+        required: false
+        default: ""
   push:
     branches:
       - "master"
@@ -71,12 +82,21 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           JFROG_HOME: ${{ runner.temp }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run transfer tests
         if: matrix.os.name != 'macos'
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.transfer --test.installDataTransferPlugin --jfrog.url=http://127.0.0.1:8082 --jfrog.targetUrl=${{ secrets.PLATFORM_URL }} --jfrog.targetAdminToken=${{ secrets.PLATFORM_ADMIN_TOKEN }} --jfrog.home=${{ runner.temp }} --ci.runId=${{ runner.os }}-transfer-7
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.transfer --test.installDataTransferPlugin
+          --jfrog.url=${{ env.JFROG_TESTS_URL || 'http://127.0.0.1:8082' }}
+          --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}
+          --jfrog.targetUrl=${{ secrets.PLATFORM_URL }}
+          --jfrog.targetAdminToken=${{ secrets.PLATFORM_ADMIN_TOKEN }}
+          --jfrog.home=${{ runner.temp }}
+          --ci.runId=${{ runner.os }}-transfer-7
 
   Transfer-Artifactory-6-Tests:
     name: artifactory-6
@@ -115,9 +135,17 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC_V6 }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           JFROG_HOME: ${{ runner.temp }}
           VERSION: 6.23.21
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run transfer tests
-        run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.transfer --test.installDataTransferPlugin --jfrog.targetUrl=${{ secrets.PLATFORM_URL }} --jfrog.targetAdminToken=${{ secrets.PLATFORM_ADMIN_TOKEN }} --jfrog.home=${{ runner.temp }} --ci.runId=${{ runner.os }}-transfer-6
+        run: >-
+          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.transfer --test.installDataTransferPlugin
+          --jfrog.targetUrl=${{ secrets.PLATFORM_URL }}
+          --jfrog.targetAdminToken=${{ secrets.PLATFORM_ADMIN_TOKEN }}
+          --jfrog.home=${{ runner.temp }}
+          --ci.runId=${{ runner.os }}-transfer-6
+          ${{ env.JFROG_TESTS_IS_EXTERNAL == 'true' && format('--jfrog.url={0} --jfrog.adminToken={1}', env.JFROG_TESTS_URL, env.JFROG_TESTS_LOCAL_ACCESS_TOKEN) || '' }}

--- a/test-suites.json
+++ b/test-suites.json
@@ -1,0 +1,19 @@
+[
+  { "suite": "artifactory", "node": true },
+  { "suite": "artifactoryProject", "node": true },
+  { "suite": "access", "node": true, "skip_tests": "TestRefreshableAccessTokens|TestAccessTokenCreate" },
+  { "suite": "npm", "node": true, "npm_auth": true },
+  { "suite": "pnpm", "node": true, "pnpm": true },
+  { "suite": "maven", "java": "17", "maven": true },
+  { "suite": "gradle", "java": "11", "gradle": "8.3" },
+  { "suite": "conan", "python": true, "conan": true },
+  { "suite": "pip", "python": true, "twine": true },
+  { "suite": "pipenv", "python": true, "pipenv": true },
+  { "suite": "nuget", "dotnet": true },
+  { "suite": "helm", "helm": true },
+  { "suite": "plugins", "node": true },
+  { "suite": "lifecycle", "node": true, "skip_tests": "TestImportReleaseBundle" },
+  { "suite": "huggingface", "python": true, "huggingface": true },
+  { "suite": "distribution", "node": true, "extra_flags": "--jfrog.user=admin" },
+  { "suite": "go", "node": true }
+]


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
---
**Composite Action: install-local-artifactory/action.yml**
What: Added two new optional inputs (JFROG_URL, JFROG_ADMIN_TOKEN) to the composite action. When JFROG_URL is provided, the action skips the local Artifactory installation entirely and instead exports three environment variables: JFROG_TESTS_LOCAL_ACCESS_TOKEN, JFROG_TESTS_URL, and JFROG_TESTS_IS_EXTERNAL. When JFROG_URL is empty (default), the existing local-rt-setup logic runs unchanged and JFROG_TESTS_URL is set to http://127.0.0.1:8082.

Why: Today, every test workflow installs a fresh local Artifactory instance via local-rt-setup. This works for open-source CI on github.com but blocks us from running the same tests against a pipeline-provisioned draft Artifactory instance (for validating pre-release builds). By making the Artifactory source configurable, we can reuse the exact same workflows for both local and external instances without duplicating workflow files.

**workflow_dispatch Inputs (all 14 workflow files)**
What: Added jfrog_url and jfrog_admin_token as optional workflow_dispatch inputs with empty string defaults to all 14 test workflows.

Why: These inputs allow an external caller (JFrog Pipelines, GHE dispatch, or manual trigger) to pass in an external Artifactory URL and admin token. When triggered by push or pull_request_target, these inputs are empty and the workflow behaves identically to before — zero impact on existing CI.

**Pattern A Workflows: Replace Hardcoded URL (6 workflows)**
Files: artifactoryTests.yml, accessTests.yml, helmTests.yml, huggingfaceTests.yml, lifecycleTests.yml, transferTests.yml (Transfer-7 job)

What: Replaced the hardcoded --jfrog.url=http://127.0.0.1:8082 with --jfrog.url=${{ env.JFROG_TESTS_URL || 'http://127.0.0.1:8082' }} in the go test commands.

Why: These workflows had the local Artifactory address baked into the test command. By reading from the JFROG_TESTS_URL environment variable (set by the composite action), the same go test command works for both local and external Artifactory. The || 'http://127.0.0.1:8082' fallback ensures backward compatibility even if the composite action hasn't been updated yet.

**Pattern B Workflows: Add Conditional Flags (8 workflows + 2 special cases)**
Files: npmTests.yml, mavenTests.yml, gradleTests.yml, conanTests.yml, pnpmTests.yml, nugetTests.yml, pythonTests.yml, pluginsTests.yml, plus artifactoryTests.yml (artifactoryProject step) and transferTests.yml (Transfer-6 job)

What: Added a conditional expression that appends --jfrog.url and --jfrog.adminToken flags only when JFROG_TESTS_IS_EXTERNAL == 'true':

${{ env.JFROG_TESTS_IS_EXTERNAL == 'true' && format('--jfrog.url={0} --jfrog.adminToken={1}', env.JFROG_TESTS_URL, env.JFROG_TESTS_LOCAL_ACCESS_TOKEN) || '' }}
Why: These workflows never passed --jfrog.url or --jfrog.adminToken — they relied on Go flag defaults (http://localhost:8081/) and the GetLocalArtifactoryTokenIfNeeded() function, which reads the token from the JFROG_TESTS_LOCAL_ACCESS_TOKEN env var only if the URL contains localhost:808. For an external Artifactory, those defaults don't work. However, unconditionally adding the flags would change the URL from port 8081 to 8082 for local installs, which could introduce subtle differences. The conditional approach preserves exact existing behavior for local installs (no flags appended, original defaults used) while adding the required flags only for external instances.

**Transfer-7: Added Explicit --jfrog.adminToken**
What: Added --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }} to the Transfer-7 go test command (previously absent).

Why: Transfer-7 previously relied on the Go flag default mechanism to pick up the token — it passed --jfrog.url=http://127.0.0.1:8082 but not --jfrog.adminToken. The token default works because at flag registration time, the default URL is localhost:8081 (which matches GetLocalArtifactoryTokenIfNeeded). With an external URL, this implicit token resolution breaks. Making it explicit is backward-compatible (same env var value) and necessary for external instances.