### PR TITLE
JGC-531 - Bump Go toolchain to 1.26.5

### DIFF
--- a/build/docker/full/Dockerfile
+++ b/build/docker/full/Dockerfile
@@ -1,6 +1,6 @@
 ARG repo_name_21
 # Remove ${repo_name_21} to pull from Docker Hub.
-FROM ${repo_name_21}/jfrog-docker/golang:1.26.3 as builder
+FROM ${repo_name_21}/jfrog-docker/golang:1.26.5 as builder
 ARG image_name=jfrog-cli-full
 ARG cli_executable_name
 WORKDIR /${image_name}

--- a/build/docker/slim/Dockerfile
+++ b/build/docker/slim/Dockerfile
@@ -1,6 +1,6 @@
 ARG repo_name_21
 # Remove ${repo_name_21} to pull from Docker Hub.
-FROM ${repo_name_21}/jfrog-docker/golang:1.26.3-alpine as builder
+FROM ${repo_name_21}/jfrog-docker/golang:1.26.5-alpine as builder
 ARG image_name=jfrog-cli
 ARG cli_executable_name
 WORKDIR /${image_name}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jfrog/jfrog-cli
 
-go 1.26.3
+go 1.26.5
 
 replace (
 	// Should not be updated to 0.11.0+ due to default spec version change (1.6 -> 1.7, https://github.com/CycloneDX/cyclonedx-go/pull/257)


### PR DESCRIPTION
## Summary
- Bump Go toolchain from 1.26.3 to 1.26.5 in `go.mod`
- Align Docker builder images to `golang:1.26.5` / `golang:1.26.5-alpine`

Fixes Xray block on Docker release bundle distribution during CLI 2.114.0 release (CVE-2026-42504, CVE-2026-39822, and related Go CVEs).

Jira: https://jfrog-int.atlassian.net/browse/JGC-531

## Test plan
- [ ] CI / build-gate green
- [ ] Merge to master
- [ ] Separate minor release bump (2.115.0) and release workflow to follow