### PR TITLE
Added Post Failure Run support for uv

### DIFF
--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -355,10 +355,7 @@ func GetCommands() []cli.Command {
 			SkipFlagParsing: true,
 			BashComplete:    corecommon.CreateBashCompletionFunc(),
 			Category:        buildToolsCategory,
-			Action: func(c *cli.Context) error {
-				cmdName, _ := getCommandName(c.Args())
-				return securityCLI.WrapCmdWithCurationPostFailureRun(c, PipenvCmd, techutils.Pipenv, cmdName)
-			},
+			Action:          PipenvCmd,
 		},
 		{
 			Name:         "poetry-config",

--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -355,7 +355,10 @@ func GetCommands() []cli.Command {
 			SkipFlagParsing: true,
 			BashComplete:    corecommon.CreateBashCompletionFunc(),
 			Category:        buildToolsCategory,
-			Action:          PipenvCmd,
+			Action: func(c *cli.Context) error {
+				cmdName, _ := getCommandName(c.Args())
+				return securityCLI.WrapCmdWithCurationPostFailureRun(c, PipenvCmd, techutils.Pipenv, cmdName)
+			},
 		},
 		{
 			Name:         "poetry-config",

--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -398,7 +398,11 @@ func GetCommands() []cli.Command {
 			SkipFlagParsing: true,
 			BashComplete:    corecommon.CreateBashCompletionFunc(),
 			Category:        buildToolsCategory,
-			Action:          UvCmd,
+			Action: func(c *cli.Context) error {
+				cmdName, _ := getCommandName(c.Args())
+				return securityCLI.WrapCmdWithCurationPostFailureRun(c, UvCmd, techutils.Uv, cmdName)
+			},
+			Hidden: true,
 		},
 		{
 			Name:            "helm",

--- a/go.mod
+++ b/go.mod
@@ -249,3 +249,5 @@ require (
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.54.2-0.20251007084958-5eeaa42c31a6
 
 // replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260723100012-d9e9c3412cb2
+
+replace github.com/jfrog/jfrog-cli-artifactory => github.com/Phavya-jfrog/jfrog-cli-artifactory v0.0.0-20260810054222-1157b1a8d54c

--- a/go.mod
+++ b/go.mod
@@ -249,5 +249,3 @@ require (
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.54.2-0.20251007084958-5eeaa42c31a6
 
 // replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260723100012-d9e9c3412cb2
-
-replace github.com/jfrog/jfrog-cli-artifactory => github.com/Phavya-jfrog/jfrog-cli-artifactory v0.0.0-20260810054222-1157b1a8d54c

--- a/go.mod
+++ b/go.mod
@@ -249,3 +249,5 @@ require (
 //replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.54.2-0.20251007084958-5eeaa42c31a6
 
 // replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260723100012-d9e9c3412cb2
+
+replace github.com/jfrog/jfrog-cli-artifactory => github.com/Phavya-jfrog/jfrog-cli-artifactory v0.0.0-20260810072032-2c09b906e5ef

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,6 @@ github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Phavya-jfrog/jfrog-cli-artifactory v0.0.0-20260810054222-1157b1a8d54c h1:519Mcy4SRDgC5UNALGm7s1zE4dr41FQnzLI1+ZO/NVA=
-github.com/Phavya-jfrog/jfrog-cli-artifactory v0.0.0-20260810054222-1157b1a8d54c/go.mod h1:gG9i1F2CcAhY9rFAFPzG2z64o8BtZcSyoo3lvIPyHPo=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
@@ -404,6 +402,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847 h1:wahxu7URLrhdHtI3CVH3aE1Y3eeubDin13t+QVJBeW8=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847/go.mod h1:p8yLtbmCxxQucIbLZKnWu0F+EDtj6NLXbRQCEK/nb6o=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260804124646-1a5e6a2d3caf h1:HJob3Bsj6FtQ3nq72GGzBWXJ7ZXvUz6rKSGpYGAXwKI=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260804124646-1a5e6a2d3caf/go.mod h1:UkVDiTbSgtk+7N2ePOsPvjPsgO8r8rJtUchjcnAk08w=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260809090751-06d8b791eb24 h1:boI4fGv/Sn+9z6sZOYRlpT45Y+nkYFL3nCK0MkQBV4w=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260809090751-06d8b791eb24/go.mod h1:MygQx8pekgPCXyXnejIAVG9S4ImGcDFmcfRPUug/0d0=
 github.com/jfrog/jfrog-cli-evidence v0.9.5 h1:YzkoYZtqChStPOxEj1odF7satpv1YPl1Zb/IZ/wZ9kc=

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/Phavya-jfrog/jfrog-cli-artifactory v0.0.0-20260810054222-1157b1a8d54c h1:519Mcy4SRDgC5UNALGm7s1zE4dr41FQnzLI1+ZO/NVA=
+github.com/Phavya-jfrog/jfrog-cli-artifactory v0.0.0-20260810054222-1157b1a8d54c/go.mod h1:gG9i1F2CcAhY9rFAFPzG2z64o8BtZcSyoo3lvIPyHPo=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
@@ -402,8 +404,6 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847 h1:wahxu7URLrhdHtI3CVH3aE1Y3eeubDin13t+QVJBeW8=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847/go.mod h1:p8yLtbmCxxQucIbLZKnWu0F+EDtj6NLXbRQCEK/nb6o=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260804124646-1a5e6a2d3caf h1:HJob3Bsj6FtQ3nq72GGzBWXJ7ZXvUz6rKSGpYGAXwKI=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260804124646-1a5e6a2d3caf/go.mod h1:UkVDiTbSgtk+7N2ePOsPvjPsgO8r8rJtUchjcnAk08w=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260809090751-06d8b791eb24 h1:boI4fGv/Sn+9z6sZOYRlpT45Y+nkYFL3nCK0MkQBV4w=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260809090751-06d8b791eb24/go.mod h1:MygQx8pekgPCXyXnejIAVG9S4ImGcDFmcfRPUug/0d0=
 github.com/jfrog/jfrog-cli-evidence v0.9.5 h1:YzkoYZtqChStPOxEj1odF7satpv1YPl1Zb/IZ/wZ9kc=

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/Phavya-jfrog/jfrog-cli-artifactory v0.0.0-20260810072032-2c09b906e5ef h1:UiJY3nIDhEX5OxJOgUmp1UliE3RUXnA9g0U64Q7Dfvo=
+github.com/Phavya-jfrog/jfrog-cli-artifactory v0.0.0-20260810072032-2c09b906e5ef/go.mod h1:UkVDiTbSgtk+7N2ePOsPvjPsgO8r8rJtUchjcnAk08w=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
@@ -402,8 +404,6 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847 h1:wahxu7URLrhdHtI3CVH3aE1Y3eeubDin13t+QVJBeW8=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847/go.mod h1:p8yLtbmCxxQucIbLZKnWu0F+EDtj6NLXbRQCEK/nb6o=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260804124646-1a5e6a2d3caf h1:HJob3Bsj6FtQ3nq72GGzBWXJ7ZXvUz6rKSGpYGAXwKI=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260804124646-1a5e6a2d3caf/go.mod h1:UkVDiTbSgtk+7N2ePOsPvjPsgO8r8rJtUchjcnAk08w=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260809090751-06d8b791eb24 h1:boI4fGv/Sn+9z6sZOYRlpT45Y+nkYFL3nCK0MkQBV4w=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260809090751-06d8b791eb24/go.mod h1:MygQx8pekgPCXyXnejIAVG9S4ImGcDFmcfRPUug/0d0=
 github.com/jfrog/jfrog-cli-evidence v0.9.5 h1:YzkoYZtqChStPOxEj1odF7satpv1YPl1Zb/IZ/wZ9kc=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
Wrap uv with the existing curation Post-Failure Run handler