### PR TITLE
RTECO-992 - Fix uv build command build-info and update jfrog-cli-artifactory dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/jfrog/build-info-go v1.13.1-0.20260429070557-93b98034d295
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-application v1.0.2-0.20260405065840-c930d515ef34
-	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260512080921-ec417dc1b7ee
+	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260514080218-aef923f46e93
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260430125911-ad12ac6f1316
 	github.com/jfrog/jfrog-cli-evidence v0.9.2
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260430094150-ce7d9b371c6f

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260405065840-c930d515ef34 h1:qD53oDmaw7+5HjaU7FupqbB55saabNzMoMtu3kJfmg4=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260405065840-c930d515ef34/go.mod h1:xum2HquWO5uExa/A7MQs3TgJJVEeoqTR+6Z4mfBr1Xw=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260512080921-ec417dc1b7ee h1:yPU08HBAYJJdVsgvdSrn1EUUHq9bhfRDTmMafaizEvA=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260512080921-ec417dc1b7ee/go.mod h1:kmU0BbU1hX5peleJ17QLNc0Y1NNBEGEH8MAd1qYDzb8=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260514080218-aef923f46e93 h1:5SjZGAsV0MDk5H8DK+7yBmbahdakfblRe0CW8Kp9vvk=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260514080218-aef923f46e93/go.mod h1:XESHQN9MEeje13fJaXtbljidwTqlJO+qhhUHHDxwntQ=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260430125911-ad12ac6f1316 h1:xAl5D+SjLeRH1gCsSHFPpXJeQQBv2HDGqDTDkFOKJ2s=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260430125911-ad12ac6f1316/go.mod h1:bjAkVD8c2W+jg4whqy10bSXDC/c+Se8/ll/GPp5F/+0=
 github.com/jfrog/jfrog-cli-evidence v0.9.2 h1:huiBzQSI9z3OF3l2RphthdXl1aH9zBsvAt+zLsApORI=

--- a/uv_test.go
+++ b/uv_test.go
@@ -381,6 +381,7 @@ func TestUvModuleTypeIsUv(t *testing.T) {
 
 // TestUvArtifactTypeIsExtension verifies artifact types are "wheel" (for .whl)
 // or "sdist" (for .tar.gz), as returned by getArtifactTypeFromName.
+// Artifacts are only recorded after publish (nothing is uploaded to Artifactory by build).
 func TestUvArtifactTypeIsExtension(t *testing.T) {
 	initUvTest(t)
 	defer cleanUvTest(t)
@@ -388,7 +389,8 @@ func TestUvArtifactTypeIsExtension(t *testing.T) {
 	projectPath := createUvProject(t, "uv-art-type", "uvproject")
 	buildNumber := "1"
 
-	assert.NoError(t, runUvCmd(t, projectPath, "build",
+	assert.NoError(t, runUvCmd(t, projectPath, "build"))
+	assert.NoError(t, runUvCmd(t, projectPath, "publish",
 		"--build-name="+tests.UvBuildName,
 		"--build-number="+buildNumber))
 	require.NoError(t, artifactoryCli.Exec("bp", tests.UvBuildName, buildNumber))
@@ -399,7 +401,6 @@ func TestUvArtifactTypeIsExtension(t *testing.T) {
 	require.NotEmpty(t, publishedBuildInfo.BuildInfo.Modules)
 
 	for _, a := range publishedBuildInfo.BuildInfo.Modules[0].Artifacts {
-		// getArtifactTypeFromName returns "wheel" for .whl files, "sdist" for .tar.gz files
 		assert.True(t, a.Type == "wheel" || a.Type == "sdist",
 			"artifact type %q should be 'wheel' (for .whl) or 'sdist' (for .tar.gz)", a.Type)
 	}


### PR DESCRIPTION
## Problem

Three UV tests were failing after jfrog-cli-artifactory PR #438 was merged:

- `TestUvBuild` — `"[]" should have 1 item(s), but has 0` (no module in build-info)
- `TestUvArtifactTypeIsExtension` — `Should NOT be empty, but was []`
- `TestUvCustomModule` — `Should NOT be empty, but was []`

PR #438 skipped build-info entirely for `jf uv build`, but the tests expected at least a module to exist.

## Fix

### jfrog-cli-artifactory (PR #449)
Restored build-info collection for `jf uv build` following Maven's convention for non-deploy goals:
- Module and dependencies are recorded
- Artifacts are cleared (nothing is uploaded to Artifactory by `uv build`)

### uv_test.go
`TestUvArtifactTypeIsExtension` was checking artifact types from `jf uv build` — but since `build` no longer records artifacts (consistent with `TestUvBuild`'s existing assertion), the test is updated to verify artifact types via `jf uv publish` instead.

## Changes
- `go.mod` / `go.sum`: updated `jfrog-cli-artifactory` to pick up the fix
- `uv_test.go`: `TestUvArtifactTypeIsExtension` now runs `build` then `publish` before checking artifact types