### PR TITLE
JGC-499 - Remove concurrency from reusable test suites

### DIFF
--- a/.github/workflows/accessTests.yml
+++ b/.github/workflows/accessTests.yml
@@ -14,10 +14,6 @@ on:
         required: false
         default: ""
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/artifactoryTests.yml
+++ b/.github/workflows/artifactoryTests.yml
@@ -14,10 +14,6 @@ on:
         required: false
         default: ""
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Artifactory-Tests:
     name: ${{ matrix.suite }} ${{ matrix.os.name }}

--- a/.github/workflows/conanTests.yml
+++ b/.github/workflows/conanTests.yml
@@ -14,9 +14,6 @@ on:
         required: false
         default: ""
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Conan-Tests:
     name: Conan tests (${{ matrix.os.name }})

--- a/.github/workflows/distributionTests.yml
+++ b/.github/workflows/distributionTests.yml
@@ -3,10 +3,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Distribution-Tests:
     name: Distribution tests (${{ matrix.os }})

--- a/.github/workflows/dockerTests.yml
+++ b/.github/workflows/dockerTests.yml
@@ -3,10 +3,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Docker-tests:
     name: Docker tests (${{ matrix.os.name }}, containerd-snapshotter=${{ !matrix.disable-containerd-snapshotter }})

--- a/.github/workflows/evidenceTests.yml
+++ b/.github/workflows/evidenceTests.yml
@@ -3,10 +3,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Evidence-Tests:
     name: Evidence tests (${{ matrix.os }})
@@ -44,4 +40,3 @@ jobs:
 
       - name: Run Evidence tests
         run: go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.evidence --jfrog.url=${{ secrets.EPLUS_PLATFORM_URL }} --jfrog.adminToken=${{ secrets.EPLUS_ADMIN_TOKEN }} --jfrog.evidenceToken=${{ secrets.EVIDENCE_USER_TOKEN }} --jfrog.projectKey=${{ secrets.EVIDENCE_PROJECT_KEY }} --jfrog.projectToken=${{ secrets.EVIDENCE_PROJECT_TOKEN }} --ci.runId=${{ runner.os }}-evidence
-

--- a/.github/workflows/ghostFrogTests.yml
+++ b/.github/workflows/ghostFrogTests.yml
@@ -3,10 +3,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Ghost-Frog-Tests:
     name: Ghost Frog tests (${{ matrix.os.name }})

--- a/.github/workflows/goTests.yml
+++ b/.github/workflows/goTests.yml
@@ -6,10 +6,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   GO-tests:
     # Go modules doesn't allow passing credentials to a private registry using an HTTP URL. Therefore, the Go tests run against a remote Artifactory server.

--- a/.github/workflows/gradleTests.yml
+++ b/.github/workflows/gradleTests.yml
@@ -14,10 +14,6 @@ on:
         required: false
         default: ""
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Gradle-Tests:
     name: ${{ matrix.os.name }}-gradle-${{ matrix.gradle-version }}

--- a/.github/workflows/helmTests.yml
+++ b/.github/workflows/helmTests.yml
@@ -14,10 +14,6 @@ on:
         required: false
         default: ""
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 permissions:
   id-token: write
   contents: read
@@ -102,4 +98,3 @@ jobs:
           go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.helm
           --jfrog.url=${{ env.JFROG_TESTS_URL || 'http://127.0.0.1:8082' }}
           --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}
-

--- a/.github/workflows/huggingfaceTests.yml
+++ b/.github/workflows/huggingfaceTests.yml
@@ -14,10 +14,6 @@ on:
         required: false
         default: ""
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 permissions:
   id-token: write
   contents: read
@@ -107,4 +103,3 @@ jobs:
           go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.huggingface
           --jfrog.url=${{ env.JFROG_TESTS_URL || 'http://127.0.0.1:8082' }}
           --jfrog.adminToken=${{ env.JFROG_TESTS_LOCAL_ACCESS_TOKEN }}
-

--- a/.github/workflows/lifecycleTests.yml
+++ b/.github/workflows/lifecycleTests.yml
@@ -16,10 +16,6 @@ on:
         required: false
         default: ""
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Lifecycle-Tests:
     name: Lifecycle tests (${{ matrix.os.name }})

--- a/.github/workflows/mavenTests.yml
+++ b/.github/workflows/mavenTests.yml
@@ -14,10 +14,6 @@ on:
         required: false
         default: ""
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Maven-Tests:
     name: Maven tests (${{ matrix.os.name }})

