### PR TITLE
Add OpenAPI spec embed for jf api operation discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ help:
 	@echo "  clean                    - Clean build artifacts"
 	@echo "  test                     - Run tests"
 	@echo "  build                    - Build the project"
+	@echo "  stub                     - Build jf with the OSS-default stub OpenAPI spec bundle"
+	@echo "  full                     - Build jf with the full OpenAPI spec bundle (requires docs/api-spec/full/ to be populated)"
 
 # Update all JFrog dependencies
 update-all: update-build-info-go update-client-go update-gofrog update-core update-artifactory update-platform-services update-security update-apptrust update-evidence
@@ -94,3 +96,12 @@ test:
 build:
 	@echo "Building project..."
 	@go build ./...
+
+# Build jf with the OSS-default stub OpenAPI spec bundle (docs/api-spec/stub/)
+stub:
+	@./build/build.sh jf
+
+# Build jf with the full OpenAPI spec bundle (docs/api-spec/full/) — used by
+# JFrog's internal release pipeline after it populates docs/api-spec/full/
+full:
+	@JF_BUILD_TAGS=full ./build/build.sh jf

--- a/build/build.sh
+++ b/build/build.sh
@@ -8,5 +8,5 @@ if [ $# -eq 0 ]
 	exe_name="$1"
 fi
 
-CGO_ENABLED=0 go build -o "$exe_name" -ldflags '-w -extldflags "-static"' main.go
+CGO_ENABLED=0 go build -o "$exe_name" -tags "${JF_BUILD_TAGS:-}" -ldflags '-w -extldflags "-static"' main.go
 echo "The $exe_name executable was successfully created."

--- a/docs/api-spec/embed_full.go
+++ b/docs/api-spec/embed_full.go
@@ -1,0 +1,24 @@
+//go:build full
+
+package apispec
+
+import (
+	"embed"
+	"strings"
+)
+
+//go:embed full/*.yaml full/VERSION
+var specFS embed.FS
+
+const rootDir = "full"
+
+// Bundle identifies which OpenAPI spec set is embedded in this binary.
+const Bundle = "full"
+
+func specVersion() string {
+	data, err := specFS.ReadFile(rootDir + "/VERSION")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/docs/api-spec/embed_stub.go
+++ b/docs/api-spec/embed_stub.go
@@ -1,0 +1,17 @@
+//go:build !full
+
+package apispec
+
+import "embed"
+
+//go:embed stub/*.yaml
+var specFS embed.FS
+
+const rootDir = "stub"
+
+// Bundle identifies which OpenAPI spec set is embedded in this binary.
+const Bundle = "stub"
+
+func specVersion() string {
+	return ""
+}

--- a/docs/api-spec/full/.placeholder.yaml
+++ b/docs/api-spec/full/.placeholder.yaml
@@ -1,0 +1,7 @@
+# Placeholder so `-tags full` compiles in an OSS checkout before JFrog's internal
+# release job populates this directory with the real rdme-admin reference bundle.
+# A go:embed glob errors at compile time if it matches zero files, so this
+# dot-prefixed, zero-operation file keeps full/*.yaml satisfied without being
+# picked up by directory-style embeds (which exclude dot-prefixed names).
+openapi: 3.1.0
+paths: {}

--- a/docs/api-spec/parser.go
+++ b/docs/api-spec/parser.go
@@ -1,0 +1,146 @@
+// Package apispec exposes the operations declared in jfrog-cli's embedded
+// OpenAPI spec bundle (a small "stub" set by default, or the real "full" set
+// in JFrog's internal release build — see docs/api-spec/).
+package apispec
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+var httpMethods = map[string]bool{
+	"get": true, "put": true, "post": true, "delete": true,
+	"options": true, "head": true, "patch": true, "trace": true,
+}
+
+// Parameter describes a single OpenAPI operation parameter.
+type Parameter struct {
+	Name        string `yaml:"name"`
+	In          string `yaml:"in"`
+	Required    bool   `yaml:"required"`
+	Description string `yaml:"description"`
+}
+
+// Operation describes a single OpenAPI path+method operation.
+type Operation struct {
+	Method      string
+	Path        string
+	Summary     string
+	Tags        []string
+	OperationId string
+	Parameters  []Parameter
+}
+
+// Metadata describes which spec bundle is embedded in this binary.
+type Metadata struct {
+	SpecBundle  string
+	SpecVersion string
+}
+
+type rawDoc struct {
+	Paths map[string]map[string]yaml.Node `yaml:"paths"`
+}
+
+type rawOperation struct {
+	Summary     string      `yaml:"summary"`
+	OperationId string      `yaml:"operationId"`
+	Tags        []string    `yaml:"tags"`
+	Parameters  []Parameter `yaml:"parameters"`
+}
+
+var (
+	once       sync.Once
+	operations []Operation
+	parseErr   error
+)
+
+// Operations returns every operation across the embedded OpenAPI spec bundle.
+// Parsing happens once per process and the result is cached.
+func Operations() ([]Operation, error) {
+	once.Do(func() {
+		operations, parseErr = parseAll()
+	})
+	return operations, parseErr
+}
+
+// Info reports which spec bundle is embedded and, for full builds, the
+// rdme-admin commit it was fetched from.
+func Info() Metadata {
+	return Metadata{
+		SpecBundle:  Bundle,
+		SpecVersion: specVersion(),
+	}
+}
+
+// isSpecFile reports whether name is a top-level OpenAPI YAML file that should
+// be parsed. Excludes rdme-admin's per-endpoint _order.yaml nav files and any
+// dotfile (including this package's own full/.placeholder.yaml).
+func isSpecFile(name string) bool {
+	return strings.HasSuffix(name, ".yaml") && !strings.HasPrefix(name, ".") && !strings.HasPrefix(name, "_")
+}
+
+func parseAll() ([]Operation, error) {
+	entries, err := specFS.ReadDir(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("apispec: reading %s: %w", rootDir, err)
+	}
+
+	var ops []Operation
+	for _, entry := range entries {
+		if entry.IsDir() || !isSpecFile(entry.Name()) {
+			continue
+		}
+		fileOps, err := parseFile(rootDir + "/" + entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("apispec: parsing %s: %w", entry.Name(), err)
+		}
+		ops = append(ops, fileOps...)
+	}
+
+	sort.Slice(ops, func(i, j int) bool {
+		if ops[i].Path != ops[j].Path {
+			return ops[i].Path < ops[j].Path
+		}
+		return ops[i].Method < ops[j].Method
+	})
+	return ops, nil
+}
+
+func parseFile(name string) ([]Operation, error) {
+	data, err := specFS.ReadFile(name)
+	if err != nil {
+		return nil, err
+	}
+
+	var doc rawDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+
+	var ops []Operation
+	for p, methods := range doc.Paths {
+		for method, node := range methods {
+			lower := strings.ToLower(method)
+			if !httpMethods[lower] {
+				continue
+			}
+			var op rawOperation
+			if err := node.Decode(&op); err != nil {
+				return nil, fmt.Errorf("path %s method %s: %w", p, method, err)
+			}
+			ops = append(ops, Operation{
+				Method:      strings.ToUpper(method),
+				Path:        p,
+				Summary:     op.Summary,
+				Tags:        op.Tags,
+				OperationId: op.OperationId,
+				Parameters:  op.Parameters,
+			})
+		}
+	}
+	return ops, nil
+}

--- a/docs/api-spec/parser_test.go
+++ b/docs/api-spec/parser_test.go
@@ -1,0 +1,97 @@
+//go:build !full
+
+// These tests assert exact values from the stub fixtures and don't apply to a
+// full build (whose docs/api-spec/full/ content is populated at release time).
+
+package apispec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperations_Stub(t *testing.T) {
+	ops, err := Operations()
+	require.NoError(t, err)
+	require.Len(t, ops, 10, "expected exactly the 10 trimmed real operations across the 7 stub files")
+
+	byOperationId := make(map[string]Operation, len(ops))
+	for _, op := range ops {
+		byOperationId[op.OperationId] = op
+	}
+
+	getUserList, ok := byOperationId["getUserList"]
+	require.True(t, ok, "getUserList should be present")
+	assert.Equal(t, "GET", getUserList.Method)
+	assert.Equal(t, "/access/api/v2/users", getUserList.Path)
+	assert.Equal(t, "Get User List", getUserList.Summary)
+	assert.Equal(t, []string{"Users"}, getUserList.Tags)
+	assert.Len(t, getUserList.Parameters, 10)
+
+	createUser, ok := byOperationId["createUser"]
+	require.True(t, ok, "createUser should be present")
+	assert.Equal(t, "POST", createUser.Method)
+	assert.Equal(t, "/access/api/v2/users", createUser.Path)
+
+	deleteWorker, ok := byOperationId["deleteWorker"]
+	require.True(t, ok, "deleteWorker should be present")
+	assert.Equal(t, "DELETE", deleteWorker.Method)
+	assert.Equal(t, "/worker/api/v1/workers/{workerKey}", deleteWorker.Path)
+	require.Len(t, deleteWorker.Parameters, 1)
+	assert.Equal(t, "workerKey", deleteWorker.Parameters[0].Name)
+	assert.Equal(t, "path", deleteWorker.Parameters[0].In)
+	assert.True(t, deleteWorker.Parameters[0].Required)
+
+	ping, ok := byOperationId["artifactoryPing"]
+	require.True(t, ok, "artifactoryPing should be present")
+	assert.Equal(t, []string{"Artifactory System"}, ping.Tags)
+	assert.Empty(t, ping.Parameters)
+}
+
+func TestOperations_SortedByPathThenMethod(t *testing.T) {
+	ops, err := Operations()
+	require.NoError(t, err)
+
+	for i := 1; i < len(ops); i++ {
+		prev, cur := ops[i-1], ops[i]
+		if prev.Path == cur.Path {
+			assert.LessOrEqual(t, prev.Method, cur.Method, "same path %q should be sorted by method", prev.Path)
+			continue
+		}
+		assert.Less(t, prev.Path, cur.Path, "operations should be sorted by path")
+	}
+}
+
+func TestOperations_CachedAcrossCalls(t *testing.T) {
+	first, err := Operations()
+	require.NoError(t, err)
+	second, err := Operations()
+	require.NoError(t, err)
+	assert.Same(t, &first[0], &second[0], "Operations should return the same cached backing array on repeat calls")
+}
+
+func TestInfo_Stub(t *testing.T) {
+	info := Info()
+	assert.Equal(t, "stub", info.SpecBundle)
+	assert.Empty(t, info.SpecVersion, "stub builds have no rdme-admin version")
+}
+
+func TestIsSpecFile(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"users-api.yaml", true},
+		{"artifactory-security_openapi.yaml", true},
+		{"_order.yaml", false},
+		{".placeholder.yaml", false},
+		{"VERSION", false},
+		{"ReadMe.md", false},
+		{"notes.txt", false},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, isSpecFile(tt.name), "isSpecFile(%q)", tt.name)
+	}
+}

