### PR TITLE
JGC-486 - Bump Go toolchain to 1.26.3

### DIFF
--- a/.github/workflows/prepareDarwinBinariesForRelease.yml
+++ b/.github/workflows/prepareDarwinBinariesForRelease.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.7
+          go-version: 1.26.3
           cache: false
 
       - name: Checkout Source

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ node("docker-ubuntu20-xlarge") {
     repo = 'jfrog-cli'
     sh 'rm -rf temp'
     sh 'mkdir temp'
-    def goRoot = tool 'go-1.25.7'
+    def goRoot = tool 'go-1.26.3'
     env.GOROOT="$goRoot"
     env.PATH+=":${goRoot}/bin:/tmp/node-${nodeVersion}-linux-x64/bin"
     env.GO111MODULE="on"

--- a/build/docker/slim/Dockerfile
+++ b/build/docker/slim/Dockerfile
@@ -1,6 +1,6 @@
 ARG repo_name_21
 # Remove ${repo_name_21} to pull from Docker Hub.
-FROM ${repo_name_21}/jfrog-docker/golang:1.25.7-alpine as builder
+FROM ${repo_name_21}/jfrog-docker/golang:1.26.3-alpine as builder
 ARG image_name=jfrog-cli
 ARG cli_executable_name
 WORKDIR /${image_name}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jfrog/jfrog-cli
 
-go 1.25.7
+go 1.26.3
 
 replace (
 	// Should not be updated to 0.2.6 due to a bug (https://github.com/jfrog/jfrog-cli-core/pull/372)

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,6 @@ github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0omw=
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/ehl-jf/jfrog-cli-artifactory v0.0.0-20260504114357-eced4616bc48 h1:NrhkA4lRmatkmsdlweEgW300kAyvzUEW6LcRcobrAU4=
-github.com/ehl-jf/jfrog-cli-artifactory v0.0.0-20260504114357-eced4616bc48/go.mod h1:A3sgUG+62BBtF7CLSbjwEfCJLC5ATL/rF8AxVHsuJDQ=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
@@ -430,8 +428,6 @@ github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260430094150-ce7d9b371c
 github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260430094150-ce7d9b371c6f/go.mod h1:JUdq/dQoNscpta62FDCAcaSVbvcCOr5VkH8UeGTG1HQ=
 github.com/jfrog/jfrog-cli-security v1.28.0 h1:A/xxwbnjCfQOGT8LqtjYsPXmGg2kpcjlABw2DMFgId8=
 github.com/jfrog/jfrog-cli-security v1.28.0/go.mod h1:+eO5IgCkfiz0/8fCf6UwBg1KWXoDbOQ/E2V8DR9Ziq8=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260428070955-750b933dc5c7 h1:MvHnFczVntYB/USj7/RRANvdWbTUcwEvXcIGr7lOyTc=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260428070955-750b933dc5c7/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260508101905-a17af78a38d7 h1:o8fk4yWLqNMldarXyh/4NbmdbYbuM+lKYobdJK7shqM=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260508101905-a17af78a38d7/go.mod h1:sCE06+GngPoyrGO0c+vmhgMoVSP83UMNiZnIuNPzU8U=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=


### PR DESCRIPTION
## Summary

Aligns the JFrog CLI repository with the latest stable Go release (**1.26.3**, 2026-05-07 per Go release history).

## Changes

- `go.mod`: `go` directive **1.25.7 → 1.26.3**
- **Jenkinsfile**: Go tool **go-1.25.7 → go-1.26.3** (ensure this tool is installed on Jenkins agents)
- **prepareDarwinBinariesForRelease** workflow: `go-version` **1.26.3**
- **build/docker/slim/Dockerfile**: builder image **golang:1.26.3-alpine** (confirm image exists in the internal registry)

`go mod tidy` was run with Go 1.26.3 (minor `go.sum` cleanup).

## Tracking

**JGC-486**

Made with [Cursor](https://cursor.com)