### PR TITLE
Fix gradle v9.3.0 compatibility

### DIFF
--- a/testdata/gradle/projectwithplugin/build.gradle
+++ b/testdata/gradle/projectwithplugin/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.+')
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:6.0.+"
     }
 }
 apply plugin: 'groovy'


### PR DESCRIPTION
## Automated fix by AZ_PMCompatFixer

**PM:** `gradle` `v9.3.0`
**Failing run:** https://github.jfrog.info/JFROG/jfrog-cli-workflows/actions/runs/639896
**Tested against:** jfrog-cli @ `master`

### What was fixed
Updated usePlugin Gradle test project to use build-info-extractor-gradle 6.0.+ for Gradle 9 compatibility

---
_Raised automatically by AZ_PMCompatFixer. Please review before merging._
