### PR TITLE
Clarify JFROG_CLI_RELEASES_REPO env var documentation

### DIFF
--- a/docs/common/env.go
+++ b/docs/common/env.go
@@ -65,7 +65,9 @@ const (
 		Configured Artifactory repository name from which to download the jar needed by the mvn/gradle command.
 		This environment variable's value format should be <server ID configured by the 'jf c add' command>/<repo name>.
 
-		The repository should proxy https://releases.jfrog.io.
+		The repository must be a remote generic repository that proxies the root of https://releases.jfrog.io (not a sub-path).
+		JFrog CLI automatically appends 'artifactory/oss-release-local/<path>' to the download URL, so the resulting request is:
+		    <artifactory-url>/<repo name>/artifactory/oss-release-local/<path>
 		This environment variable is used by the 'jf mvn' and 'jf gradle' commands, and also by the 'jf audit' command, when used for maven or gradle projects.`
 
 	JfrogCliDependenciesDir = `	JFROG_CLI_DEPENDENCIES_DIR


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---

The env var docs only stated that the remote should proxy https://releases.jfrog.io, without mentioning that the CLI appends 'artifactory/oss-release-local/<path>' to the request URL. This caused confusion at our end configuring a remote pointing at a sub-path or a non-standard upstream. Spell out the exact URL that gets built and the root-proxy requirement. 