### PR TITLE
RTECO-1003 - Fix teardown_env: use resource property syntax for SERVER_NAME

### DIFF
--- a/.jfrog-pipelines/pipelines.yml
+++ b/.jfrog-pipelines/pipelines.yml
@@ -103,6 +103,8 @@ pipelines:
               echo "Environment URL: ${env_url}"
               
               # Write to resource
+              prefix="${server_name%${suffix}}"
+              write_output "cli_coreapps_env_details" "prefix=${prefix}"
               write_output "cli_coreapps_env_details" "suffix=${suffix}"
               write_output "cli_coreapps_env_details" "env_url=${env_url}"
               
@@ -132,7 +134,7 @@ pipelines:
                 - success
           jenkinsJobName: tools/platform/environment_setup_gen2
           buildParameters:
-            SERVER_NAME: "cli${res_cli_coreapps_env_details_suffix}"
+            SERVER_NAME: "${res_cli_coreapps_env_details_prefix}${res_cli_coreapps_env_details_suffix}"
             DEPLOYMENT_TYPE: onprem
             ACCOUNT_TYPE: "enterprise_plus"
             GROUP: "ARTIFACTORY"
@@ -555,9 +557,11 @@ pipelines:
                 - skipped
                 - unstable
                 - timeout
+          inputResources:
+            - name: cli_coreapps_env_details
           integrations:
             - name: jenkins_entplus_rt
           jenkinsJobName: tools/platform/environment_operate
           buildParameters:
-            SERVER_NAME: "${server_name}"
+            SERVER_NAME: "${res_cli_coreapps_env_details_prefix}${res_cli_coreapps_env_details_suffix}"
             ACTION: "delete"

--- a/docker_test.go
+++ b/docker_test.go
@@ -467,26 +467,14 @@ CMD ["echo", "Hello from nested path"]`, baseImage)
 	// Publish build info
 	runJfrogCli(t, "rt", "build-publish", buildName, buildNumber)
 
-	// Validate the published build-info exists. This already exercises the build-name /
-	// build-number property attachment end-to-end (the build-info publish would not
-	// produce non-empty modules if property attachment had silently failed).
+	// Validate the published build-info exists
 	publishedBuildInfo, found, err := tests.GetBuildInfo(serverDetails, buildName, buildNumber)
 	assert.NoError(t, err)
 	assert.True(t, found, "build info was expected to be found")
 	assert.True(t, len(publishedBuildInfo.BuildInfo.Modules) >= 1, "Expected at least 1 module in build info")
 
-	// Validate image layers were physically pushed to the nested path. Use a
-	// pattern-only search and deliberately omit .Build(buildName): jfrog-client-go's
-	// SearchBySpecWithBuild path peeks at the artifacts reader (NextRecord) and then
-	// calls Reset() on it while the producer goroutine is still alive (see
-	// filterBuildArtifactsAndDependencies). When a follow-up reader operation spawns a
-	// second producer goroutine, both write to the same channel and one closes it from
-	// under the other. The race is invisible against remote JFrog Cloud (network
-	// latency hides it) but reliably panics with "send on closed channel" against
-	// localhost Artifactory tenants. Since the property attachment is covered by the
-	// build-info assertion above, validating physical placement at the nested path is
-	// sufficient here.
-	searchSpec := spec.NewBuilder().Pattern(tests.OciLocalRepo + "/" + nestedPath + "/*").Recursive(true).BuildSpec()
+	// Validate build-name & build-number properties in all image layers at nested path
+	searchSpec := spec.NewBuilder().Pattern(tests.OciLocalRepo + "/" + nestedPath + "/*").Build(buildName).Recursive(true).BuildSpec()
 	searchCmd := generic.NewSearchCommand()
 	searchCmd.SetServerDetails(serverDetails).SetSpec(searchSpec)
 	reader, err := searchCmd.Search()


### PR DESCRIPTION
${server_name}` pipeline variable is not resolved in Jenkins step buildParameters (only available in bash execution blocks). Use `cli${res_cli_coreapps_env_details_suffix}` — the same pattern already used in `deploy_environment` — so Jenkins receives a non-empty SERVER_NAME and the environment_operate job no longer fails with "ACTION and SERVER_NAME are mandatory parameters".

- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
---
