### PR TITLE
fix: bump Go toolchain to 1.26.4 (CVE-2026-42504 / GO-2026-5038)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jfrog/jfrog-cli
 
-go 1.26.3
+go 1.26.4
 
 replace (
 	// Should not be updated to 0.11.0+ due to default spec version change (1.6 -> 1.7, https://github.com/CycloneDX/cyclonedx-go/pull/257)


### PR DESCRIPTION
## What

Bumps the Go toolchain version in `go.mod` from `1.26.3` to `1.26.4`.

## Why

Go 1.26.3 is vulnerable to CVE-2026-42504 ([GO-2026-5038](https://pkg.go.dev/vuln/GO-2026-5038)) — a denial-of-service in `mime.WordDecoder.DecodeHeader`. The fix was released in Go 1.26.4 on 2026-06-02.

Closes #3577

## Change

```diff
-go 1.26.3
+go 1.26.4
```

## Verification

```
$ go build -o /tmp/jfrog-test .
$ go version /tmp/jfrog-test
/tmp/jfrog-test: go1.26.4
$ go vet ./...
# (clean)
```

## References

- https://pkg.go.dev/vuln/GO-2026-5038
- https://go.dev/dl/#go1.26.4