### PR TITLE
JGC-492 - Add e2e test for release bundle --format flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jfrog/build-info-go v1.13.1-0.20260610071651-260ad6720e0d
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-application v1.0.2-0.20260608074325-4de652aef752
-	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260610074911-82ce7d90edbd
+	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260617065038-e7be947840da
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260609101026-df3091b39d06
 	github.com/jfrog/jfrog-cli-evidence v0.9.5-0.20260601141509-8df6c9a4bc9b
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260601140139-4cefb6add7b7
@@ -249,7 +249,3 @@ require (
 // replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260604085947-7c110b77b4b4
 
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.54.2-0.20251007084958-5eeaa42c31a6
-
-// TEMPORARY: points to the JGC-492 --format branch so the e2e test below can run.
-// Remove once https://github.com/jfrog/jfrog-cli-artifactory/pull/488 is merged and the dependency is bumped.
-replace github.com/jfrog/jfrog-cli-artifactory => github.com/ehl-jf/jfrog-cli-artifactory v0.0.0-20260615113839-04c78a8cf4fb

--- a/go.mod
+++ b/go.mod
@@ -249,3 +249,7 @@ require (
 // replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260604085947-7c110b77b4b4
 
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.54.2-0.20251007084958-5eeaa42c31a6
+
+// TEMPORARY: points to the JGC-492 --format branch so the e2e test below can run.
+// Remove once https://github.com/jfrog/jfrog-cli-artifactory/pull/488 is merged and the dependency is bumped.
+replace github.com/jfrog/jfrog-cli-artifactory => github.com/ehl-jf/jfrog-cli-artifactory v0.0.0-20260615113839-04c78a8cf4fb

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,8 @@ github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/qyY=
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ehl-jf/jfrog-cli-artifactory v0.0.0-20260615113839-04c78a8cf4fb h1:scGVRkRKWi6wVN2CbM3WPSDIwA35nF6WtyoZgkcMVxc=
+github.com/ehl-jf/jfrog-cli-artifactory v0.0.0-20260615113839-04c78a8cf4fb/go.mod h1:VqV0Bed11HoBlugAEGa3RumbwnDVslEf0gKocTzLs9s=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
@@ -406,8 +408,6 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260608074325-4de652aef752 h1:Fcb54+kmZjEuBbGstzerLz37Lk6SutfMF7CxLqgXRlE=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260608074325-4de652aef752/go.mod h1:EeLKgLeJfKcS7671H52bfCgj1xK8wyJJGBRD5a+vJMc=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260610074911-82ce7d90edbd h1:1AKWhJehl5Z8X69ibX7Azjt70x2L4PnBdnrGiVzdWxY=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260610074911-82ce7d90edbd/go.mod h1:VqV0Bed11HoBlugAEGa3RumbwnDVslEf0gKocTzLs9s=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260609101026-df3091b39d06 h1:A8hWKHyvqzGXfWmh+8lXv3waAkim4xiucBfGhl7ZOeQ=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260609101026-df3091b39d06/go.mod h1:9R90mhbczGXwW5EGlDs7F08ejQU/xdoDhYHMvzBiqgE=
 github.com/jfrog/jfrog-cli-evidence v0.9.5-0.20260601141509-8df6c9a4bc9b h1:V0FxnU3xh29y8yJHWymm6rPr1MrjG1DdPQlr3ckImwk=

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,6 @@ github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707/go.mod h1:qssHWj6
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/qyY=
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/ehl-jf/jfrog-cli-artifactory v0.0.0-20260615113839-04c78a8cf4fb h1:scGVRkRKWi6wVN2CbM3WPSDIwA35nF6WtyoZgkcMVxc=
-github.com/ehl-jf/jfrog-cli-artifactory v0.0.0-20260615113839-04c78a8cf4fb/go.mod h1:VqV0Bed11HoBlugAEGa3RumbwnDVslEf0gKocTzLs9s=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
@@ -408,6 +406,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260608074325-4de652aef752 h1:Fcb54+kmZjEuBbGstzerLz37Lk6SutfMF7CxLqgXRlE=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260608074325-4de652aef752/go.mod h1:EeLKgLeJfKcS7671H52bfCgj1xK8wyJJGBRD5a+vJMc=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260617065038-e7be947840da h1:BnmMBxYQlJ/WMrVO31q7LumJ5fDLQdIm3MVGNrNDC4w=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260617065038-e7be947840da/go.mod h1:VqV0Bed11HoBlugAEGa3RumbwnDVslEf0gKocTzLs9s=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260609101026-df3091b39d06 h1:A8hWKHyvqzGXfWmh+8lXv3waAkim4xiucBfGhl7ZOeQ=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260609101026-df3091b39d06/go.mod h1:9R90mhbczGXwW5EGlDs7F08ejQU/xdoDhYHMvzBiqgE=
 github.com/jfrog/jfrog-cli-evidence v0.9.5-0.20260601141509-8df6c9a4bc9b h1:V0FxnU3xh29y8yJHWymm6rPr1MrjG1DdPQlr3ckImwk=

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -491,6 +491,51 @@ func TestPromoteReleaseBundleWithPromotionTypeFlag(t *testing.T) {
 	assertStatusCompleted(t, lcManager, tests.LcRbName1, number1, "")
 }
 
+// TestReleaseBundleFormatFlag verifies the --format flag output of the lifecycle commands:
+//   - release-bundle-create --format=json emits a JSON confirmation object.
+//   - release-bundle-promote --format=table renders a summary table.
+//
+// The release-bundle-promote --format=json (default) path is already covered by promoteRb.
+func TestReleaseBundleFormatFlag(t *testing.T) {
+	cleanCallback := initLifecycleTest(t, signingKeyOptionalArtifactoryMinVersion)
+	defer cleanCallback()
+	lcManager := getLcServiceManager(t)
+
+	deleteBuilds := uploadBuilds(t)
+	defer deleteBuilds()
+
+	// release-bundle-create --format=json emits a JSON confirmation object.
+	specFile, err := tests.CreateSpec(tests.LifecycleBuilds12)
+	assert.NoError(t, err)
+	createOutput := lcCli.RunCliCmdWithOutput(t, "rbc", tests.LcRbName1, number1,
+		getOption("spec", specFile),
+		getOption(cliutils.SigningKey, gpgKeyPairName),
+		getOption(cliutils.Sync, "true"),
+		getOption(cliutils.Format, "json"))
+	defer deleteReleaseBundle(t, lcManager, tests.LcRbName1, number1)
+
+	var created struct {
+		Name    string `json:"release_bundle_name"`
+		Version string `json:"release_bundle_version"`
+		Status  string `json:"status"`
+	}
+	assert.NoError(t, json.Unmarshal([]byte(createOutput), &created))
+	assert.Equal(t, tests.LcRbName1, created.Name)
+	assert.Equal(t, number1, created.Version)
+	assert.Equal(t, "created", created.Status)
+
+	// release-bundle-promote --format=table renders a summary table.
+	tableOutput := lcCli.RunCliCmdWithOutput(t, "rbp", tests.LcRbName1, number1, prodEnvironment,
+		getOption(cliutils.SigningKey, gpgKeyPairName),
+		getOption(cliutils.IncludeRepos, tests.RtProdRepo1),
+		"--project=default",
+		getOption(cliutils.Format, "table"))
+	assert.Contains(t, tableOutput, "BUNDLE NAME")
+	assert.Contains(t, tableOutput, "ENVIRONMENT")
+	assert.Contains(t, tableOutput, tests.LcRbName1)
+	assertStatusCompleted(t, lcManager, tests.LcRbName1, number1, "")
+}
+
 func TestReleaseBundleCreationWithDraftFlagFromSpec(t *testing.T) {
 	cleanCallback := initLifecycleTest(t, draftBundleArtifactoryMinVersion)
 	defer cleanCallback()

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -530,9 +530,12 @@ func TestReleaseBundleFormatFlag(t *testing.T) {
 		getOption(cliutils.IncludeRepos, tests.RtProdRepo1),
 		"--project=default",
 		getOption(cliutils.Format, "table"))
+	// The bundle name column wraps across lines, so assert on stable, non-wrapping
+	// content: the table title, headers, and the environment value.
+	assert.Contains(t, tableOutput, "Promotion Result")
 	assert.Contains(t, tableOutput, "BUNDLE NAME")
 	assert.Contains(t, tableOutput, "ENVIRONMENT")
-	assert.Contains(t, tableOutput, tests.LcRbName1)
+	assert.Contains(t, tableOutput, prodEnvironment)
 	assertStatusCompleted(t, lcManager, tests.LcRbName1, number1, "")
 }
 


### PR DESCRIPTION
## Summary

Adds end-to-end coverage for the `--format` flag on the lifecycle Release Bundle V2 commands, introduced in [jfrog-cli-artifactory#488](https://github.com/jfrog/jfrog-cli-artifactory/pull/488) (now merged).

`TestReleaseBundleFormatFlag` (in `lifecycle_test.go`) verifies:
- **`release-bundle-create --format=json`** emits a JSON confirmation object (`release_bundle_name`, `release_bundle_version`, `status: "created"`).
- **`release-bundle-promote --format=table`** renders a summary table containing the expected title and headers (`Promotion Result`, `BUNDLE NAME`, `ENVIRONMENT`) and the environment value. The assertions target stable, non-wrapping content to avoid column-wrap flakiness.

The `release-bundle-promote --format=json` (default) path is already covered by the existing `promoteRb` helper.

## Dependency bump

Bumps `github.com/jfrog/jfrog-cli-artifactory` to the merged-master commit that contains the `--format` feature (`v0.8.1-0.20260617065038-e7be947840da`). The temporary `replace` directive that pointed at the feature branch during review has been removed.

---
- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---