### PR TITLE
Include --ci.runId in test ProjectKey to prevent cross-suite collisions

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -3672,7 +3672,6 @@ func TestArtifactoryDownloadByBuildUsingSimpleDownloadWithProject(t *testing.T) 
 	// Assign the repository to the project
 	err = accessManager.AssignRepoToProject(tests.RtRepo1, tests.ProjectKey, true)
 	assert.NoError(t, err)
-	waitForProjectInArtifactory(t, tests.ProjectKey)
 
 	// Delete the build if exists
 	inttestutils.DeleteBuild(serverDetails.ArtifactoryUrl, tests.RtBuildName1, artHttpDetails)
@@ -3684,8 +3683,10 @@ func TestArtifactoryDownloadByBuildUsingSimpleDownloadWithProject(t *testing.T) 
 	// Upload files with buildName, buildNumber and project flags
 	runRt(t, "upload", "--spec="+specFileB, "--build-name="+tests.RtBuildName1, "--build-number="+buildNumberA, "--project="+tests.ProjectKey)
 
-	// Publish buildInfo with project flag
-	runRt(t, "build-publish", tests.RtBuildName1, buildNumberA, "--project="+tests.ProjectKey)
+	// Publish buildInfo with project flag — retried automatically if project cache not yet warm
+	assert.NoError(t, retryOnProjectNotFound(func() error {
+		return artifactoryCli.Exec("build-publish", tests.RtBuildName1, buildNumberA, "--project="+tests.ProjectKey)
+	}))
 
 	// Download by project, b1 should be downloaded
 	runRt(t, "download", tests.RtRepo1+"/data/b1.in", filepath.Join(tests.Out, "download", "simple_by_build")+fileutils.GetFileSeparator(),
@@ -3725,7 +3726,6 @@ func TestArtifactoryDownloadWithEnvProject(t *testing.T) {
 	// Assign the repository to the project
 	err = accessManager.AssignRepoToProject(tests.RtRepo1, tests.ProjectKey, true)
 	assert.NoError(t, err)
-	waitForProjectInArtifactory(t, tests.ProjectKey)
 
 	// Delete the build if exists
 	inttestutils.DeleteBuild(serverDetails.ArtifactoryUrl, tests.RtBuildName1, artHttpDetails)
@@ -3742,8 +3742,10 @@ func TestArtifactoryDownloadWithEnvProject(t *testing.T) {
 	// Upload files with buildName, buildNumber and project flags
 	runRt(t, "upload", "--spec="+specFileB)
 
-	// Publish buildInfo with project flag
-	runRt(t, "build-publish")
+	// Publish buildInfo with project flag — retried automatically if project cache not yet warm
+	assert.NoError(t, retryOnProjectNotFound(func() error {
+		return artifactoryCli.Exec("build-publish")
+	}))
 
 	// Download by project, b1 should be downloaded
 	runRt(t, "download", tests.RtRepo1+"/data/b1.in", filepath.Join(tests.Out, "download", "simple_by_build")+fileutils.GetFileSeparator(),

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -3672,6 +3672,7 @@ func TestArtifactoryDownloadByBuildUsingSimpleDownloadWithProject(t *testing.T) 
 	// Assign the repository to the project
 	err = accessManager.AssignRepoToProject(tests.RtRepo1, tests.ProjectKey, true)
 	assert.NoError(t, err)
+	waitForProjectInArtifactory(t, tests.ProjectKey)
 
 	// Delete the build if exists
 	inttestutils.DeleteBuild(serverDetails.ArtifactoryUrl, tests.RtBuildName1, artHttpDetails)
@@ -3724,6 +3725,7 @@ func TestArtifactoryDownloadWithEnvProject(t *testing.T) {
 	// Assign the repository to the project
 	err = accessManager.AssignRepoToProject(tests.RtRepo1, tests.ProjectKey, true)
 	assert.NoError(t, err)
+	waitForProjectInArtifactory(t, tests.ProjectKey)
 
 	// Delete the build if exists
 	inttestutils.DeleteBuild(serverDetails.ArtifactoryUrl, tests.RtBuildName1, artHttpDetails)

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -1807,7 +1807,7 @@ func waitForLifecycleProjectVisibility(t *testing.T, projectKey string) {
 // deployments. Up to maxRetries attempts are made with retryInterval between each attempt.
 func retryOnProjectNotFound(fn func() error) error {
 	const (
-		maxRetries    = 5
+		maxRetries    = 10
 		retryInterval = 30 * time.Second
 	)
 	var err error

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -163,6 +163,7 @@ func TestReleaseBundleCreationFromMultiBundlesUsingCommandFlagWithProject(t *tes
 			}
 		}()
 	}
+	waitForProjectInArtifactory(t, tests.ProjectKey)
 	lcManager := getLcServiceManager(t)
 
 	deleteBuilds := uploadBuildsWithProject(t)
@@ -724,6 +725,7 @@ func TestCreateBundleWithoutSpecAndWithProject(t *testing.T) {
 			}
 		}()
 	}
+	waitForProjectInArtifactory(t, tests.ProjectKey)
 	lcManager := getLcServiceManager(t)
 	deleteBuilds := uploadBuildsWithProject(t)
 	defer deleteBuilds()
@@ -1424,6 +1426,7 @@ func TestReleaseBundlesSearchVersions(t *testing.T) {
 			}
 		}()
 	}
+	waitForProjectInArtifactory(t, tests.ProjectKey)
 
 	deleteBuildsWithProject := uploadBuildsWithProject(t)
 	defer deleteBuildsWithProject()
@@ -1764,4 +1767,38 @@ type KeyPairPayload struct {
 	Passphrase string `json:"passphrase,omitempty"`
 	PublicKey  string `json:"publicKey,omitempty"`
 	PrivateKey string `json:"privateKey,omitempty"` // #nosec G117 -- test struct, not a real secret
+}
+
+// waitForProjectInArtifactory polls until the project's build-info repository is visible
+// on every Artifactory node behind the load balancer. In HA deployments each node has its
+// own in-memory cache of Access project data; a single 200 only confirms one node is warm.
+// We require consecutiveRequired back-to-back 200 responses (one per poll tick, each
+// potentially hitting a different node in round-robin) before proceeding.
+func waitForProjectInArtifactory(t *testing.T, projectKey string) {
+	const (
+		timeout             = 30 * time.Second
+		pollInterval        = 1 * time.Second
+		consecutiveRequired = 5
+	)
+	client, err := httpclient.ClientBuilder().Build()
+	if !assert.NoError(t, err) {
+		return
+	}
+	// Artifactory auto-creates <projectKey>-build-info when the project is registered.
+	probeURL := serverDetails.ArtifactoryUrl + "api/repositories/" + projectKey + "-build-info"
+	deadline := time.Now().Add(timeout)
+	consecutive := 0
+	for time.Now().Before(deadline) {
+		resp, _, _, probErr := client.SendGet(probeURL, true, artHttpDetails, "")
+		if probErr == nil && resp.StatusCode == http.StatusOK {
+			consecutive++
+			if consecutive >= consecutiveRequired {
+				return
+			}
+		} else {
+			consecutive = 0
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Logf("waitForProjectInArtifactory: project %q did not become fully visible within %s; proceeding anyway", projectKey, timeout)
 }

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -163,7 +163,6 @@ func TestReleaseBundleCreationFromMultiBundlesUsingCommandFlagWithProject(t *tes
 			}
 		}()
 	}
-	waitForProjectInArtifactory(t, tests.ProjectKey)
 	lcManager := getLcServiceManager(t)
 
 	deleteBuilds := uploadBuildsWithProject(t)
@@ -725,7 +724,6 @@ func TestCreateBundleWithoutSpecAndWithProject(t *testing.T) {
 			}
 		}()
 	}
