### PR TITLE
Hide survey link when invoked by an AI agent

### DIFF
--- a/docs/common/env.go
+++ b/docs/common/env.go
@@ -110,7 +110,8 @@ const (
 
 	JfrogCliHideSurvey = `    JFROG_CLI_HIDE_SURVEY
 		[Default: false]
-		Set to true to hide the survey link that appears after successful command execution.`
+		Set to true to hide the survey link that appears after successful command execution.
+		The survey is also automatically hidden when JFrog CLI is invoked by a detected AI agent.`
 )
 
 var (

--- a/main_test.go
+++ b/main_test.go
@@ -451,8 +451,34 @@ func TestDockerScanHelp(t *testing.T) {
 	assert.Contains(t, string(content), "jfrog docker scan - Scan local docker image using the docker client and Xray.")
 }
 
+// agentDetectorEnvVars lists every env var jfrog-cli-core's agent detector consults
+// (see ExecutionContext in jfrog-cli-core/common/commands). Tests clear these so
+// survey-visibility assertions are deterministic regardless of the shell running
+// `go test` (e.g. running inside Claude Code, Cursor, etc.).
+var agentDetectorEnvVars = []string{
+	"CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT",
+	"GEMINI_CLI",
+	"GOOSE_TERMINAL",
+	"CURSOR_AGENT", "CURSOR_CLI", "CURSOR_TRACE_ID",
+	"COPILOT_CLI",
+	"KILO_IPC_SOCKET_PATH", "KILO_SERVER_PASSWORD",
+	"ROO_CODE_IPC_SOCKET_PATH",
+	"CODEX_CI",
+	"AGENT",
+}
+
+func clearAgentEnvVarsForTest(t *testing.T) {
+	t.Helper()
+	for _, e := range agentDetectorEnvVars {
+		t.Setenv(e, "")
+	}
+	commands.ResetExecutionContextForTest()
+	t.Cleanup(commands.ResetExecutionContextForTest)
+}
+
 func TestSurvey_DisplayedOnHelp(t *testing.T) {
 	t.Setenv("CI", "false")
+	clearAgentEnvVarsForTest(t)
 	jfrogCli := coreTests.NewJfrogCli(execMain, "jfrog", "")
 	_, contentErr, err := tests.GetCmdOutput(t, jfrogCli, "help")
 	require.NoError(t, err)
@@ -461,6 +487,18 @@ func TestSurvey_DisplayedOnHelp(t *testing.T) {
 
 func TestSurvey_NotDisplayedOnHelpCI(t *testing.T) {
 	t.Setenv("CI", "true")
+	jfrogCli := coreTests.NewJfrogCli(execMain, "jfrog", "")
+	_, contentErr, err := tests.GetCmdOutput(t, jfrogCli, "help")
+	require.NoError(t, err)
+	assert.NotContains(t, string(contentErr), "https://") // not doing more check as url can change
+}
+
+func TestSurvey_NotDisplayedOnHelpAgent(t *testing.T) {
+	t.Setenv("CI", "false")
+	clearAgentEnvVarsForTest(t)
+	t.Setenv("CLAUDECODE", "true")
+	commands.ResetExecutionContextForTest()
+
 	jfrogCli := coreTests.NewJfrogCli(execMain, "jfrog", "")
 	_, contentErr, err := tests.GetCmdOutput(t, jfrogCli, "help")
 	require.NoError(t, err)

--- a/utils/cliutils/utils.go
+++ b/utils/cliutils/utils.go
@@ -777,8 +777,9 @@ func GetJFrogApplicationKey(c *cli.Context) string {
 	return applicationKey
 }
 
-// ShouldHideSurveyLink checks if the survey should be hidden based on the JFROG_CLI_HIDE_SURVEY and CI environment variables
+// ShouldHideSurveyLink checks if the survey should be hidden based on the JFROG_CLI_HIDE_SURVEY
+// and CI environment variables, or when the CLI is invoked by an AI agent.
 // Returns true if the survey should be hidden, false otherwise
 func ShouldHideSurveyLink() bool {
-	return getCiValue() || os.Getenv(JfrogCliHideSurvey) == "true"
+	return getCiValue() || os.Getenv(JfrogCliHideSurvey) == "true" || commonCommands.DetectExecutionContext().IsAgent
 }

--- a/utils/cliutils/utils_test.go
+++ b/utils/cliutils/utils_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	biutils "github.com/jfrog/build-info-go/utils"
+	corecommands "github.com/jfrog/jfrog-cli-core/v2/common/commands"
 	configtests "github.com/jfrog/jfrog-cli-core/v2/utils/config/tests"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	clientTestUtils "github.com/jfrog/jfrog-client-go/utils/tests"
@@ -385,6 +386,31 @@ func (t *redirectingTransport) RoundTrip(req *http.Request) (*http.Response, err
 	return t.baseTransport.RoundTrip(req)
 }
 
+// agentDetectorEnvVars lists every env var jfrog-cli-core's agent detector consults
+// (see ExecutionContext in jfrog-cli-core/common/commands). Tests clear these so
+// ShouldHideSurveyLink's agent check is deterministic regardless of the shell
+// running `go test` (e.g. running inside Claude Code, Cursor, etc.).
+var agentDetectorEnvVars = []string{
+	"CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT",
+	"GEMINI_CLI",
+	"GOOSE_TERMINAL",
+	"CURSOR_AGENT", "CURSOR_CLI", "CURSOR_TRACE_ID",
+	"COPILOT_CLI",
+	"KILO_IPC_SOCKET_PATH", "KILO_SERVER_PASSWORD",
+	"ROO_CODE_IPC_SOCKET_PATH",
+	"CODEX_CI",
+	"AGENT",
+}
+
+func clearAgentEnvVarsForTest(t *testing.T) {
+	t.Helper()
+	for _, e := range agentDetectorEnvVars {
+		t.Setenv(e, "")
+	}
+	corecommands.ResetExecutionContextForTest()
+	t.Cleanup(corecommands.ResetExecutionContextForTest)
+}
+
 // TestGetHasDisplayedSurveyLink tests the survey link environment variable check with parametrized test cases
 func TestGetHasDisplayedSurveyLink(t *testing.T) {
 	testCases := []struct {
@@ -411,6 +437,7 @@ func TestGetHasDisplayedSurveyLink(t *testing.T) {
 	t.Setenv(coreutils.CI, "")
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			clearAgentEnvVarsForTest(t)
 			t.Setenv(JfrogCliHideSurvey, tc.envValue)
 
 			shouldHide := ShouldHideSurveyLink()
@@ -428,6 +455,16 @@ func TestSettingCIFlagRemovesSurvey(t *testing.T) {
 	t.Setenv(coreutils.CI, "true")
 	shouldHide := ShouldHideSurveyLink()
 	assert.True(t, shouldHide, "Expected survey to be hidden when CI flag is set")
+}
+
+func TestSurveyHiddenForAgent(t *testing.T) {
+	t.Setenv(coreutils.CI, "")
+	t.Setenv(JfrogCliHideSurvey, "")
+	clearAgentEnvVarsForTest(t)
+	t.Setenv("CLAUDECODE", "true")
+	corecommands.ResetExecutionContextForTest()
+
+	assert.True(t, ShouldHideSurveyLink(), "Expected survey to be hidden when invoked by an agent")
 }
 
 func TestLoginCommandFlagsIncludeServerId(t *testing.T) {


### PR DESCRIPTION
After running `jf help`, JFrog CLI prints a survey link to stderr. This is already suppressed in CI and via `JFROG_CLI_HIDE_SURVEY=true`, but it was still shown when the CLI is driven by an AI coding agent (Claude Code, Cursor, Gemini CLI, etc.), which can't act on the link anyway.

This extends `ShouldHideSurveyLink()` to also hide the survey when `jfrog-cli-core`'s `ExecutionContext.IsAgent` detects an agent invocation, reusing the detection already added upstream and already used elsewhere in this repo (trace-ID propagation) and in `jfrog-cli-core` itself (AI-flavored help text).

- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
