### PR TITLE
JGC-490 - Skip Chocolatey publish when version already exists

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -556,7 +556,17 @@ def publishChocoPackage(version, jfrogCliRepoDir, architecture) {
                 cp $jfrogCliRepoDir/${cliExecutableName}.exe $jfrogCliRepoDir/build/chocolatey/$identifier/tools
                 cp $jfrogCliRepoDir/LICENSE $jfrogCliRepoDir/build/chocolatey/$identifier/tools
                 docker run -v \$PWD:/work -w /work $architecture.chocoImage choco pack version=$version
-                docker run -v \$PWD:/work -w /work $architecture.chocoImage choco push --source='https://push.chocolatey.org/' --apiKey \$CHOCO_API_KEY ${packageName}.${version}.nupkg
+                output=\$(docker run -v \$PWD:/work -w /work $architecture.chocoImage choco push --source='https://push.chocolatey.org/' --apiKey \$CHOCO_API_KEY ${packageName}.${version}.nupkg 2>&1)
+                exit_code=\$?
+                echo "\$output"
+                if [[ \$exit_code -ne 0 ]]; then
+                    if echo "\$output" | grep -qi "already exists"; then
+                        echo "Choco package publish skipped - $packageName $version already exists"
+                        exit 0
+                    else
+                        exit \$exit_code
+                    fi
+                fi
             """
         }
     }


### PR DESCRIPTION
Treat the "already exists" response from `choco push` as success so the v2-jf phase doesn't re-fail on rerun and the outer retry loop only kicks in for genuine transient failures. Mirrors the existing npm/rbc guards.

- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