--- a/docs/api-spec/stub/access-tokens-api.yaml
+++ b/docs/api-spec/stub/access-tokens-api.yaml
@@ -1,0 +1,106 @@
+# Trimmed excerpt of JFrog's public Platform Access Tokens API reference, kept as
+# an OSS test fixture for the jfrog-cli apispec package (JGC-525). Not the full
+# spec — see docs/api-spec/full/ (populated only in JFrog's internal release
+# build).
+openapi: 3.1.0
+info:
+  title: JFrog Platform - Access Tokens API
+  description: >
+    Manage access tokens for the JFrog Platform, including creating, refreshing,
+    listing, and revoking tokens.
+
+
+    **Authentication:** Access Tokens as bearer token in authorization header
+    (`Authorization: Bearer <token>`). Basic authentication is also supported
+    for the Create Token API when enabled in the platform configuration.
+
+
+    **Security:** Security requirements vary per operation. See individual
+    operation descriptions for details.
+  version: 1.0.0
+  contact:
+    name: JFrog Support
+servers:
+  - url: https://{jfrog_url}
+tags:
+  - name: Access Tokens
+    description: >-
+      Create, retrieve, refresh, and revoke access tokens for JFrog Platform
+      services.
+security:
+  - BearerAuth: []
+paths:
+  /access/api/v1/tokens:
+    get:
+      tags:
+        - Access Tokens
+      summary: Get Tokens
+      description: >
+        Returns token information based on the authenticated principal and
+        optional filters. Admin users can view all tokens; non-admin users can
+        only view their own tokens.
+
+
+        Reference tokens are supported from Artifactory version 7.133.8.
+
+
+        **Security:** Requires a valid token.
+      operationId: getTokens
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenListResponse'
+        '401':
+          description: Bad Credentials - Invalid credentials
+        '403':
+          description: Permission Denied - Insufficient permissions
+components:
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+      description: Basic authentication using username and password
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: Access Token as bearer token
+  schemas:
+    TokenDetails:
+      type: object
+      properties:
+        token_id:
+          type: string
+        subject:
+          type: string
+        expiry:
+          type: integer
+        issued_at:
+          type: integer
+        issuer:
+          type: string
+        description:
+          type: string
+        refreshable:
+          type: boolean
+        scope:
+          type: string
+        last_used:
+          type: integer
+          description: >
+            The Unix timestamp (in seconds) of when the token was last used.
+            Supported from Artifactory version 7.108.3 and above. Requires
+            `access_token_last_used_enabled: True` and
+            `access_token_last_used_threshold: 900` system properties to be
+            configured.
+    TokenListResponse:
+      type: object
+      properties:
+        tokens:
+          type: array
+          items:
+            $ref: '#/components/schemas/TokenDetails'
+x-readme:
+  explorer-enabled: false

