### PR TITLE
RTECO-1352 - Fix jf setup docker login when using --url

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -1573,3 +1573,71 @@ CMD ["echo", "Hello from CI VCS test"]`, baseImage)
 	}
 	assert.Greater(t, artifactCount, 0, "No artifacts in build info")
 }
+
+// TestSetupDockerCommand verifies `jf setup docker --url ...` end-to-end.
+//
+// Guards RTECO-1352: configureContainer (in jfrog-cli-artifactory) used to read
+// ServerDetails.GetUrl(), which createServerDetailsFromFlags clears for the Rt
+// command domain after copying it into ArtifactoryUrl. On the --url invocation
+// path that left the registry host empty and routed `docker login ""` to Docker
+// Hub, producing a misleading 401. The corresponding fix in jfrog-cli-artifactory
+// derives the host from GetArtifactoryUrl() (with GetUrl() fallback for the
+// --server-id path) and asserts a non-empty host.
+//
+// This e2e test exercises the *exact* failure path — `--url` + `--access-token`
+// flags with no saved config — and verifies that the docker config file ends up
+// with an auth entry keyed by the Artifactory registry hostname.
+func TestSetupDockerCommand(t *testing.T) {
+	if !*tests.TestDocker {
+		t.Skip("Skipping setup docker test. To run it, add the '-test.docker=true' option.")
+	}
+
+	// Isolate the docker config to a temp dir so the test never touches the
+	// developer's ~/.docker/config.json. The docker CLI honors DOCKER_CONFIG
+	// as the config-file directory.
+	dockerConfigDir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dockerConfigDir)
+
+	// Build credentials from the test globals. The --url path is what the bug
+	// hit, so pass it explicitly along with --access-token (or --user/--password)
+	// rather than relying on a saved server config.
+	artifactoryUrl := *tests.JfrogUrl + tests.ArtifactoryEndpoint
+	user := *tests.JfrogUser
+	credFlag := ""
+	switch {
+	case *tests.JfrogAccessToken != "":
+		credFlag = "--access-token=" + *tests.JfrogAccessToken
+		if user == "" {
+			user = auth.ExtractUsernameFromAccessToken(*tests.JfrogAccessToken)
+		}
+	case *tests.JfrogPassword != "":
+		credFlag = "--password=" + *tests.JfrogPassword
+	default:
+		t.Skip("Skipping setup docker test: no JFrog credentials available.")
+	}
+
+	jfrogCli := coreTests.NewJfrogCli(execMain, "jfrog", "")
+	require.NoError(t, jfrogCli.Exec(
+		"setup", "docker",
+		"--url="+artifactoryUrl,
+		"--user="+user,
+		credFlag,
+		"--repo="+tests.DockerVirtualRepo,
+	))
+
+	// Derive the expected registry host the same way the fix does: take the
+	// host component of the Artifactory URL.
+	parsedUrl, err := url.Parse(artifactoryUrl)
+	require.NoError(t, err)
+	expectedRegistryHost := parsedUrl.Host
+	require.NotEmpty(t, expectedRegistryHost, "Artifactory URL must have a host")
+
+	// Verify the docker config file was updated with an auth entry for the
+	// derived registry host. Before the fix the entry would have been keyed by
+	// an empty string (and the underlying `docker login` would have failed).
+	dockerConfigPath := filepath.Join(dockerConfigDir, "config.json")
+	contentBytes, err := os.ReadFile(dockerConfigPath)
+	require.NoError(t, err, "docker config file should be created by setup docker")
+	assert.Contains(t, string(contentBytes), expectedRegistryHost,
+		"docker config should contain the Artifactory registry host derived from --url")
+}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jfrog/build-info-go v1.13.1-0.20260528065004-80409c046540
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-application v1.0.2-0.20260511133105-55a0ab56fd64
-	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260601110159-16e27949b870
+	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260603064046-17ea3d82e8c7
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260601130310-8d52a530da18
 	github.com/jfrog/jfrog-cli-evidence v0.9.5-0.20260528121456-17c6218af996
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260430094150-ce7d9b371c6f

--- a/go.sum
+++ b/go.sum
@@ -412,8 +412,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260511133105-55a0ab56fd64 h1:bxcy1v1LXQV4T0kVU1duWQr3h7vKfHyMD1B+IuFLWUw=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260511133105-55a0ab56fd64/go.mod h1:cKqb/JgN+XuD4RhOxvSZnyGyXw3cJsTZfQT3rk9MCho=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260601110159-16e27949b870 h1:oRICL3VxTToKN7DqufQyOkU2HXBoTQg3F405qfulFHs=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260601110159-16e27949b870/go.mod h1:GQEGVW3wT1XPykXNsEiPQrF8/+01JvDVcGGYb5vqJuE=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260603064046-17ea3d82e8c7 h1:/nMrTVuY7nCivCbzj+4d66NXQDqef4GCUanDF3voaOA=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260603064046-17ea3d82e8c7/go.mod h1:GQEGVW3wT1XPykXNsEiPQrF8/+01JvDVcGGYb5vqJuE=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260601130310-8d52a530da18 h1:tPv7XscDFAZaijVwMQNb+HmuucUMYQdjuA5frdGzhF0=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260601130310-8d52a530da18/go.mod h1:9R90mhbczGXwW5EGlDs7F08ejQU/xdoDhYHMvzBiqgE=
 github.com/jfrog/jfrog-cli-evidence v0.9.5-0.20260528121456-17c6218af996 h1:jFldEXM8i2G+iQDRMQZ1ZaEMF0H+D2mgG7gTVgQcbZg=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli-core#tests) passed.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-core/actions/workflows/analysis.yml) passed locally (`gofmt`, `go vet`).
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.

-----

## Summary

Companion to jfrog/jfrog-cli-artifactory#460 — adds an end-to-end test that exercises `jf setup docker --url=...`, the exact failure path of **RTECO-1352**. Pins `jfrog-cli-artifactory` to the matching fix branch via `go.mod` replace so CI runs the test against the fixed code.

## What's tested

- `jf setup docker` with `--url` + `--user` + `--access-token` + `--repo` flags (no saved server config).
- Asserts the docker config file ends up with an auth entry keyed by the Artifactory registry host derived from `--url`.

Before the fix the command resolved to Docker Hub and returned a 401. After the fix it correctly authenticates against the JFrog registry.

## go.mod replace

Pinned to `github.com/Edenb2131/jfrog-cli-artifactory@RTECO-1352-fix-setup-docker-empty-registry`. **Remove the replace directive before merge** once jfrog/jfrog-cli-artifactory#460 lands and a release pins the version naturally.

Depends on:
1. jfrog-cli-artifactory - https://github.com/jfrog/jfrog-cli-artifactory/pull/460