### PR TITLE
Fix ghost frog CI: remove go from package-alias-tools

### DIFF
--- a/.github/workflows/ghostFrogTests.yml
+++ b/.github/workflows/ghostFrogTests.yml
@@ -92,7 +92,7 @@ jobs:
           download-repository: ghost-frog-cli
           version: ${{ env.JF_CLI_VERSION }}
           enable-package-alias: true
-          package-alias-tools: npm,mvn,go,pip
+          package-alias-tools: npm,mvn,pip
         env:
           JF_URL: ${{ secrets.PLATFORM_URL }}
           JF_ACCESS_TOKEN: ${{ secrets.PLATFORM_ADMIN_TOKEN }}


### PR DESCRIPTION
The `go` alias installed by `setup-jfrog-cli@package-alias` was intercepting the `go test` command in the "Run Ghost Frog tests" step. With `JFROG_CLI_GHOST_FROG=true` set at the step level, the ghost frog shim transformed `go test -v ...` into `jf go test -v ...`, which failed with "no config file was found". Removing `go` from `package-alias-tools` fixes this — the test suite already covers the `go` alias internally by installing it in an isolated temp dir.

- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---