--- a/docs/api-spec/stub/artifactory-system-api.yaml
+++ b/docs/api-spec/stub/artifactory-system-api.yaml
@@ -1,0 +1,119 @@
+# Trimmed excerpt of JFrog's public Platform Artifactory System API reference,
+# kept as an OSS test fixture for the jfrog-cli apispec package (JGC-525). Not the
+# full spec — see docs/api-spec/full/ (populated only in JFrog's internal release
+# build).
+openapi: 3.1.0
+info:
+  title: JFrog Platform - Artifactory System API
+  description: >
+    Artifactory system configuration APIs for the JFrog Platform.
+
+
+    **Authentication:**
+
+    - Basic authentication using username and password
+
+    - Access Tokens instead of password for basic authentication
+
+    - Access Tokens as bearer token in authorization header (Authorization:
+    Bearer <token>)
+  version: 1.0.0
+  contact:
+    name: JFrog Support
+servers:
+  - url: https://{jfrog_url}
+    description: JFrog Platform
+    variables:
+      jfrog_url:
+        default: myserver.jfrog.io
+        description: Your JFrog Platform hostname (e.g., mycompany.jfrog.io)
+tags:
+  - name: Artifactory System
+    description: Artifactory system configuration APIs.
+security:
+  - BearerAuth: []
+paths:
+  /artifactory/api/system/ping:
+    get:
+      tags:
+        - Artifactory System
+      summary: Artifactory Ping
+      description: |
+        Get a simple status response about the state of Artifactory.
+
+        **Since:** 2.3.0
+
+        **Security:** Requires a valid user (can be anonymous).
+      operationId: artifactoryPing
+      security: []
+      responses:
+        '200':
+          description: Artifactory is alive and working properly
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: OK
+        '500':
+          description: Internal Server Error
+  /artifactory/api/system/version:
+    get:
+      tags:
+        - Artifactory System
+      summary: Get Artifactory Version
+      description: >
+        Return information about the current Artifactory version, revision, and
+        currently installed Add-ons.
+
+
+        **Since:** 2.2.2
+
+
+        **Security:** Requires a valid user (can be anonymous).
+      operationId: getArtifactoryVersion
+      security: []
+      responses:
+        '200':
+          description: Artifactory version, revision, and list of installed add-ons
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                    description: Artifactory version
+                  revision:
+                    type: string
+                    description: Revision number
+                  addons:
+                    type: array
+                    items:
+                      type: string
+                    description: List of addons
+            application/vnd.org.jfrog.artifactory.system.Version+json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                  revision:
+                    type: string
+                  addons:
+                    type: array
+                    items:
+                      type: string
+        '401':
+          description: Bad Credentials - Invalid credentials
+components:
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+      description: Basic authentication using username and password
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: Access Token as bearer token
+x-readme:
+  explorer-enabled: false

