### PR TITLE
JGC-455 - Encourage migration from jfrog-cli-v2 to jfrog-cli-v2-jf in npm README

### DIFF
--- a/build/npm/v2/README.md
+++ b/build/npm/v2/README.md
@@ -8,6 +8,22 @@
 
 [Website](http://www.jfrog.com)  •  [Docs](https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli)  •  [Issues](https://github.com/jfrog/jfrog-cli/issues)  •  [Blog](https://jfrog.com/blog/)  •  [We're Hiring](https://join.jfrog.com/)  •  [Artifactory Free Trial](https://jfrog.com/artifactory/free-trial/)
 
+> [!IMPORTANT]
+> **Please migrate to [`jfrog-cli-v2-jf`](https://www.npmjs.com/package/jfrog-cli-v2-jf).**
+>
+> This package (`jfrog-cli-v2`) installs the CLI under the **`jfrog`** executable name. The actively maintained package, [`jfrog-cli-v2-jf`](https://www.npmjs.com/package/jfrog-cli-v2-jf), installs the very same CLI but under the shorter **`jf`** executable name, which is now the standard across JFrog's documentation, examples, and CI/CD integrations.
+>
+> **What this means for you:**
+> - The command you type changes from `jfrog ...` to `jf ...` — update your scripts, pipelines, aliases, and shell completions accordingly.
+> - Both executables share the same configuration, so your existing servers and settings continue to work.
+> - You can install both side by side during the transition, but to avoid confusion we recommend switching fully to `jf`.
+>
+> To migrate:
+> ```bash
+> npm uninstall -g jfrog-cli-v2
+> npm install -g jfrog-cli-v2-jf
+> ```
+
 ## Overview
 
 JFrog CLI is a compact and smart client that provides a simple interface that automates access to *Artifactory*, *Xray*,


### PR DESCRIPTION
## What

Adds a prominent migration note to the top of the `jfrog-cli-v2` npm package README (`build/npm/v2/README.md`).

## Why

The `jfrog-cli-v2` package installs the CLI under the legacy `jfrog` executable name, while the actively maintained `jfrog-cli-v2-jf` package installs the identical CLI under the standard `jf` name. This note steers users toward `jfrog-cli-v2-jf` and explains the practical consequences.

Note that the older [`jfrog-cli-go`](https://www.npmjs.com/package/jfrog-cli-go) package has already been deprecated, so `jfrog-cli-v2-jf` is the package users should move to.

## Note

The README is a static file published as-is by the Jenkinsfile (`npm publish` from `build/npm/v2/`), so this change reaches npmjs.com only on the next publish run.