### PR TITLE
Add timestamp suffix to Nix repos and build name for test isolation

### DIFF
--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -587,6 +587,9 @@ func AddTimestampToGlobalVars() {
 	UvLocalRepo += uniqueSuffix
 	UvRemoteRepo += uniqueSuffix
 	UvVirtualRepo += uniqueSuffix
+	NixLocalRepo += uniqueSuffix
+	NixRemoteRepo += uniqueSuffix
+	NixVirtualRepo += uniqueSuffix
 	ConanLocalRepo += uniqueSuffix
 	ConanRemoteRepo += uniqueSuffix
 	ConanVirtualRepo += uniqueSuffix
@@ -619,6 +622,7 @@ func AddTimestampToGlobalVars() {
 	PipenvBuildName += uniqueSuffix
 	PoetryBuildName += uniqueSuffix
 	UvBuildName += uniqueSuffix
+	NixBuildName += uniqueSuffix
 	ConanBuildName += uniqueSuffix
 	HelmBuildName += uniqueSuffix
 	HuggingFaceBuildName += uniqueSuffix


### PR DESCRIPTION
## Problem

`NixLocalRepo`, `NixRemoteRepo`, `NixVirtualRepo` and `NixBuildName` are missing from `AddTimestampToGlobalVars()` in `utils/tests/utils.go`. Every other package manager's repositories and build name receive the unique `-<runId>-<timestamp>` suffix, but the Nix ones stay literal (`cli-nix-local`, `cli-nix-remote`, `cli-nix-virtual`, `cli-nix-build`).

This is invisible in this repo's CI because each job runs against its own ephemeral local Artifactory. But when multiple Nix test runs execute **concurrently against a shared Artifactory instance**, they all create and clean up the *same* repositories:

1. Run A: `InitBuildToolsTests` → `createRequiredRepos()` creates `cli-nix-virtual`
2. Run B: `InitBuildToolsTests` → `cleanUpOldRepositories()` deletes `cli-nix-virtual`
3. Run A: `initNixTest` → `isRepoExist(cli-nix-virtual)` → false → `require.True` fails with **"Nix test virtual repository doesn't exist."**

Observed: 14 of 15 concurrent Nix runs failed this way; the repos are created unsuffixed and then deleted out from under each other.

## Fix

Add the four Nix globals to `AddTimestampToGlobalVars()` so each run's repositories and build name are unique and isolated — matching how every other package manager is already handled (and mirroring the earlier `UvBuildName` fix).

## Testing

- `go vet ./utils/tests/` passes.
- Four-line change, consistent with the surrounding lines in the same function.