### PR TITLE
ci(jenkins): skip Windows executable signing when RUN_CHOCOLATEY is disabled

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,9 @@ def runRelease(architectures) {
         }
 
         // We sign the binary also for the standalone Windows executable, and not just for Windows executable packaged inside Chocolaty.
-        downloadToolsCert()
+        if (params.RUN_CHOCOLATEY) {
+            downloadToolsCert()
+        }
         if (params.RUN_UPLOAD_CLI) {
             stage('Upload CLI') {
                 print "Uploading version $version to Repo21"
@@ -445,7 +447,7 @@ def build(goos, goarch, pkg, fileName) {
         env.GOOS=""
         env.GOARCH=""
 
-        if (goos == 'windows') {
+        if (goos == 'windows' && params.RUN_CHOCOLATEY) {
             dir("${jfrogCliRepoDir}build/sign") {
                 // Move the jfrog executable into the 'sign' directory, so that it is signed there.
                 sh "mv ${jfrogCliRepoDir}${fileName} ${fileName}.unsigned"


### PR DESCRIPTION
## Summary
- Gate the Windows signing block in `build()` on `params.RUN_CHOCOLATEY` so the Docker-based signing step is skipped on runs that don't publish to Chocolatey.
- Also skip `downloadToolsCert()` in that case, since the cert is only consumed by the (now-skipped) Windows signing step.

When `RUN_CHOCOLATEY=true` (the default), behavior is unchanged. When it is disabled, the standalone Windows `.exe` uploaded by `uploadCli` will be unsigned — intended for dev/test runs without access to the signing infrastructure.

## Test plan
- [x] Run the Jenkins job with `RUN_CHOCOLATEY=false` and confirm no signing/cert download stages execute and the Windows binary uploads succeed.
- [ ] Run the Jenkins job with `RUN_CHOCOLATEY=true` and confirm signing still happens for both the standalone Windows exe and the Chocolatey package.