### PR TITLE
Fix npm installer hanging after CLI download

### DIFF
--- a/build/npm/v2-jf/init.js
+++ b/build/npm/v2-jf/init.js
@@ -1,5 +1,3 @@
-validateNpmVersion();
-
 const {get} = require("https");
 const {request} = require("http");
 const {URL} = require("url");
@@ -10,7 +8,10 @@ const filePath = "bin/" + fileName;
 const version = packageJson.version;
 const pkgName = "jfrog-cli-" + getArchitecture();
 
-downloadCli();
+if (require.main === module) {
+    validateNpmVersion();
+    downloadCli();
+}
 
 function validateNpmVersion() {
     if (!isValidNpmVersion()) {
@@ -40,6 +41,7 @@ function downloadWithProxy(myUrl) {
                 },
                 function (res) {
                     if (res.statusCode === 301 || res.statusCode === 302) {
+                        res.resume();
                         downloadWithProxy(res.headers.location);
                     } else if (res.statusCode === 200) {
                         writeToFile(res);
@@ -59,8 +61,9 @@ function downloadWithProxy(myUrl) {
 }
 
 function download(url) {
-    get(url, function (res) {
+    get(new URL(url), {agent: false}, function (res) {
         if (res.statusCode === 301 || res.statusCode === 302) {
+            res.resume();
             download(res.headers.location);
         } else if (res.statusCode === 200) {
             writeToFile(res);
@@ -103,19 +106,24 @@ function isValidNpmVersion() {
 
 function writeToFile(response) {
     const file = createWriteStream(filePath);
-    response
-        .on("data", function (chunk) {
-            file.write(chunk);
-        })
-        .on("end", function () {
-            file.end();
-            if (!process.platform.startsWith("win")) {
-                chmodSync(filePath, '755');
+    response.on("error", function (err) {
+        console.error(err);
+    });
+    file.on("error", function (err) {
+        console.error(err);
+    });
+    file.on("finish", function () {
+        file.close(function (err) {
+            if (err) {
+                console.error(err);
+                return;
             }
-        })
-        .on("error", function (err) {
-            console.error(err);
+            if (!process.platform.startsWith("win")) {
+                chmodSync(filePath, "755");
+            }
         });
+    });
+    response.pipe(file);
 }
 
 function getArchitecture() {

--- a/build/npm/v2/init.js
+++ b/build/npm/v2/init.js
@@ -1,5 +1,3 @@
-validateNpmVersion();
-
 const {get} = require("https");
 const {request} = require("http");
 const {URL} = require("url");
@@ -10,7 +8,10 @@ const filePath = "bin/" + fileName;
 const version = packageJson.version;
 const pkgName = "jfrog-cli-" + getArchitecture();
 
-downloadCli();
+if (require.main === module) {
+    validateNpmVersion();
+    downloadCli();
+}
 
 function validateNpmVersion() {
     if (!isValidNpmVersion()) {
@@ -40,6 +41,7 @@ function downloadWithProxy(myUrl) {
                 },
                 function (res) {
                     if (res.statusCode === 301 || res.statusCode === 302) {
+                        res.resume();
                         downloadWithProxy(res.headers.location);
                     } else if (res.statusCode === 200) {
                         writeToFile(res);
@@ -59,8 +61,9 @@ function downloadWithProxy(myUrl) {
 }
 
 function download(url) {
-    get(url, function (res) {
+    get(new URL(url), {agent: false}, function (res) {
         if (res.statusCode === 301 || res.statusCode === 302) {
+            res.resume();
             download(res.headers.location);
         } else if (res.statusCode === 200) {
             writeToFile(res);
@@ -103,19 +106,24 @@ function isValidNpmVersion() {
 
 function writeToFile(response) {
     const file = createWriteStream(filePath);
-    response
-        .on("data", function (chunk) {
-            file.write(chunk);
-        })
-        .on("end", function () {
-            file.end();
-            if (!process.platform.startsWith("win")) {
-                chmodSync(filePath, '755');
+    response.on("error", function (err) {
+        console.error(err);
+    });
+    file.on("error", function (err) {
+        console.error(err);
+    });
+    file.on("finish", function () {
+        file.close(function (err) {
+            if (err) {
+                console.error(err);
+                return;
             }
-        })
-        .on("error", function (err) {
-            console.error(err);
+            if (!process.platform.startsWith("win")) {
+                chmodSync(filePath, "755");
+            }
         });
+    });
+    response.pipe(file);
 }
 
 function getArchitecture() {


### PR DESCRIPTION
## What changed
- disable pooled sockets for the direct HTTPS download path used by the npm installers
- consume redirect responses before following them
- switch the file write path to `response.pipe(file)` and wait for the stream to finish before chmod

## Why
This addresses issue #3423, where `npm i -g jfrog-cli-v2-jf` could sit around for about a minute after the binary download completed. The direct `https.get(url)` path was keeping the process alive long after the download had finished.

## Verification
- reproduced the hang locally by running `node init.js` in `build/npm/v2-jf` before the change; it stayed alive past 30 seconds and left an empty `bin/jf`
- after the change, `time node init.js` completed in about 7 seconds in both `build/npm/v2-jf` and `build/npm/v2`, and each command produced the expected binary