--- a/docs/api-spec/stub/global-roles-api.yaml
+++ b/docs/api-spec/stub/global-roles-api.yaml
@@ -1,0 +1,96 @@
+# Trimmed excerpt of JFrog's public Platform Global Roles API reference, kept as
+# an OSS test fixture for the jfrog-cli apispec package (JGC-525). Not the full
+# spec — see docs/api-spec/full/ (populated only in JFrog's internal release
+# build).
+openapi: 3.1.0
+info:
+  title: JFrog Platform - Global Roles API
+  description: >
+    Custom global role management APIs for the JFrog Platform.
+
+
+    **Authentication:** Access Tokens as bearer token in authorization header
+    (Authorization: Bearer `<token>`)
+
+
+    **Security:** Unless otherwise specified, all APIs require admin privileges.
+  version: 1.0.0
+  contact:
+    name: JFrog Support
+servers:
+  - url: https://{jfrog_url}
+tags:
+  - name: Global Roles
+    description: >-
+      APIs for creating, editing, deleting, and listing global roles in the
+      JFrog Platform.
+security:
+  - BearerAuth: []
+paths:
+  /access/api/v1/roles:
+    get:
+      tags:
+        - Global Roles
+      summary: Get All Global Roles
+      description: |
+        Get all global roles. The response includes predefined roles and custom
+        global roles.
+
+
+        **Security:** Requires admin or Project Admin privileges.
+      operationId: getAllGlobalRoles
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GlobalRole'
+        '401':
+          description: Bad Credentials - Invalid credentials
+        '403':
+          description: Permission Denied - Insufficient permissions
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: Access Token as bearer token
+  schemas:
+    GlobalRoleType:
+      type: string
+      description: >-
+        Type for roles returned by this API. ADMIN is the Project Admin role;
+        PREDEFINED is other built-in roles (e.g. Viewer); CUSTOM_GLOBAL is a
+        user-defined global role. On PUT, the value must match the role's
+        current type (the server rejects type changes).
+      enum:
+        - ADMIN
+        - PREDEFINED
+        - CUSTOM_GLOBAL
+    GlobalRole:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Role name
+        description:
+          type: string
+          description: Role description
+        type:
+          $ref: '#/components/schemas/GlobalRoleType'
+        environments:
+          type: array
+          items:
+            type: string
+        actions:
+          type: array
+          description: >-
+            Permission actions as enum constant names (e.g. READ_REPOSITORY,
+            MANAGE_MEMBERS).
+          items:
+            type: string
+x-readme:
+  explorer-enabled: false

