### PR TITLE
fix(jenkins): bump audit agent to ubuntu24 for SAST glibc 2.34

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ properties([
     ])
 ])
 
-node("docker-ubuntu20-xlarge") {
+node("docker-ubuntu24-xlarge") {
     cleanWs()
     // Subtract repo name from the repo url (https://REPO_NAME/ -> REPO_NAME/)
     withCredentials([string(credentialsId: 'repo21-url', variable: 'REPO21_URL')]) {


### PR DESCRIPTION
## Summary

- Switches the Jenkins agent label from `docker-ubuntu20-xlarge` to `docker-ubuntu24-xlarge` (single-line change to `Jenkinsfile:17`).
- Resolves the release-pipeline failure: `failed to run Sast scan. Exit code received: exit status 51` seen in the Audit stage.

## Root cause

The analyzer-manager SAST sub-binary (`zd_scanner/scanner`) is a PyInstaller-packed Python 3.14 app whose native extension `_dfa.cpython-314-x86_64-linux-gnu.so` is linked against `GLIBC_2.34`. The previous `docker-ubuntu20-xlarge` agent ships glibc 2.31, which is too old:

```
ImportError: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found
(required by .../zd_scanner/native/_dfa.cpython-314-x86_64-linux-gnu.so)
```

Other JAS scanners (SCA, Secrets, IaC) are unaffected because they use a Go binary (`jas_scanner` / `tf_scanner`), not the Python `zd_scanner`. That's why only SAST was failing while the rest of the audit ran clean.

Ubuntu 24.04 ships glibc 2.39, which satisfies the requirement.

## Test plan

- [x] Confirm `docker-ubuntu24-xlarge` agent pool is online and accepts the job.
- [x] Trigger a release run on this branch and verify the Audit stage completes without `exit status 51`.
- [x] Verify the rest of the release flow (build, deb/rpm pack, Windows signing, docker publish, distribution) is unaffected by the agent change.

Reproduced locally in `ubuntu:20.04` (fails identically) and verified the root cause via the analyzer-manager debug log (`AM_LOG_DIRECTORY`).