-	waitForProjectInArtifactory(t, tests.ProjectKey)
 	lcManager := getLcServiceManager(t)
 	deleteBuilds := uploadBuildsWithProject(t)
 	defer deleteBuilds()
@@ -1426,8 +1424,6 @@ func TestReleaseBundlesSearchVersions(t *testing.T) {
 			}
 		}()
 	}
-	waitForProjectInArtifactory(t, tests.ProjectKey)
-
 	deleteBuildsWithProject := uploadBuildsWithProject(t)
 	defer deleteBuildsWithProject()
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -1771,37 +1771,13 @@ type KeyPairPayload struct {
 	PrivateKey string `json:"privateKey,omitempty"` // #nosec G117 -- test struct, not a real secret
 }
 
-// waitForProjectInArtifactory polls the Access API until the project is confirmed created.
-// It does NOT sleep for cache propagation — project-scoped operations use retryOnProjectNotFound
-// to handle the Access→Artifactory and Access→Lifecycle cache sync delay at the call site.
-func waitForProjectInArtifactory(t *testing.T, projectKey string) {
-	const (
-		accessTimeout = 30 * time.Second
-		pollInterval  = 500 * time.Millisecond
-	)
-	client, err := httpclient.ClientBuilder().Build()
-	if !assert.NoError(t, err) {
-		return
-	}
-	probeURL := *tests.JfrogUrl + "access/api/v1/projects/" + projectKey
-	deadline := time.Now().Add(accessTimeout)
-	for time.Now().Before(deadline) {
-		resp, _, _, probErr := client.SendGet(probeURL, true, artHttpDetails, "")
-		if probErr == nil && resp.StatusCode == http.StatusOK {
-			return
-		}
-		time.Sleep(pollInterval)
-	}
-	t.Logf("waitForProjectInArtifactory: project %q not visible in Access within %s; proceeding anyway", projectKey, accessTimeout)
-}
-
 // retryOnProjectNotFound retries fn when Artifactory or Lifecycle reports that a project is not
 // yet visible — a transient condition caused by the Access→service cache propagation delay in HA
 // deployments. Up to maxRetries attempts are made with retryInterval between each attempt.
 func retryOnProjectNotFound(fn func() error) error {
 	const (
-		maxRetries    = 12
-		retryInterval = 5 * time.Second
+		maxRetries    = 5
+		retryInterval = 30 * time.Second
 	)
 	var err error
 	for attempt := 0; attempt < maxRetries; attempt++ {

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -767,7 +767,9 @@ func createRbWithFlags(t *testing.T, specFilePath, sourceOption, buildName, buil
 		argsAndOptions = append(argsAndOptions, getOption(cliutils.Draft, "true"))
 	}
 
-	assert.NoError(t, lcCli.Exec(argsAndOptions...))
+	assert.NoError(t, retryOnProjectNotFound(func() error {
+		return lcCli.Exec(argsAndOptions...)
+	}))
 }
 
 func updateRbWithFlags(t *testing.T, specFilePath, rbName, rbVersion, project, sourceTypeBuilds string, sync bool) {
@@ -1642,7 +1644,9 @@ func uploadBuildWithArtifactsAndProject(t *testing.T, specFileName, buildName, b
 	assert.NoError(t, err)
 
 	runRt(t, "upload", "--spec="+specFile, "--build-name="+buildName, "--build-number="+buildNumber, "--project="+projectKey)
-	runRt(t, "build-publish", buildName, buildNumber, "--project="+projectKey)
+	assert.NoError(t, retryOnProjectNotFound(func() error {
+		return artifactoryCli.Exec("build-publish", buildName, buildNumber, "--project="+projectKey)
+	}))
 }
 
 func uploadBuildWithDepsAndProject(t *testing.T, buildName, buildNumber, projectKey string) {
@@ -1655,7 +1659,9 @@ func uploadBuildWithDepsAndProject(t *testing.T, buildName, buildNumber, project
 	runRt(t, "upload", randFile.Name(), tests.RtDevRepo, "--flat", "--project="+projectKey)
 	assert.NoError(t, lcCli.WithoutCredentials().Exec("rt", "bad", buildName, buildNumber, tests.RtDevRepo+"/dep-file", "--from-rt"))
 
-	runRt(t, "build-publish", buildName, buildNumber, "--project="+projectKey)
+	assert.NoError(t, retryOnProjectNotFound(func() error {
+		return artifactoryCli.Exec("build-publish", buildName, buildNumber, "--project="+projectKey)
+	}))
 }
 
 func initLifecycleTest(t *testing.T, minVersion string) (cleanCallback func()) {
@@ -1765,16 +1771,13 @@ type KeyPairPayload struct {
 	PrivateKey string `json:"privateKey,omitempty"` // #nosec G117 -- test struct, not a real secret
 }
 
-// waitForProjectInArtifactory first confirms the project is visible in the Access service,
-// then waits for Artifactory's internal project cache to sync from Access. The Access API
-// (GET /access/api/v1/projects/<key>) is the correct source of truth for project existence.
-// After Access confirms the project, we sleep briefly to allow Artifactory nodes to pick up
-// the new project before any build-publish or release-bundle calls that scope to the project.
+// waitForProjectInArtifactory polls the Access API until the project is confirmed created.
+// It does NOT sleep for cache propagation — project-scoped operations use retryOnProjectNotFound
+// to handle the Access→Artifactory and Access→Lifecycle cache sync delay at the call site.
 func waitForProjectInArtifactory(t *testing.T, projectKey string) {
 	const (
-		accessTimeout  = 30 * time.Second
-		pollInterval   = 500 * time.Millisecond
-		artifactoryTTL = 30 * time.Second
+		accessTimeout = 30 * time.Second
+		pollInterval  = 500 * time.Millisecond
 	)
 	client, err := httpclient.ClientBuilder().Build()
 	if !assert.NoError(t, err) {
@@ -1785,11 +1788,34 @@ func waitForProjectInArtifactory(t *testing.T, projectKey string) {
 	for time.Now().Before(deadline) {
 		resp, _, _, probErr := client.SendGet(probeURL, true, artHttpDetails, "")
 		if probErr == nil && resp.StatusCode == http.StatusOK {
-			// Project confirmed in Access; give Artifactory time to sync its cache.
-			time.Sleep(artifactoryTTL)
 			return
 		}
 		time.Sleep(pollInterval)
 	}
 	t.Logf("waitForProjectInArtifactory: project %q not visible in Access within %s; proceeding anyway", projectKey, accessTimeout)
+}
+
+// retryOnProjectNotFound retries fn when Artifactory or Lifecycle reports that a project is not
+// yet visible — a transient condition caused by the Access→service cache propagation delay in HA
+// deployments. Up to maxRetries attempts are made with retryInterval between each attempt.
+func retryOnProjectNotFound(fn func() error) error {
+	const (
+		maxRetries    = 12
+		retryInterval = 5 * time.Second
+	)
+	var err error
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		err = fn()
+		if err == nil {
+			return nil
+		}
+		errMsg := err.Error()
+		if !strings.Contains(errMsg, "not found") && !strings.Contains(errMsg, "project key") {
+			return err
+		}
+		if attempt < maxRetries-1 {
+			time.Sleep(retryInterval)
+		}
+	}
+	return err
 }

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -670,6 +670,10 @@ func uploadBuildsWithProject(t *testing.T) func() {
 	uploadBuildWithArtifactsAndProject(t, tests.UploadDevSpecA, tests.LcBuildName1, number1, tests.ProjectKey)
 	uploadBuildWithArtifactsAndProject(t, tests.UploadDevSpecB, tests.LcBuildName2, number2, tests.ProjectKey)
 	uploadBuildWithDepsAndProject(t, tests.LcBuildName3, number3, tests.ProjectKey)
+	// Wait for the Lifecycle service to register the project before any release-bundle
+	// creation attempts. LC has its own cache separate from Artifactory's; it can take
+	// several minutes to warm in HA deployments running Artifactory draft builds.
+	waitForLifecycleProjectVisibility(t, tests.ProjectKey)
 	return func() {
 		inttestutils.DeleteBuild(serverDetails.ArtifactoryUrl, tests.LcBuildName1, artHttpDetails)
 		inttestutils.DeleteBuild(serverDetails.ArtifactoryUrl, tests.LcBuildName2, artHttpDetails)
@@ -1769,6 +1773,33 @@ type KeyPairPayload struct {
 	Passphrase string `json:"passphrase,omitempty"`
 	PublicKey  string `json:"publicKey,omitempty"`
 	PrivateKey string `json:"privateKey,omitempty"` // #nosec G117 -- test struct, not a real secret
+}
+
+// waitForLifecycleProjectVisibility polls the Lifecycle service until the project is visible
+// to it. LC has a project cache separate from Artifactory's and can take many minutes to warm
+// in HA deployments. Polling a cheap endpoint avoids wasting the retry budget on expensive
+// full CLI commands before LC is actually ready.
+func waitForLifecycleProjectVisibility(t *testing.T, projectKey string) {
+	const (
+		timeout      = 15 * time.Minute
+		pollInterval = 15 * time.Second
+	)
+	client, err := httpclient.ClientBuilder().Build()
+	if !assert.NoError(t, err) {
+		return
+	}
+	// GET on a non-existent RB returns 400 when LC doesn't know the project yet,
+	// and 404 when it does (RB not found, but project is recognised).
+	probeURL := *tests.JfrogUrl + "lifecycle/api/v2/release_bundle/records/non-existing-rb?project=" + projectKey
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, _, _, probErr := client.SendGet(probeURL, true, artHttpDetails, "")
+		if probErr == nil && resp.StatusCode != http.StatusBadRequest {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Logf("waitForLifecycleProjectVisibility: LC still not aware of project %q after %s; proceeding anyway", projectKey, timeout)
 }
 
 // retryOnProjectNotFound retries fn when Artifactory or Lifecycle reports that a project is not

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -1769,36 +1769,31 @@ type KeyPairPayload struct {
 	PrivateKey string `json:"privateKey,omitempty"` // #nosec G117 -- test struct, not a real secret
 }
 
-// waitForProjectInArtifactory polls until the project's build-info repository is visible
-// on every Artifactory node behind the load balancer. In HA deployments each node has its
-// own in-memory cache of Access project data; a single 200 only confirms one node is warm.
-// We require consecutiveRequired back-to-back 200 responses (one per poll tick, each
-// potentially hitting a different node in round-robin) before proceeding.
+// waitForProjectInArtifactory first confirms the project is visible in the Access service,
+// then waits for Artifactory's internal project cache to sync from Access. The Access API
+// (GET /access/api/v1/projects/<key>) is the correct source of truth for project existence.
+// After Access confirms the project, we sleep briefly to allow Artifactory nodes to pick up
+// the new project before any build-publish or release-bundle calls that scope to the project.
 func waitForProjectInArtifactory(t *testing.T, projectKey string) {
 	const (
-		timeout             = 30 * time.Second
-		pollInterval        = 1 * time.Second
-		consecutiveRequired = 5
+		accessTimeout  = 30 * time.Second
+		pollInterval   = 500 * time.Millisecond
+		artifactoryTTL = 5 * time.Second
 	)
 	client, err := httpclient.ClientBuilder().Build()
 	if !assert.NoError(t, err) {
 		return
 	}
-	// Artifactory auto-creates <projectKey>-build-info when the project is registered.
-	probeURL := serverDetails.ArtifactoryUrl + "api/repositories/" + projectKey + "-build-info"
-	deadline := time.Now().Add(timeout)
-	consecutive := 0
+	probeURL := *tests.JfrogUrl + "access/api/v1/projects/" + projectKey
+	deadline := time.Now().Add(accessTimeout)
 	for time.Now().Before(deadline) {
 		resp, _, _, probErr := client.SendGet(probeURL, true, artHttpDetails, "")
 		if probErr == nil && resp.StatusCode == http.StatusOK {
-			consecutive++
-			if consecutive >= consecutiveRequired {
-				return
-			}
-		} else {
-			consecutive = 0
+			// Project confirmed in Access; give Artifactory time to sync its cache.
+			time.Sleep(artifactoryTTL)
+			return
 		}
 		time.Sleep(pollInterval)
 	}
-	t.Logf("waitForProjectInArtifactory: project %q did not become fully visible within %s; proceeding anyway", projectKey, timeout)
+	t.Logf("waitForProjectInArtifactory: project %q not visible in Access within %s; proceeding anyway", projectKey, accessTimeout)
 }

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -1778,7 +1778,7 @@ func waitForProjectInArtifactory(t *testing.T, projectKey string) {
 	const (
 		accessTimeout  = 30 * time.Second
 		pollInterval   = 500 * time.Millisecond
-		artifactoryTTL = 5 * time.Second
+		artifactoryTTL = 30 * time.Second
 	)
 	client, err := httpclient.ClientBuilder().Build()
 	if !assert.NoError(t, err) {

--- a/pnpm_test.go
+++ b/pnpm_test.go
@@ -898,22 +898,17 @@ func TestPnpmBuildPublishWithCIVcsProps(t *testing.T) {
 func TestPnpmInstallAndPublishWithProject(t *testing.T) {
 	initPnpmTest(t)
 
-	// Create Access service manager and project before deferring cleanPnpmTest,
-	// so that t.Skipf doesn't trigger cleanup asserts that override the skip status.
 	accessManager, err := utils.CreateAccessServiceManager(serverDetails, false)
 	if err != nil {
 		t.Skipf("Skipping project test - cannot create access manager: %v", err)
 	}
 
-	// Try creating project first to verify access works before deferring any cleanup
 	projectParams := accessServices.ProjectParams{
 		ProjectDetails: accessServices.Project{
 			DisplayName: "pnpm-project-test " + tests.ProjectKey,
 			ProjectKey:  tests.ProjectKey,
 		},
 	}
-	// Create project — silently reuse if it already exists to avoid cache poisoning
-	// from delete+recreate on re-runs.
 	if err = accessManager.CreateProject(projectParams); err != nil && !strings.Contains(err.Error(), "already exists") {
 		t.Skipf("Skipping project test - cannot create project: %v", err)
 	}
@@ -925,7 +920,6 @@ func TestPnpmInstallAndPublishWithProject(t *testing.T) {
 		_ = accessManager.DeleteProject(tests.ProjectKey)
 	}()
 
-	// Assign npm repos to the project
 	err = accessManager.AssignRepoToProject(tests.NpmRepo, tests.ProjectKey, true)
 	assert.NoError(t, err)
 	err = accessManager.AssignRepoToProject(tests.NpmRemoteRepo, tests.ProjectKey, true)
@@ -941,38 +935,30 @@ func TestPnpmInstallAndPublishWithProject(t *testing.T) {
 	buildName := tests.PnpmBuildName + "-project"
 	buildNumber := "800"
 
-	// Clean old build
 	inttestutils.DeleteBuild(serverDetails.ArtifactoryUrl, buildName, artHttpDetails)
 	defer inttestutils.DeleteBuild(serverDetails.ArtifactoryUrl, buildName, artHttpDetails)
 
-	// Setup pnpm project
 	pnpmProjectPath := createPnpmProject(t, "pnpmproject")
 	projectDir := filepath.Dir(pnpmProjectPath)
 	prepareArtifactoryForPnpmBuild(t, projectDir)
-
 	clientTestUtils.ChangeDirAndAssert(t, projectDir)
 
-	// Run pnpm install with --project flag
 	runJfrogCli(t, "pnpm", "install", "--store-dir="+tempCacheDirPath,
 		"--build-name="+buildName, "--build-number="+buildNumber,
 		"--project="+tests.ProjectKey)
 
-	// Run pnpm publish with --project flag
 	cleanupAuth := setupPnpmPublishAuth(t, tests.NpmRepo)
 	defer cleanupAuth()
 	runJfrogCli(t, "pnpm", "publish", "--no-git-checks",
 		"--build-name="+buildName, "--build-number="+buildNumber,
 		"--project="+tests.ProjectKey)
 
-	// Publish build info with --project flag — retry on Artifactory project cache lag
 	assert.NoError(t, retryOnProjectNotFound(func() error {
 		return artifactoryCli.Exec("bp", buildName, buildNumber, "--project="+tests.ProjectKey)
 	}))
 
-	// Restore working directory
 	clientTestUtils.ChangeDirAndAssert(t, wd)
 
-	// Get the published build info with project key
 	servicesManager, err := utils.CreateServiceManager(serverDetails, -1, 0, false)
 	assert.NoError(t, err)
 	params := artServices.NewBuildInfoParams()
@@ -984,7 +970,6 @@ func TestPnpmInstallAndPublishWithProject(t *testing.T) {
 	assert.True(t, found, "Build info was not found for project %s", tests.ProjectKey)
 
 	bi := publishedBuildInfo.BuildInfo
-	// pnpm install + publish on the same build should produce 1 module with both deps and artifacts
 	if assert.NotEmpty(t, bi.Modules, "Build info should contain modules") {
 		assert.NotEmpty(t, bi.Modules[0].Dependencies, "Module should have dependencies from pnpm install")
 		assert.NotEmpty(t, bi.Modules[0].Artifacts, "Module should have artifacts from pnpm publish")

--- a/pnpm_test.go
+++ b/pnpm_test.go
@@ -912,9 +912,9 @@ func TestPnpmInstallAndPublishWithProject(t *testing.T) {
 			ProjectKey:  tests.ProjectKey,
 		},
 	}
-	// First delete if exists, ignoring errors since access might not support it
-	_ = accessManager.DeleteProject(tests.ProjectKey)
-	if err = accessManager.CreateProject(projectParams); err != nil {
+	// Create project — silently reuse if it already exists to avoid cache poisoning
+	// from delete+recreate on re-runs.
+	if err = accessManager.CreateProject(projectParams); err != nil && !strings.Contains(err.Error(), "already exists") {
 		t.Skipf("Skipping project test - cannot create project: %v", err)
 	}
 
@@ -964,8 +964,10 @@ func TestPnpmInstallAndPublishWithProject(t *testing.T) {
 		"--build-name="+buildName, "--build-number="+buildNumber,
 		"--project="+tests.ProjectKey)
 
-	// Publish build info with --project flag
-	assert.NoError(t, artifactoryCli.Exec("bp", buildName, buildNumber, "--project="+tests.ProjectKey))
+	// Publish build info with --project flag — retry on Artifactory project cache lag
+	assert.NoError(t, retryOnProjectNotFound(func() error {
+		return artifactoryCli.Exec("bp", buildName, buildNumber, "--project="+tests.ProjectKey)
+	}))
 
 	// Restore working directory
 	clientTestUtils.ChangeDirAndAssert(t, wd)

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -540,10 +540,13 @@ func validateCsvConflicts(t *testing.T, csvPath string, projectsSupported bool) 
 func createTestProject(t *testing.T) func() error {
 	accessManager, err := rtUtils.CreateAccessServiceManager(serverDetails, false)
 	assert.NoError(t, err)
-	// Delete the project if already exists
-	deleteProjectIfExists(t, accessManager, tests.ProjectKey)
 
-	// Create new project
+	// Do NOT delete the project before creating it. Project keys are unique per test-suite
+	// run (timestamp-based), so pre-emptive deletion only occurs on gotestsum re-runs when
+	// the previous attempt left the project behind. Deleting and immediately recreating the
+	// same key poisons Artifactory's internal project cache with a "not found" entry that
+	// takes minutes to expire on some HA nodes, causing all subsequent project-scoped
+	// operations to fail with 400 "Project was not found" even after retries.
 	adminPrivileges := accessServices.AdminPrivileges{
 		ManageMembers:   utils.Pointer(false),
 		ManageResources: utils.Pointer(false),
@@ -558,12 +561,14 @@ func createTestProject(t *testing.T) func() error {
 		ProjectKey:        tests.ProjectKey,
 	}
 
-	if assert.NoError(t, accessManager.CreateProject(accessServices.ProjectParams{ProjectDetails: projectDetails})) {
-		return func() error {
-			return accessManager.DeleteProject(tests.ProjectKey)
-		}
+	createErr := accessManager.CreateProject(accessServices.ProjectParams{ProjectDetails: projectDetails})
+	if createErr != nil && !strings.Contains(createErr.Error(), "already exists") {
+		assert.NoError(t, createErr)
+		return nil
 	}
-	return nil
+	return func() error {
+		return accessManager.DeleteProject(tests.ProjectKey)
+	}
 }
 
 func updateProjectParams(t *testing.T, projectParams *accessServices.Project, targetAccessManager *access.AccessServicesManager) {

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -559,7 +559,6 @@ func createTestProject(t *testing.T) func() error {
 	}
 
 	if assert.NoError(t, accessManager.CreateProject(accessServices.ProjectParams{ProjectDetails: projectDetails})) {
-		waitForProjectInArtifactory(t, tests.ProjectKey)
 		return func() error {
 			return accessManager.DeleteProject(tests.ProjectKey)
 		}

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -559,6 +559,7 @@ func createTestProject(t *testing.T) func() error {
 	}
 
 	if assert.NoError(t, accessManager.CreateProject(accessServices.ProjectParams{ProjectDetails: projectDetails})) {
+		waitForProjectInArtifactory(t, tests.ProjectKey)
 		return func() error {
 			return accessManager.DeleteProject(tests.ProjectKey)
 		}

--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -88,6 +88,28 @@ var (
 	timestampAdded            bool
 )
 
+// nonProjectKeyCharsRegex matches any character that isn't allowed in an Artifactory
+// project key (project keys allow only lowercase alphanumeric characters and hyphens).
+// We use this to sanitize the --ci.runId value before splicing it into resource names
+// whose format is constrained (project keys, GPG keypair names, etc.). Project-key
+// charset is a strict subset of the GPG keypair charset, so a single sanitization is
+// safe for both.
+var nonProjectKeyCharsRegex = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// SanitizedCiRunId returns the --ci.runId flag value lowercased with any characters
+// outside [a-z0-9-] collapsed to a single hyphen and surrounding hyphens trimmed.
+// Returns "" if the flag wasn't set. Callers that need a per-runId suffix on
+// resources whose name format is constrained (e.g. Artifactory project keys, GPG
+// keypair names) should use this so concurrent runs against a shared JPD don't
+// clobber each other.
+func SanitizedCiRunId() string {
+	if ciRunId == nil || *ciRunId == "" {
+		return ""
+	}
+	sanitized := nonProjectKeyCharsRegex.ReplaceAllString(strings.ToLower(*ciRunId), "-")
+	return strings.Trim(sanitized, "-")
+}
+
 func init() {
 	JfrogUrl = flag.String("jfrog.url", "http://localhost:8081/", "JFrog platform url")
 	JfrogUser = flag.String("jfrog.user", "admin", "JFrog platform  username")
@@ -641,7 +663,25 @@ func AddTimestampToGlobalVars() {
 	Password2 += uniqueSuffix + strconv.FormatFloat(randomSequence.Float64(), 'f', 2, 32)
 
 	// Projects
-	ProjectKey += timestamp[len(timestamp)-7:]
+	// Artifactory project keys must be 2-32 lowercase alphanumeric or hyphen
+	// characters and must start with a letter. We always include the sanitized
+	// --ci.runId (when set) so that concurrent runs against a shared JPD don't
+	// clobber each other's project — createTestProject calls
+	// deleteProjectIfExists(tests.ProjectKey) unconditionally, which means a
+	// colliding key from another concurrent suite will silently delete the
+	// project (and every release bundle inside it) out from under us.
+	projectSuffix := timestamp
+	if sanitizedRunId := SanitizedCiRunId(); sanitizedRunId != "" {
+		projectSuffix = sanitizedRunId + "-" + projectSuffix
+	}
+	// ProjectKey starts as "prj" (3 chars), and the total must be <= 32. Trim
+	// from the front so the trailing timestamp (used for visual debuggability)
+	// is preserved and we don't end up with a key that starts with a hyphen.
+	const maxProjectKeyLen = 32
+	if maxSuffixLen := maxProjectKeyLen - len(ProjectKey); len(projectSuffix) > maxSuffixLen {
+		projectSuffix = strings.TrimLeft(projectSuffix[len(projectSuffix)-maxSuffixLen:], "-")
+	}
+	ProjectKey += projectSuffix
 
 	timestampAdded = true
 }


### PR DESCRIPTION
The test-only ProjectKey was suffixed with only the last 7 digits of the unix timestamp, so two test runs starting within the same calendar second on a shared JPD produced byte-identical keys (e.g. "prj1777802"). Because createTestProject() calls deleteProjectIfExists(tests.ProjectKey) unconditionally before creating the project, one suite would silently nuke another concurrent suite's project (and every release bundle inside it), showing up as flaky "not found" failures in lifecycle and artifactory project tests on shared JFrog instances.

Splice the sanitized --ci.runId into the key so concurrent runs get isolated keys (e.g. "prjlinux-lifecycle-1777802"), while still respecting the 2-32 lowercase-alphanumeric-hyphen project-key format and the "starts with a letter" rule. A new SanitizedCiRunId() helper exposes the runId in a charset-safe form for any future callers that need the same.

No behavior change when --ci.runId is unset (local single-suite runs and upstream workflows that bootstrap a fresh JPD per job).

- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