--- a/docs/api-spec/stub/groups-api.yaml
+++ b/docs/api-spec/stub/groups-api.yaml
@@ -1,0 +1,102 @@
+# Trimmed excerpt of JFrog's public Platform Groups API reference, kept as an
+# OSS test fixture for the jfrog-cli apispec package (JGC-525). Not the full spec —
+# see docs/api-spec/full/ (populated only in JFrog's internal release build).
+openapi: 3.1.0
+info:
+  title: JFrog Platform - Groups API
+  description: >
+    Group management APIs for the JFrog Platform.
+
+
+    **Authentication:** Access Tokens as bearer token in authorization header
+    (Authorization: Bearer <token>)
+
+
+    **Security:** Unless otherwise specified, all APIs require admin privileges.
+
+
+    **Availability:** Artifactory 7.49.3+
+  version: 1.0.0
+  contact:
+    name: JFrog Support
+servers:
+  - url: https://{jfrog_url}
+tags:
+  - name: Groups
+    description: >-
+      APIs for creating, updating, deleting, and managing JFrog Platform groups
+      and group memberships.
+security:
+  - BearerAuth: []
+paths:
+  /access/api/v2/groups/{name}:
+    get:
+      tags:
+        - Groups
+      summary: Get Group Details
+      description: |
+        Returns the group's details based on the group name.
+
+
+        **Security:** Requires admin privileges.
+      operationId: getGroupDetails
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The group name
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupDetails'
+        '400':
+          description: Bad Request - Invalid input
+        '401':
+          description: Bad Credentials - Invalid credentials
+        '403':
+          description: Permission Denied - Insufficient permissions
+        '404':
+          description: Not Found - Group not found
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: Access Token as bearer token
+  schemas:
+    GroupDetails:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The group name
+        description:
+          type: string
+          description: Group description
+        auto_join:
+          type: boolean
+          description: Whether new users auto-join this group
+        admin_privileges:
+          type: boolean
+          description: Whether group has admin privileges
+        realm:
+          type: string
+          description: The authentication realm
+        realm_attributes:
+          type: string
+          description: Realm attributes
+        external_id:
+          type: string
+          description: External ID for SCIM
+        members:
+          type: array
+          items:
+            type: string
+          description: Group members
+x-readme:
+  explorer-enabled: false

