### PR TITLE
RTECO-1052 -  Fix docker performance

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -266,15 +266,17 @@ func TestContainerPushWithMultipleSlash(t *testing.T) {
 	}
 }
 
-// TestContainerEnforceImageIdVerification re-runs the existing container
-// push, pull, and build+push flows with JFROG_CLI_ENFORCE_DOCKER_IMAGE_ID_VERIFICATION=true
-// to exercise the legacy strict path (local `daemon.Image` image id lookup).
-// The default / fast path is already covered by the same underlying tests,
-// which run without the env var set.
-func TestContainerEnforceImageIdVerification(t *testing.T) {
+// TestContainerSkipImageIdVerification re-runs the existing container
+// push, pull, and buildx (which is also a push) flows with
+// JFROG_CLI_SKIP_DOCKER_IMAGE_ID_VERIFICATION=true to prove build-info is
+// still collected correctly when users opt into the skip escape hatch. The
+// default path (verify, with WithFileBufferedOpener) is already covered by
+// the same underlying tests running without the env var. Pull must ignore
+// the skip env and always verify — this test also guards that contract.
+func TestContainerSkipImageIdVerification(t *testing.T) {
 	initContainerTest(t)
-	clientTestUtils.SetEnvAndAssert(t, container.EnforceDockerImageIdVerificationEnv, "true")
-	defer clientTestUtils.UnSetEnvAndAssert(t, container.EnforceDockerImageIdVerificationEnv)
+	clientTestUtils.SetEnvAndAssert(t, container.SkipDockerImageIdVerificationEnv, "true")
+	defer clientTestUtils.UnSetEnvAndAssert(t, container.SkipDockerImageIdVerificationEnv)
 
 	t.Run("push", TestContainerPush)
 	t.Run("pull", TestContainerPull)

--- a/docker_test.go
+++ b/docker_test.go
@@ -266,6 +266,21 @@ func TestContainerPushWithMultipleSlash(t *testing.T) {
 	}
 }
 
+// TestContainerEnforceImageIdVerification re-runs the existing container
+// push, pull, and build+push flows with JFROG_CLI_ENFORCE_DOCKER_IMAGE_ID_VERIFICATION=true
+// to exercise the legacy strict path (local `daemon.Image` image id lookup).
+// The default / fast path is already covered by the same underlying tests,
+// which run without the env var set.
+func TestContainerEnforceImageIdVerification(t *testing.T) {
+	initContainerTest(t)
+	clientTestUtils.SetEnvAndAssert(t, container.EnforceDockerImageIdVerificationEnv, "true")
+	defer clientTestUtils.UnSetEnvAndAssert(t, container.EnforceDockerImageIdVerificationEnv)
+
+	t.Run("push", TestContainerPush)
+	t.Run("pull", TestContainerPull)
+	t.Run("buildx", TestDockerBuildxWithBuildInfo)
+}
+
 func runPushTest(containerManager container.ContainerManagerType, imageName, module string, withModule bool, t *testing.T, repo string) {
 	imageTag, err := inttestutils.BuildTestImage(imageName+":1", "", repo, containerManager)
 	assert.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -248,7 +248,7 @@ require (
 
 //replace github.com/ktrysmt/go-bitbucket => github.com/ktrysmt/go-bitbucket v0.9.80
 
-// replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260331093138-48a54e89a292
+replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260420120548-31e79ff2eabf
 
 //replace github.com/jfrog/build-info-go => github.com/fluxxBot/build-info-go v1.10.10-0.20260105070825-d3f36f619ba5
 

--- a/go.mod
+++ b/go.mod
@@ -248,7 +248,7 @@ require (
 
 //replace github.com/ktrysmt/go-bitbucket => github.com/ktrysmt/go-bitbucket v0.9.80
 
-replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260420123726-c507833dacd0
+replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260421082647-2c85c5bbdaab
 
 //replace github.com/jfrog/build-info-go => github.com/fluxxBot/build-info-go v1.10.10-0.20260105070825-d3f36f619ba5
 

--- a/go.mod
+++ b/go.mod
@@ -248,7 +248,7 @@ require (
 
 //replace github.com/ktrysmt/go-bitbucket => github.com/ktrysmt/go-bitbucket v0.9.80
 
-replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260420120548-31e79ff2eabf
+replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260420123726-c507833dacd0
 
 //replace github.com/jfrog/build-info-go => github.com/fluxxBot/build-info-go v1.10.10-0.20260105070825-d3f36f619ba5
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/jfrog/build-info-go v1.13.1-0.20260331040230-c3b53d1a24ac
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-application v1.0.2-0.20260405065840-c930d515ef34
-	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260416104146-471c3f71ce61
+	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260421101844-c42ed5f491fa
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260417224747-1bea4a117b59
 	github.com/jfrog/jfrog-cli-evidence v0.9.2
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260415140604-583ae2ada347
@@ -248,7 +248,7 @@ require (
 
 //replace github.com/ktrysmt/go-bitbucket => github.com/ktrysmt/go-bitbucket v0.9.80
 
-replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260421082647-2c85c5bbdaab
+// replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260421082647-2c85c5bbdaab
 
 //replace github.com/jfrog/build-info-go => github.com/fluxxBot/build-info-go v1.10.10-0.20260105070825-d3f36f619ba5
 

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260405065840-c930d515ef34 h1:qD53oDmaw7+5HjaU7FupqbB55saabNzMoMtu3kJfmg4=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260405065840-c930d515ef34/go.mod h1:xum2HquWO5uExa/A7MQs3TgJJVEeoqTR+6Z4mfBr1Xw=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260420120548-31e79ff2eabf h1:xr0bTFrqA3de6DZ9h7YbC/3pB3EjuFcUOSjDnv5CJk8=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260420120548-31e79ff2eabf/go.mod h1:u2yb7nO6VLxXwHKoICnxd8NEY4OclCk9YAi2n/Sbpn8=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260420123726-c507833dacd0 h1:9CVsZkmhFPfo5lj+MTfrSXLTNtmjBAlCKuhZg7CDcTQ=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260420123726-c507833dacd0/go.mod h1:u2yb7nO6VLxXwHKoICnxd8NEY4OclCk9YAi2n/Sbpn8=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260417224747-1bea4a117b59 h1:8FhaIKTTE3sERmW4oNtiMP5F3mCSDju3BKLOVsiZ6GA=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260417224747-1bea4a117b59/go.mod h1:qpD7einonjqskDTEyqeG3NzAbZO6se0s0Pet0ObBQ3I=
 github.com/jfrog/jfrog-cli-evidence v0.9.2 h1:huiBzQSI9z3OF3l2RphthdXl1aH9zBsvAt+zLsApORI=

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260405065840-c930d515ef34 h1:qD53oDmaw7+5HjaU7FupqbB55saabNzMoMtu3kJfmg4=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260405065840-c930d515ef34/go.mod h1:xum2HquWO5uExa/A7MQs3TgJJVEeoqTR+6Z4mfBr1Xw=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260421082647-2c85c5bbdaab h1:tSF3FlNkbmNRqz5eiZ8w7exocTezWsBb3i56gZnwsdE=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260421082647-2c85c5bbdaab/go.mod h1:u2yb7nO6VLxXwHKoICnxd8NEY4OclCk9YAi2n/Sbpn8=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260421101844-c42ed5f491fa h1:TYcV+5qmFF1x8+jNpklseXQnKc4K5xh6XminwFhZbTo=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260421101844-c42ed5f491fa/go.mod h1:6QJFQvde/CLnFeIIFOvm/6QuQr8OT1QWiTJAkQ+1Mnc=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260417224747-1bea4a117b59 h1:8FhaIKTTE3sERmW4oNtiMP5F3mCSDju3BKLOVsiZ6GA=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260417224747-1bea4a117b59/go.mod h1:qpD7einonjqskDTEyqeG3NzAbZO6se0s0Pet0ObBQ3I=
 github.com/jfrog/jfrog-cli-evidence v0.9.2 h1:huiBzQSI9z3OF3l2RphthdXl1aH9zBsvAt+zLsApORI=

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260405065840-c930d515ef34 h1:qD53oDmaw7+5HjaU7FupqbB55saabNzMoMtu3kJfmg4=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260405065840-c930d515ef34/go.mod h1:xum2HquWO5uExa/A7MQs3TgJJVEeoqTR+6Z4mfBr1Xw=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260416104146-471c3f71ce61 h1:cES0xZ9ABOY/f3nq+3ETiVPgzjs7tEpHFzstc8h3W2U=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260416104146-471c3f71ce61/go.mod h1:6QJFQvde/CLnFeIIFOvm/6QuQr8OT1QWiTJAkQ+1Mnc=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260420120548-31e79ff2eabf h1:xr0bTFrqA3de6DZ9h7YbC/3pB3EjuFcUOSjDnv5CJk8=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260420120548-31e79ff2eabf/go.mod h1:u2yb7nO6VLxXwHKoICnxd8NEY4OclCk9YAi2n/Sbpn8=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260417224747-1bea4a117b59 h1:8FhaIKTTE3sERmW4oNtiMP5F3mCSDju3BKLOVsiZ6GA=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260417224747-1bea4a117b59/go.mod h1:qpD7einonjqskDTEyqeG3NzAbZO6se0s0Pet0ObBQ3I=
 github.com/jfrog/jfrog-cli-evidence v0.9.2 h1:huiBzQSI9z3OF3l2RphthdXl1aH9zBsvAt+zLsApORI=

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260405065840-c930d515ef34 h1:qD53oDmaw7+5HjaU7FupqbB55saabNzMoMtu3kJfmg4=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260405065840-c930d515ef34/go.mod h1:xum2HquWO5uExa/A7MQs3TgJJVEeoqTR+6Z4mfBr1Xw=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260420123726-c507833dacd0 h1:9CVsZkmhFPfo5lj+MTfrSXLTNtmjBAlCKuhZg7CDcTQ=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260420123726-c507833dacd0/go.mod h1:u2yb7nO6VLxXwHKoICnxd8NEY4OclCk9YAi2n/Sbpn8=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260421082647-2c85c5bbdaab h1:tSF3FlNkbmNRqz5eiZ8w7exocTezWsBb3i56gZnwsdE=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260421082647-2c85c5bbdaab/go.mod h1:u2yb7nO6VLxXwHKoICnxd8NEY4OclCk9YAi2n/Sbpn8=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260417224747-1bea4a117b59 h1:8FhaIKTTE3sERmW4oNtiMP5F3mCSDju3BKLOVsiZ6GA=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260417224747-1bea4a117b59/go.mod h1:qpD7einonjqskDTEyqeG3NzAbZO6se0s0Pet0ObBQ3I=
 github.com/jfrog/jfrog-cli-evidence v0.9.2 h1:huiBzQSI9z3OF3l2RphthdXl1aH9zBsvAt+zLsApORI=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---


RTECO-1052 — Docker image id verification: fix OOM, make slow path opt-out
PR #410 introduced daemon.WithUnbufferedOpener() in containerManager.Id() to stop the Docker push flow from OOMing on large images — daemon.Image(ref) buffers the entire docker save tarball in memory. That change fixed the OOM but caused a second regression: on Docker 29 (which most customers now run) and on resource-constrained agents, the unbuffered opener stalls the push for 5+ minutes on multi-GB images. During that stall the jf docker push appears hung, sitting between the Pushed line from the Docker daemon and the subsequent Setting properties... build-info step.

The root cause is daemon.Image(...).Manifest() invoking a full docker save over the whole image just to read the config digest. On Docker 29 the docker images --format {{.ID}} fallback cannot be used because it now reports the manifest digest, not the config digest, so we can't cheaply substitute it.

What this PR does
Two changes, both scoped to the Docker-client path inside containerManager.Id():

Replace WithUnbufferedOpener with WithFileBufferedOpener — spools the docker save stream to a temp file instead of RAM, permanently removing the OOM risk without needing any flag. Memory usage stays bounded regardless of image size.
Add a Push-only opt-in to skip the local id lookup entirely via a new env var JFROG_CLI_SKIP_DOCKER_IMAGE_ID_VERIFICATION. When set to a truthy value on a docker push, Id() short-circuits and returns an empty string; the build-info builder then adopts the Artifactory-side manifest's Config.Digest for layer lookups, bypassing docker save completely. Pull and all other flows ignore the flag and always verify.
Default behavior is unchanged: we still verify the local id, just with file-backed buffering instead of in-memory buffering.


Depends on:
1. https://github.com/jfrog/jfrog-cli-artifactory/pull/428