### PR TITLE
feat: create package alias for helm and updated integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,7 @@ go test -v github.com/jfrog/jfrog-cli -test.gradle [flags]
 ##### Requirements
 
 - Make sure the `RTLIC` environment variable is configured with a valid license.
-- You can start an Artifactory container by running the `startArtifactory.sh` script located in the `testdata/docker/artifactory` directory. Before running the tests, wait for Artifactory to finish booting up in the container.
+- You can start an Artifactory container by running the `start.sh` script located in the `testdata/docker/artifactory` directory. Before running the tests, wait for Artifactory to finish booting up in the container.
 
 | Flag                      | Description                         |
 | ------------------------- | ----------------------------------- |

--- a/ghostfrog_test.go
+++ b/ghostfrog_test.go
@@ -468,10 +468,11 @@ func TestGhostFrogHighFanOutStress(t *testing.T) {
 // E2E-030: setup-jfrog-cli native integration
 func TestGhostFrogSetupJFrogCLINativeIntegration(t *testing.T) {
 	homeDir := initGhostFrogTest(t)
-	installAliases(t, "npm,mvn,go,pip")
+	tools := []string{"npm", "mvn", "go", "pip", "helm"}
+	installAliases(t, strings.Join(tools, ","))
 
 	binDir := aliasBinDir(homeDir)
-	for _, tool := range []string{"npm", "mvn", "go", "pip"} {
+	for _, tool := range tools {
 		_, err := os.Stat(aliasToolPath(homeDir, tool))
 		require.NoError(t, err, "alias for %s should exist", tool)
 	}
@@ -484,7 +485,7 @@ func TestGhostFrogSetupJFrogCLINativeIntegration(t *testing.T) {
 	// Verify alias dir is populated
 	entries, err := os.ReadDir(binDir)
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, len(entries), 4, "should have at least 4 alias entries")
+	assert.GreaterOrEqual(t, len(entries), len(tools), fmt.Sprintf("should have at least %d alias entries", len(tools)))
 }
 
 // E2E-031: Auto build-info publish (requires Artifactory)

--- a/helm_test.go
+++ b/helm_test.go
@@ -218,9 +218,14 @@ func TestHelmPackageWithBuildInfo(t *testing.T) {
 	err = helmCmd.Run()
 	require.NoError(t, err, "helm dependency update should succeed")
 
+	chartArchiveDestinationDir := filepath.Join(chartDir, "target")
+	err = os.MkdirAll(chartArchiveDestinationDir, 0o755)
+	require.NoError(t, err, "Unable to create target directory for chart archive")
+
 	jfrogCli := coreTests.NewJfrogCli(execMain, "jfrog", "")
 	args := []string{
 		"helm", "package", ".",
+		"--destination", chartArchiveDestinationDir,
 		"--build-name=" + buildName,
 		"--build-number=" + buildNumber,
 	}

--- a/packagealias/packagealias.go
+++ b/packagealias/packagealias.go
@@ -33,6 +33,7 @@ var SupportedTools = []string{
 	"docker",
 	"gem",
 	"bundle",
+	"helm",
 }
 
 // AliasMode represents how a tool should be handled


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
1. Allows intercepting helm CLI calls to be intercepted by jfrog CLI.

      We use helm-maven-plugin in our builds, which under the hood executes
  `helm dependency`, `helm package` and `helm push` commands. Without this
  feature we only have a dirty workaround to create a shim which mimics
  package aliasing feature in order to capture helm chart in a build-info.
  This allows us to keep using `helm-maven-plugin` and indirectly invoke
  `jf helm` to record the build-info along with maven artifacts. **Feature was originally requested as a jfrog support ticket 427008**

2. updated integration test for `jf helm package`

    relates to https://github.com/jfrog/jfrog-cli-artifactory/pull/501