### PR TITLE
Make jf uv command publicly available

### DIFF
--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -369,7 +369,6 @@ func GetCommands() []cli.Command {
 			BashComplete:    corecommon.CreateBashCompletionFunc(),
 			Category:        buildToolsCategory,
 			Action:          UvCmd,
-			Hidden:          true,
 		},
 		{
 			Name:            "helm",


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
Expose uv command by removing Hidden flag