### PR TITLE
fix(jenkins): install unzip in Audit stage for Advanced Security Scans

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,6 +126,10 @@ def runRelease(architectures) {
             stage("Audit") {
                 dir("$jfrogCliRepoDir") {
                     sh """#!/bin/bash
+                        set -e
+                        if ! command -v unzip >/dev/null 2>&1 && ! command -v 7z >/dev/null 2>&1; then
+                            apt-get update && apt-get install -y unzip
+                        fi
                         ../$builderPath audit --fail=false
                     """
                 }


### PR DESCRIPTION
## Description

The `Audit` stage in the release `Jenkinsfile` fails with:

> could not find any of the required executables ('unzip', '7z') in the system PATH to run the Advanced Security Scans

The `docker-ubuntu20-xlarge` agent does not ship with `unzip` or `7z`, which the JAS scanners require to unpack their analyzer bundles.

This change installs `unzip` on demand inside the Audit stage (only when neither `unzip` nor `7z` is already present), right before invoking `jf audit`. The install is guarded so re-runs and future image upgrades are no-ops.

---

- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---