--- a/docs/api-spec/stub/permissions-api.yaml
+++ b/docs/api-spec/stub/permissions-api.yaml
@@ -1,0 +1,104 @@
+# Trimmed excerpt of JFrog's public Platform Permissions API reference, kept as an
+# OSS test fixture for the jfrog-cli apispec package (JGC-525). Not the full spec —
+# see docs/api-spec/full/ (populated only in JFrog's internal release build).
+openapi: 3.1.0
+info:
+  title: JFrog Platform - Permissions API
+  description: >
+    Permission management APIs for the JFrog Platform.
+
+
+    **Authentication:** Access Tokens as bearer token in authorization header
+    (Authorization: Bearer <token>)
+
+
+    **Security:** Unless otherwise specified, all APIs require admin privileges.
+
+
+    **Availability:** Artifactory 7.72.0+
+  version: 1.0.0
+  contact:
+    name: JFrog Support
+servers:
+  - url: https://{jfrog_url}
+tags:
+  - name: Permissions
+    description: >-
+      APIs for creating, updating, deleting, and managing JFrog Platform
+      permission targets and resources.
+security:
+  - BearerAuth: []
+paths:
+  /access/api/v2/permissions:
+    get:
+      tags:
+        - Permissions
+      summary: Get Permissions
+      description: >
+        Get the list of all permissions in the system.
+
+
+
+        **Note:** You can use `cursor` and `limit` attributes independently or
+        together to refine the results. Enter a permission name in `cursor` to
+        list permissions starting from that name. Enter an integer in `limit` to
+        define the number of results, between 1 and 99,999 (non-inclusive).
+
+
+
+        **Security:** Requires admin privileges, or a scoped token with
+        `system:permissions:r`.
+
+
+
+        **Availability:** Artifactory 7.72.0+
+      operationId: getPermissions
+      parameters:
+        - name: cursor
+          in: query
+          schema:
+            type: string
+          description: Permission name to start listing from
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 99999
+          description: Number of results (between 1 and 99,999, non-inclusive)
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PermissionListResponse'
+        '400':
+          description: Bad Request - Invalid input
+        '401':
+          description: Bad Credentials - Invalid credentials
+        '403':
+          description: Permission Denied - Insufficient permissions
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: Access Token as bearer token
+  schemas:
+    PermissionListResponse:
+      type: object
+      properties:
+        permissions:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              uri:
+                type: string
+        cursor:
+          type: string
+x-readme:
+  explorer-enabled: false

