### PR TITLE
Rteco 1299 jfrog artifactory ecomatrix cli e2e

### DIFF
--- a/.jfrog-pipelines/pipelines.yml
+++ b/.jfrog-pipelines/pipelines.yml
@@ -76,6 +76,10 @@ pipelines:
             default: "true"
             description: "Forward Artifactory logs from the deployed ephemeral environment to Kibana (via Coralogix). Maps to the LOGS_TO_KIBANA parameter of the environment_setup_gen2 Jenkins job. Set 'false' to disable."
             allowCustom: true
+          DEPLOYMENT_SIZING:
+            default: "large"
+            description: "Artifactory deployment sizing profile. Maps to the DEPLOYMENT_SIZING parameter of the environment_setup_gen2 Jenkins job. Valid values: common, xsmall, small, medium, mediumha, large, large-xray-old, large-xray-dynamic-sizing-1, large-xray-dynamic-sizing-2, large-xray, large-xray-art-2. Reference: https://git.jfrog.info/projects/devops/repos/saas-configuration/browse/development/jfrogregions/global/jfrog_application_sizing_info.yaml"
+            allowCustom: true
     steps:
       - name: setup_cli_test
         type: Bash
@@ -145,6 +149,7 @@ pipelines:
             GROUP: "ARTIFACTORY"
             EXPIRY: 2d
             LOGS_TO_KIBANA: "${LOGS_TO_KIBANA}"
+            DEPLOYMENT_SIZING: "${DEPLOYMENT_SIZING}"
             EXTRA_PARAMS: "conf_artifactory_unified_version=${RT_VERSION} master_key=${MASTER_KEY}"
 
       - name: setup_environment

--- a/.jfrog-pipelines/pipelines.yml
+++ b/.jfrog-pipelines/pipelines.yml
@@ -72,6 +72,10 @@ pipelines:
             default: "artifactory-dind-amd-scale-set"
             description: "GitHub Actions runs-on label for all test jobs (use your self-hosted label; github.com-style ubuntu-24.04 is often unavailable on GHE)"
             allowCustom: true
+          LOGS_TO_KIBANA:
+            default: "true"
+            description: "Forward Artifactory logs from the deployed ephemeral environment to Kibana (via Coralogix). Maps to the LOGS_TO_KIBANA parameter of the environment_setup_gen2 Jenkins job. Set 'false' to disable."
+            allowCustom: true
     steps:
       - name: setup_cli_test
         type: Bash
@@ -140,6 +144,7 @@ pipelines:
             ACCOUNT_TYPE: "enterprise_plus"
             GROUP: "ARTIFACTORY"
             EXPIRY: 2d
+            LOGS_TO_KIBANA: "${LOGS_TO_KIBANA}"
             EXTRA_PARAMS: "conf_artifactory_unified_version=${RT_VERSION} master_key=${MASTER_KEY}"
 
       - name: setup_environment

--- a/.jfrog-pipelines/pipelines.yml
+++ b/.jfrog-pipelines/pipelines.yml
@@ -78,7 +78,7 @@ pipelines:
             allowCustom: true
           DEPLOYMENT_SIZING:
             default: "large"
-            description: "Artifactory deployment sizing profile. Maps to the DEPLOYMENT_SIZING parameter of the environment_setup_gen2 Jenkins job. Valid values: common, xsmall, small, medium, mediumha, large, large-xray-old, large-xray-dynamic-sizing-1, large-xray-dynamic-sizing-2, large-xray, large-xray-art-2. Reference: https://git.jfrog.info/projects/devops/repos/saas-configuration/browse/development/jfrogregions/global/jfrog_application_sizing_info.yaml"
+            description: "Artifactory deployment sizing profile."
             allowCustom: true
     steps:
       - name: setup_cli_test


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
---
What: Added logs to kibana parameter
Why: Unable to debug artifactory instance failures for ecomatrix cli e2e
Testing: NA