### PR TITLE
RTECO-1560 - Skip agentplugins tests

### DIFF
--- a/agent_plugins_test.go
+++ b/agent_plugins_test.go
@@ -43,9 +43,7 @@ func CleanAgentPluginsTests() {
 }
 
 func initAgentPluginsTest(t *testing.T) {
-	if !*tests.TestAgentPlugins {
-		t.Skip("Skipping agent plugins tests. To run add '--test.agentPlugins'.")
-	}
+	t.Skip("Agent plugins e2e tests are disabled")
 	createJfrogHomeConfig(t, false)
 	require.True(t, isRepoExist(tests.AgentPluginsLocalRepo), "agent plugins local repo does not exist: "+tests.AgentPluginsLocalRepo)
 	// The test Artifactory instance has no evidence/One-Model service configured.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---

### Summary:

Skipping agent plugin tests as implementation structure is changed