--- a/.github/workflows/nixTests.yml
+++ b/.github/workflows/nixTests.yml
@@ -14,9 +14,6 @@ on:
         required: false
         default: ""
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Nix-Tests:
     name: Nix tests (${{ matrix.os.name }})

--- a/.github/workflows/npmTests.yml
+++ b/.github/workflows/npmTests.yml
@@ -14,10 +14,6 @@ on:
         required: false
         default: ""
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   npm-Tests:
     name: npm tests (${{ matrix.os.name }})

--- a/.github/workflows/nugetTests.yml
+++ b/.github/workflows/nugetTests.yml
@@ -15,11 +15,6 @@ on:
         required: false
         default: ""
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   NuGet-Tests:
     name: NuGet tests (${{ matrix.os.name }})

--- a/.github/workflows/oidcTests.yml
+++ b/.github/workflows/oidcTests.yml
@@ -5,11 +5,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   JFROG_CLI_LOG_LEVEL: DEBUG
 

--- a/.github/workflows/pluginsTests.yml
+++ b/.github/workflows/pluginsTests.yml
@@ -14,10 +14,6 @@ on:
         required: false
         default: ""
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Plugins-Tests:
     name: Plugins tests (${{ matrix.os.name }})

--- a/.github/workflows/pnpmTests.yml
+++ b/.github/workflows/pnpmTests.yml
@@ -14,10 +14,6 @@ on:
         required: false
         default: ""
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   pnpm-Tests:
     name: "pnpm 10 tests (${{ matrix.os.name }})"

--- a/.github/workflows/podmanTests.yml
+++ b/.github/workflows/podmanTests.yml
@@ -3,10 +3,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Podman-tests:
     name: Podman tests (${{ matrix.os.name }})

--- a/.github/workflows/poetryTests.yml
+++ b/.github/workflows/poetryTests.yml
@@ -19,11 +19,6 @@ on:
         required: false
         default: "1.8.5"
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   Poetry-Tests:
     name: poetry ${{ matrix.os.name }}

--- a/.github/workflows/pythonTests.yml
+++ b/.github/workflows/pythonTests.yml
@@ -14,10 +14,6 @@ on:
         required: false
         default: ""
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Python-Tests:
     name: ${{ matrix.suite }} ${{ matrix.os.name }}

--- a/.github/workflows/scriptTests.yml
+++ b/.github/workflows/scriptTests.yml
@@ -3,10 +3,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Scripts-tests:
     name: Script tests (${{ matrix.os.name }}-${{ matrix.os.version }})

--- a/.github/workflows/transferTests.yml
+++ b/.github/workflows/transferTests.yml
@@ -14,10 +14,6 @@ on:
         required: false
         default: ""
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   Transfer-Artifactory-7-Tests:
     name: Transfer tests (${{ matrix.os.name }})

--- a/.github/workflows/uvTests.yml
+++ b/.github/workflows/uvTests.yml
@@ -3,11 +3,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Ensures that only the latest commit is running for each PR at a time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   UV-Tests:
     name: uv ${{ matrix.os.name }} py${{ matrix.python-version }} uv${{ matrix.uv-version }}


### PR DESCRIPTION
## Summary

Fixes the post-merge `Build Gate` run on `master` (#3535), where **only `frogbot` ran** and `build-gate-success` failed immediately because every test suite was cancelled before starting.

## Root cause

Each reusable suite still declared its own:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
  cancel-in-progress: true
```

When a workflow is invoked via `workflow_call`, `github.workflow` resolves to the **caller** (`Build Gate`), so all 25 suites *and* the parent run compute the **same** concurrency group. With `cancel-in-progress: true` they cancelled one another (and collided with the parent) before starting. `frogbot` survived only because it has no `concurrency` block. With all suites cancelled, `build-gate-success` (`if: always()`) ran and failed on `contains(needs.*.result, 'cancelled')`.

## Fix

Remove the `concurrency:` block from the 25 reusable suite workflows. The orchestrator (`build-gate.yml`) keeps its own `concurrency`, which already supersedes older runs per PR/branch — so cancellation behaviour is preserved without the self-collision.

## Validation

- All 25 suite files parse as valid YAML.
- Deletions only (`105 deletions(-)`); no logic changed.
