### PR TITLE
Fix/latest release for hf breaks cli

### DIFF
--- a/.github/workflows/huggingfaceTests.yml
+++ b/.github/workflows/huggingfaceTests.yml
@@ -64,7 +64,10 @@ jobs:
       - name: Install HuggingFace Library
         if: matrix.os.name != 'macos'
         run: |
-          pip install huggingface_hub
+          # Pin to 1.19.0: huggingface_hub 1.20.0 made RepoUrl parse the commit
+          # response's commitUrl field strictly as an hf:// URI (PR #4324), which
+          # breaks against Artifactory's placeholder commitUrl value.
+          pip install "huggingface_hub==1.19.0"
         shell: bash
 
       - name: Debug macOS Environment and Set Timeout

--- a/scripts/setup-test-deps.sh
+++ b/scripts/setup-test-deps.sh
@@ -155,7 +155,7 @@ case "${SUITE}" in
     ;;
   huggingface)
     install_python 3.11
-    pip install huggingface_hub
+    pip install "huggingface_hub==1.19.0"
     ;;
   distribution)
     # Go-only (uses platform secrets, not local RT)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
