### PR TITLE
RTECO-1263 - Fixed Content Reader race panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/jfrog/jfrog-cli-evidence v0.9.4
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260430094150-ce7d9b371c6f
 	github.com/jfrog/jfrog-cli-security v1.29.0
-	github.com/jfrog/jfrog-client-go v1.55.1-0.20260518073856-78c118beaa69
+	github.com/jfrog/jfrog-client-go v1.55.1-0.20260521115926-32f082854b39
 	github.com/jszwec/csvutil v1.10.0
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -428,8 +428,8 @@ github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260430094150-ce7d9b371c
 github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260430094150-ce7d9b371c6f/go.mod h1:JUdq/dQoNscpta62FDCAcaSVbvcCOr5VkH8UeGTG1HQ=
 github.com/jfrog/jfrog-cli-security v1.29.0 h1:TN2OCA5i/iPbikQWzSwVqGvySvIvw1P6rPga+DbVBOI=
 github.com/jfrog/jfrog-cli-security v1.29.0/go.mod h1:q38TPlxortIJvbyD3u9P9UhHwyx007tEb9WbXlXw2E0=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260518073856-78c118beaa69 h1:ARMrNOd2lp3LjjnH7h1xzaHarrutEUrH4VUF84R/dJE=
-github.com/jfrog/jfrog-client-go v1.55.1-0.20260518073856-78c118beaa69/go.mod h1:k3PqoFpS6XDt9/4xg3pS8J8JUvxtaz1w2vdTdodknGk=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260521115926-32f082854b39 h1:cXWtxiTOWFha3yBWh6FDxr0qCNVd0Q40rB/rB+bU3eY=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260521115926-32f082854b39/go.mod h1:k3PqoFpS6XDt9/4xg3pS8J8JUvxtaz1w2vdTdodknGk=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---


## Summary                                                                                                                                                                           
                                                                                                                                                                                     
  Fixes `panic: send on closed channel` in `ContentReader` triggered intermittently by concurrent use of `NextRecord` and `Reset` (or by callers that invoke `Reset` internally, e.g.  
  `Length`, `SortContentReader`).
                                                                                                                                                                                       
  Resolves [RTECO-1263](https://jfrog-int.atlassian.net/browse/RTECO-1263).                                                                                                            
                                      
  ## Background                                                                                                                                                                        
                                                                                                                                                                                     
  `ContentReader.NextRecord` spawns a producer goroutine once (via `sync.Once`) that streams JSON array elements from one or more files into `cr.dataChannel`. The receiver in         
  `NextRecord` and the producer in `readSingleFile` both read `cr.dataChannel` from the struct field on each access.
                                                                                                                                                                                       
  `Reset()` replaces both `cr.dataChannel` and `cr.once` without any synchronization. This created three independent race conditions that together produce the panic:                  
                                      
  1. **Producer / Reset race** — a producer goroutine paused between sends (between files, or while blocked on a full buffer) could resume after `Reset()` had swapped the channel     
  field. The producer's next send would land on the new channel, which could already have been closed by the next cycle's `defer close`.                                             
  2. **Receiver / Reset race** — `NextRecord` could fire `once.Do` against the old `once`, then read `cr.dataChannel` *after* `Reset()` had swapped both fields, causing the receiver  
  and producer to operate on different channels (deadlock).                                                                                                                            
  3. **Defer / send mismatch** — `defer close(cr.dataChannel)` evaluates the channel argument at defer-registration time, but `cr.dataChannel <- item` re-reads the field on every
  send. The defer and the send could refer to two different channels.                                                                                                                  
                                                                                                                                                                                     
  The race is timing-dependent; it surfaces in CI under load (e.g. `TestPushFatManifestImageWithNestedPath` in the docker test suite) but is hard to reproduce locally without `-race` 
  and concurrent stress.                                                                                                                                                             
                                                                                                                                                                                       
  Stack trace from the failing CI run:                                                                                                                                               
                                      
  panic: send on closed channel
  goroutine 2699 [running]:
  github.com/jfrog/jfrog-client-go/utils/io/content.(*ContentReader).readSingleFile
      .../utils/io/content/contentreader.go:216 +0x492
  github.com/jfrog/jfrog-client-go/utils/io/content.(*ContentReader).run(...)
      .../utils/io/content/contentreader.go:178
  github.com/jfrog/jfrog-client-go/utils/io/content.(*ContentReader).NextRecord.func1.1()
      .../utils/io/content/contentreader.go:78 +0x7a

[RTECO-1263]: https://jfrog-int.atlassian.net/browse/RTECO-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