--- a/docs/api-spec/stub/users-api.yaml
+++ b/docs/api-spec/stub/users-api.yaml
@@ -1,0 +1,270 @@
+# Trimmed excerpt of JFrog's public Platform Users API reference, kept as an
+# OSS test fixture for the jfrog-cli apispec package (JGC-525). Not the full spec —
+# see docs/api-spec/full/ (populated only in JFrog's internal release build).
+openapi: 3.1.0
+info:
+  title: JFrog Platform - Users API
+  description: >
+    User management APIs for the JFrog Platform.
+
+    **Authentication:** Access Tokens as bearer token in authorization header
+    (Authorization: Bearer <token>)
+
+    **Security:** Unless otherwise specified, all APIs require admin privileges.
+
+    **Availability:** Artifactory 7.49.3+
+  version: 1.0.0
+  contact:
+    name: JFrog Support
+servers:
+  - url: https://{jfrog_url}
+tags:
+  - name: Users
+    description: >-
+      APIs for creating, updating, deleting, and managing JFrog Platform users,
+      groups, and passwords.
+security:
+  - BearerAuth: []
+paths:
+  /access/api/v2/users:
+    get:
+      tags:
+        - Users
+      summary: Get User List
+      description: >
+        Returns the list of users.
+
+
+        **Security:** Requires admin privileges, or a scoped token with
+        `system:identities:r`.
+      operationId: getUserList
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum:
+              - invited
+              - enabled
+              - disabled
+              - locked
+          description: Filter users by status
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            default: 1000
+          description: Number of results to return (minimum 1, default 1000)
+        - name: username
+          in: query
+          schema:
+            type: string
+          description: Filter by username (contains)
+        - name: onlyAdmins
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            Filter to only admin users. Cannot be used with resourceName.
+            Available from Artifactory 7.117.x.
+        - name: cursor
+          in: query
+          schema:
+            type: string
+          description: Pagination cursor - shows results after this cursor
+        - name: role
+          in: query
+          schema:
+            type: string
+          description: >-
+            Filter users by role. When filtering by role, onlyAdmins and
+            username parameters are ignored. Available from Artifactory 7.117.x.
+        - name: resourceType
+          in: query
+          schema:
+            type: string
+          description: >-
+            Filter by resource type. Required when filtering by repository role.
+            Available from Artifactory 7.117.x.
+        - name: resourceName
+          in: query
+          schema:
+            type: string
+          description: >-
+            Filter by repository name. Cannot be used with onlyAdmins. Available
+            from Artifactory 7.117.x.
+        - name: projectKey
+          in: query
+          schema:
+            type: string
+          description: >-
+            Filter by project key. Refines search within a specific project
+            context.
+        - name: descendingOrder
+          in: query
+          schema:
+            type: boolean
+          description: Sort results in descending order
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserListResponse'
+        '400':
+          description: Bad Request - Invalid input, object invalid
+        '401':
+          description: Bad Credentials - Invalid credentials
+        '403':
+          description: Permission Denied - Insufficient permissions
+    post:
+      tags:
+        - Users
+      summary: Create User
+      description: >
+        Creates a new Access user.
+
+
+
+        **Note:**
+
+        - When `internal_password_disabled=true`, the 'password' field is not
+        mandatory.
+
+        - The parameter `realm` will be `internal`
+
+
+
+        **Security:** Requires admin privileges.
+      operationId: createUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserCreateRequest'
+      responses:
+        '201':
+          description: User created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserDetails'
+        '400':
+          description: Bad Request - Invalid input, object invalid
+        '401':
+          description: Bad Credentials - Invalid credentials
+        '403':
+          description: Permission Denied - Insufficient permissions
+        '409':
+          description: Conflict - User already exists
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: Access Token as bearer token
+  schemas:
+    UserDetails:
+      type: object
+      properties:
+        username:
+          type: string
+          description: The username
+        email:
+          type: string
+          description: The user's email address
+        admin:
+          type: boolean
+          description: Whether the user is an admin
+        effective_admin:
+          type: boolean
+          description: Whether the user is effectively an admin (based on groups).
+        profile_updatable:
+          type: boolean
+          description: Whether the user can update their profile
+        disable_ui_access:
+          type: boolean
+          description: Whether UI access is disabled for this user
+        internal_password_disabled:
+          type: boolean
+          description: Whether internal password is disabled
+        last_logged_in:
+          type: string
+          format: date-time
+          description: Last login timestamp
+        realm:
+          type: string
+          description: The authentication realm
+        groups:
+          type: array
+          items:
+            type: string
+          description: Groups the user belongs to
+        status:
+          type: string
+          enum:
+            - invited
+            - enabled
+            - disabled
+            - locked
+          description: User status
+    UserCreateRequest:
+      type: object
+      required:
+        - username
+        - email
+      properties:
+        username:
+          type: string
+          description: The username (required)
+        password:
+          type: string
+          description: The password (not required if internal_password_disabled=true)
+        email:
+          type: string
+          description: The user's email address
+        groups:
+          type: array
+          items:
+            type: string
+          description: Groups to add the user to
+        admin:
+          type: boolean
+          default: false
+          description: Whether the user is an admin
+        profile_updatable:
+          type: boolean
+          default: true
+          description: Whether the user can update their profile
+        internal_password_disabled:
+          type: boolean
+          default: false
+          description: Whether internal password is disabled
+        disable_ui_access:
+          type: boolean
+          default: false
+          description: Whether UI access is disabled
+    UserListResponse:
+      type: object
+      properties:
+        users:
+          type: array
+          items:
+            type: object
+            properties:
+              username:
+                type: string
+              uri:
+                type: string
+              realm:
+                type: string
+              status:
+                type: string
+        cursor:
+          type: string
+          description: Pagination cursor
+x-readme:
+  explorer-enabled: false

