### PR TITLE
RTECO-1003 - added default token for github entrprise

### DIFF
--- a/.jfrog-pipelines/pipelines.yml
+++ b/.jfrog-pipelines/pipelines.yml
@@ -20,6 +20,7 @@ pipelines:
     configuration:
       integrations:
         - name: jfrog_cli_tests
+        - name: github_dispatch
       environmentVariables:
         readOnly:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"

--- a/.jfrog-pipelines/pipelines.yml
+++ b/.jfrog-pipelines/pipelines.yml
@@ -64,7 +64,7 @@ pipelines:
             description: "Git ref to checkout in jfrog/jfrog-cli (branch, tag, or SHA)."
             allowCustom: true
           GITHUB_DISPATCH_TOKEN:
-            default: ""
+            default: "${int_github_dispatch_token}"
             description: "Token for github.jfrog.info API (repo + workflow scopes). MUST be a fine-grained PAT, a GitHub App installation token, or an OAuth App token — the JFROG org on github.jfrog.info forbids classic PATs and will return 403 with message 'forbids access via a personal access token (classic)'. If left empty, int_jfrog_cli_gh_token from the jfrog_cli_gh integration is used, and that integration itself must be configured with a fine-grained PAT (classic PATs will be rejected the same way)."
             allowCustom: true
           GHE_ACTIONS_RUNNER:


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
---
added default token for github entrprise