### PR TITLE
RTECO-1003 - Updated branch name for jfrog-cli

### DIFF
--- a/.jfrog-pipelines/pipelines.yml
+++ b/.jfrog-pipelines/pipelines.yml
@@ -5,7 +5,7 @@ resources:
       path: jfrog/jfrog-cli
       gitProvider: jfrog_cli_gh
       branches:
-        include: jfrogpipelines
+        include: master
   - name: cli_coreapps_env_details
     type: PropertyBag
     configuration:
@@ -60,7 +60,7 @@ pipelines:
             description: "org/repo passed to Actions as jfrog_cli_repository"
             allowCustom: true
           JFROG_CLI_GITHUB_REF:
-            default: "jfrogpipelines"
+            default: "master"
             description: "Git ref to checkout in jfrog/jfrog-cli (branch, tag, or SHA)."
             allowCustom: true
           GITHUB_DISPATCH_TOKEN:


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
---
What: Updated branch name for jfrog-cli