### PR TITLE
Add timestamp suffix to UvBuildName for test isolation

### DIFF
--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -618,6 +618,7 @@ func AddTimestampToGlobalVars() {
 	PipBuildName += uniqueSuffix
 	PipenvBuildName += uniqueSuffix
 	PoetryBuildName += uniqueSuffix
+	UvBuildName += uniqueSuffix
 	ConanBuildName += uniqueSuffix
 	HelmBuildName += uniqueSuffix
 	HuggingFaceBuildName += uniqueSuffix


### PR DESCRIPTION
## Problem

`UvBuildName` is missing from `AddTimestampToGlobalVars()` in `utils/tests/utils.go`. Every other package manager's build name (`NpmBuildName`, `ConanBuildName`, `PoetryBuildName`, `HuggingFaceBuildName`, …) receives the unique `-<runId>-<timestamp>` suffix, but `UvBuildName` was left out, so it stays the literal `cli-uv-build` across all runs — even though the UV repositories (`UvLocalRepo`, `UvRemoteRepo`, `UvVirtualRepo`) are correctly suffixed.

This is invisible in CI here because each CI job runs against its own ephemeral local Artifactory. But when multiple UV test runs execute **concurrently against a shared Artifactory instance**, they all publish to and delete the **same build** `cli-uv-build/1`:

1. Run A: `jf rt bp` publishes `cli-uv-build/1` ✅
2. Run B: `cleanUvTest` / `initUvTest` → `DeleteBuild(cli-uv-build)` deletes it
3. Run A: `tests.GetBuildInfo(...)` returns `found=false`
4. Run A fails: `build info not found — was jf rt bp successful?`

The failure is intermittent and depends purely on the interleaving of concurrent runs' cleanup vs. query.

## Fix

Add `UvBuildName += uniqueSuffix` alongside the other build names, so each run's build name is unique and isolated — matching how every other PM is already handled.

## Testing

- `go vet ./utils/tests/` passes.
- One-line change, consistent with the 20+ sibling lines in the same function.