### PR TITLE
RTECO-1017 - Enrich User-Agent with agent/CI context and reuse Cursor…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-application v1.0.2-0.20260511133105-55a0ab56fd64
 	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260515045427-eb0cec44a4e2
-	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260515092054-cca97077293d
+	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260519061857-676e48fbefcd
 	github.com/jfrog/jfrog-cli-evidence v0.9.4
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260430094150-ce7d9b371c6f
 	github.com/jfrog/jfrog-cli-security v1.29.0
@@ -252,7 +252,7 @@ require (
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.13.1-0.20260428071432-1e9d9a1991ad
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/agrasth/jfrog-cli-core/v2 v2.0.0-20260428093456-2bc01db3b153
+// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260518123155-036d9195c4e9
 
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.54.2-0.20251007084958-5eeaa42c31a6
 

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/jfrog/jfrog-cli-application v1.0.2-0.20260511133105-55a0ab56fd64 h1:b
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260511133105-55a0ab56fd64/go.mod h1:cKqb/JgN+XuD4RhOxvSZnyGyXw3cJsTZfQT3rk9MCho=
 github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260515045427-eb0cec44a4e2 h1:1nCyNPDxH2EXUz0zx2bFBViYrW/KoqGcQDH9Jm8HHs8=
 github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260515045427-eb0cec44a4e2/go.mod h1:XESHQN9MEeje13fJaXtbljidwTqlJO+qhhUHHDxwntQ=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260515092054-cca97077293d h1:6IRzTppsSWOMIRVXmFVlnOHi0QLs5+4Mfd3sHATsRTw=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260515092054-cca97077293d/go.mod h1:bh1ptuSLGZT4l51hl+xgUlS7sAd8K77tKn0wa5n7TQo=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260519061857-676e48fbefcd h1:R7wPNFOAFfPDb8ZQPw3hJcbaPIGsi325fZaLoWwGTGg=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260519061857-676e48fbefcd/go.mod h1:bh1ptuSLGZT4l51hl+xgUlS7sAd8K77tKn0wa5n7TQo=
 github.com/jfrog/jfrog-cli-evidence v0.9.4 h1:RAqZYaH2RrzmhW+bGA7dx/yTqa4X1fZ4/5V7VVMSJtc=
 github.com/jfrog/jfrog-cli-evidence v0.9.4/go.mod h1:nLSLqLIhQz1Hi2n+KjHZTyK1mcmPLevv41LjItLswmE=
 github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260430094150-ce7d9b371c6f h1:M1cesbKYSznwPA76dNctjCELxGx34TSSjwoYnJm9/6Y=

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	appTrustCLI "github.com/jfrog/jfrog-cli-application/cli"
 	artifactoryCLI "github.com/jfrog/jfrog-cli-artifactory/cli"
 	corecommon "github.com/jfrog/jfrog-cli-core/v2/docs/common"
+	corecommands "github.com/jfrog/jfrog-cli-core/v2/common/commands"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	coreconfig "github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
@@ -163,13 +164,19 @@ func displaySurveyLinkIfNeeded() {
 	fmt.Fprintln(os.Stderr, "\n💬 Help us improve JFrog CLI! \033]8;;https://www.surveymonkey.com/r/JFCLICLI\033\\https://www.surveymonkey.com/r/JFCLICLI\033]8;;\033\\")
 }
 
-// This command generates and sets an Uber Trace ID token which will be attached as a header to every request.
+// This command sets an Uber Trace ID token which will be attached as a header to every request.
+// If the parent agent (e.g. Cursor) propagates a trace ID via env, reuse it so server-side logs
+// correlate end-to-end with the agent's trace. Otherwise generate a fresh one.
 // This allows users to easily identify which logs on the server side are related to the command executed by the CLI.
 func setUberTraceIdToken() error {
-	var err error
-	traceID, err = generateTraceIdToken()
-	if err != nil {
-		return err
+	if propagated := corecommands.DetectExecutionContext().TraceID; propagated != "" {
+		traceID = propagated
+	} else {
+		generated, err := generateTraceIdToken()
+		if err != nil {
+			return err
+		}
+		traceID = generated
 	}
 	httpclient.SetUberTraceIdToken(traceID)
 	clientlog.Debug(traceIdLogMsg, traceID)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---

## Summary
Wires the invocation-context detection from [jfrog-cli-core PR #1555](https://github.com/jfrog/jfrog-cli-core/pull/1555) into `jf`:
- Appends agent + CI info to the `User-Agent` header sent to Artifactory.
- Reuses `CURSOR_TRACE_ID` (when invoked from Cursor) as the Uber Trace ID instead of generating a fresh one, so server-side logs correlate end-to-end with the agent's trace.

## Motivation
[RTECO-1017](https://jfrog-int.atlassian.net/browse/RTECO-1017): differentiate human / CI / agent invocations of `jf`. Surface agent identity in every API call so support and observability can attribute traffic correctly without parsing metric payloads separately.

## Changes
- **`main.go`**:
  - `setUberTraceIdToken` reuses `ExecutionContext.TraceID` (currently `CURSOR_TRACE_ID`) when present; falls back to the existing 16-char hex generator otherwise.
  - `clientutils.SetUserAgent` now calls `corecommands.EnrichUserAgent(base)` which appends `(agent; ci=<system>)` to the base CLI User-Agent. Returns base unchanged when neither agent nor CI is detected.
- **`go.mod`** — points at the published pre-release of jfrog-cli-core that contains the detection logic. Must be bumped to the final tagged version once core PR #1555 merges.

## Examples
| Context | User-Agent |
|---|---|
| Plain shell | `jfrog-cli-go/2.103.0` |
| Claude Code | `jfrog-cli-go/2.103.0 (claude)` |
| Cursor | `jfrog-cli-go/2.103.0 (cursor)` |
| Cursor in GitHub Actions | `jfrog-cli-go/2.103.0 (cursor; ci=github_actions)` |
| GitHub Actions, no agent | `jfrog-cli-go/2.103.0 (ci=github_actions)` |

## Trace-ID propagation
`CURSOR_TRACE_ID` is reused when the detected agent is `cursor`. For all other agents, a fresh 16-char hex trace ID is generated as before. Gated on agent identity — prevents stale values leaked from an outer shell being used when a different agent is the real invoker.

## Memoization (sync.Once in core)
`DetectExecutionContext()` is called from two places in `main.go` — `EnrichUserAgent` and `setUberTraceIdToken`. Both return the same cached snapshot (memoized via `sync.Once` in core on first call). No divergence possible even if env mutates between calls.


[RTECO-1017]: https://jfrog-int.atlassian.net/browse/RTECO-1017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Depends on:
1. https://github.com/jfrog/jfrog-cli-core/pull/1555