--- a/docs/api-spec/stub/workers-api.yaml
+++ b/docs/api-spec/stub/workers-api.yaml
@@ -1,0 +1,108 @@
+# Trimmed excerpt of JFrog's public Platform Workers API reference, kept as an
+# OSS test fixture for the jfrog-cli apispec package (JGC-525). Not the full spec —
+# see docs/api-spec/full/ (populated only in JFrog's internal release build).
+openapi: 3.1.0
+info:
+  title: JFrog Platform - Workers API
+  description: >
+    Worker service management APIs for the JFrog Platform.
+
+
+    **Authentication:** Access Tokens as bearer token in authorization header
+    (Authorization: Bearer `<token>`)
+
+
+    **Security:** Unless otherwise specified, all APIs require Platform Admin
+    privileges.
+  version: 1.0.0
+  contact:
+    name: JFrog Support
+servers:
+  - url: https://{jfrog_url}
+tags:
+  - name: Workers
+    description: Manage worker services, actions, and executions on the JFrog Platform.
+security:
+  - BearerAuth: []
+paths:
+  /worker/api/v1/workers:
+    get:
+      tags:
+        - Workers
+      summary: Get Workers
+      description: |
+        Returns a list of all workers.
+
+
+        **Security:** Requires Platform Admin privileges.
+      operationId: getWorkers
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Worker'
+        '401':
+          description: Bad Credentials - Invalid credentials
+        '403':
+          description: Permission Denied - Insufficient permissions
+  /worker/api/v1/workers/{workerKey}:
+    delete:
+      tags:
+        - Workers
+      summary: Delete Worker
+      description: |
+        Deletes a worker.
+
+
+        **Security:** Requires Platform Admin privileges.
+      operationId: deleteWorker
+      parameters:
+        - name: workerKey
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The worker key
+      responses:
+        '204':
+          description: Worker deleted
+        '401':
+          description: Bad Credentials - Invalid credentials
+        '403':
+          description: Permission Denied - Insufficient permissions
+        '404':
+          description: Not Found - Worker not found
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: Access Token as bearer token
+  schemas:
+    Worker:
+      type: object
+      properties:
+        key:
+          type: string
+          description: Worker key
+        description:
+          type: string
+          description: Worker description
+        enabled:
+          type: boolean
+          description: Whether the worker is enabled
+        sourceCode:
+          type: string
+          description: Worker source code (TypeScript/JavaScript)
+        action:
+          type: string
+          description: Worker action
+        filterCriteria:
+          type: object
+          description: Filter criteria for the worker
+x-readme:
+  explorer-enabled: false


### PR DESCRIPTION
## Summary

Adds a small, lazily-parsed `apispec` package (`docs/api-spec/`) that embeds an OpenAPI operation catalog for `jf api`, which today has no knowledge of what operations/paths/parameters exist ("OpenAPI bundles are not shipped with the CLI").

Two embed sets, selected by build tag:
- **stub** (default, no tag) — 10 real, trimmed operations across 7 files, extracted byte-faithful from JFrog's platform API reference (Access users/groups/permissions/tokens/roles, Artifactory system, Workers). Ships in every OSS build.
- **full** (`-tags full`) — a placeholder in this repo; JFrog's internal release pipeline populates `docs/api-spec/full/` with the real ~32-file bundle before building. Nothing here depends on that private source being reachable.

Also adds `Makefile` `stub`/`full` targets and a `JF_BUILD_TAGS` env passthrough in `build/build.sh` so the internal release pipeline can request the full tag without duplicating build flags — default (unset) behavior is unchanged.

Follow-up (not in this PR): wiring `apispec.Operations()` into the actual `jf api` command/help text.

- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. New unit tests were added for the `apispec` parser (`docs/api-spec/parser_test.go`) and pass under both the default and `full` build tags. Platform-dependent integration tests are unaffected by this change and were not run.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...` (verified for both the default and `-tags full` builds).
- [x] The code has been formatted properly using `go fmt ./...`.
