### PR TITLE
Re-enable Evidence and Ghost Frog test workflows

### DIFF
--- a/.github/workflows/evidenceTests.yml
+++ b/.github/workflows/evidenceTests.yml
@@ -6,9 +6,6 @@ on:
 jobs:
   Evidence-Tests:
     name: Evidence tests (${{ matrix.os }})
-    # TODO: Evidence tests are temporarily disabled due to test failures caused by the Evidence team's dependencies.
-    # Re-enable once the Evidence team resolves the underlying issues.
-    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ghostFrogTests.yml
+++ b/.github/workflows/ghostFrogTests.yml
@@ -6,9 +6,6 @@ on:
 jobs:
   Ghost-Frog-Tests:
     name: Ghost Frog tests (${{ matrix.os.name }})
-    # TODO: Ghost Frog tests are temporarily disabled due to failures caused by missing --test.ghostFrog flag definition.
-    # Re-enable once the Ghost Frog team fixes the test infrastructure.
-    if: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---

Removes the `if: false` guards (and their TODO comments) from `evidenceTests.yml` and `ghostFrogTests.yml` to re-enable both CI suites.