### PR TITLE
Report usage on jf setup when the target repo fails validation

### DIFF
--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -105,8 +105,7 @@ const (
 func GetCommands() []cli.Command {
 	cmds := cliutils.GetSortedCommands(cli.CommandsByName{
 		{
-			// Currently, the setup command is hidden from the help menu, till it will be released as GA.
-			Hidden:       true,
+			Hidden:       false,
 			Name:         "setup",
 			Flags:        cliutils.GetCommandFlags(cliutils.Setup),
 			Usage:        setupdocs.GetDescription(),

--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -1821,26 +1821,36 @@ func setupCmd(c *cli.Context) (err error) {
 	if err != nil {
 		return err
 	}
+
+	// From here on, the server and package manager are known, so a usage report must fire no
+	// matter which return path is taken below - including validation added here in the future.
+	// ExecWithPackageManager reports on its own once reached, so it disarms this deferred report
+	// instead of letting it fire a second time.
+	reportPending := true
+	defer func() {
+		if !reportPending {
+			return
+		}
+		commandName := setupCmd.CommandName()
+		var flagsUsed []string
+		for _, f := range c.Command.Flags {
+			if name := f.GetName(); c.IsSet(name) {
+				flagsUsed = append(flagsUsed, name)
+			}
+		}
+		waitUsageReport := usage.StartReport(commandName, flagsUsed, artDetails)
+		usage.WaitForReport(commandName, waitUsageReport, usage.DefaultReportTimeout)
+	}()
+
 	repoName := c.String("repo")
 	if repoName != "" {
 		// If a repository was provided, validate it exists in Artifactory.
 		if err = validateRepoExists(repoName, artDetails); err != nil {
-			// The server and package manager are already known at this point, so report usage
-			// here too - otherwise every setup attempt against a mistyped or inaccessible repo
-			// silently disappears from usage telemetry instead of being counted as an attempt.
-			commandName := setupCmd.CommandName()
-			var flagsUsed []string
-			for _, f := range c.Command.Flags {
-				if name := f.GetName(); c.IsSet(name) {
-					flagsUsed = append(flagsUsed, name)
-				}
-			}
-			waitUsageReport := usage.StartReport(commandName, flagsUsed, artDetails)
-			usage.WaitForReport(commandName, waitUsageReport, usage.DefaultReportTimeout)
 			return err
 		}
 	}
 	setupCmd.SetServerDetails(artDetails).SetRepoName(repoName).SetProjectKey(cliutils.GetProject(c))
+	reportPending = false
 	return commands.ExecWithPackageManager(setupCmd, packageManager.String())
 }
 

--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -18,13 +18,11 @@ import (
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/python"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/setup"
 	artutils "github.com/jfrog/jfrog-cli-artifactory/artifactory/utils"
-	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/ioutils"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 	"github.com/jfrog/jfrog-cli/docs/buildtools/helmcommand"
 	"github.com/jfrog/jfrog-cli/docs/buildtools/rubyconfig"
 	setupdocs "github.com/jfrog/jfrog-cli/docs/buildtools/setup"
-	"github.com/jfrog/jfrog-cli/utils/usage"
 
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/container"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/dotnet"
@@ -1821,46 +1819,10 @@ func setupCmd(c *cli.Context) (err error) {
 	if err != nil {
 		return err
 	}
-
-	// From here on, the server and package manager are known, so a usage report must fire no
-	// matter which return path is taken below - including validation added here in the future.
-	// ExecWithPackageManager reports on its own once reached, so it disarms this deferred report
-	// instead of letting it fire a second time.
-	reportPending := true
-	defer func() {
-		if !reportPending {
-			return
-		}
-		commandName := setupCmd.CommandName()
-		var flagsUsed []string
-		for _, f := range c.Command.Flags {
-			if name := f.GetName(); c.IsSet(name) {
-				flagsUsed = append(flagsUsed, name)
-			}
-		}
-		waitUsageReport := usage.StartReport(commandName, flagsUsed, artDetails)
-		usage.WaitForReport(commandName, waitUsageReport, usage.DefaultReportTimeout)
-	}()
-
-	repoName := c.String("repo")
-	if repoName != "" {
-		// If a repository was provided, validate it exists in Artifactory.
-		if err = validateRepoExists(repoName, artDetails); err != nil {
-			return err
-		}
-	}
-	setupCmd.SetServerDetails(artDetails).SetRepoName(repoName).SetProjectKey(cliutils.GetProject(c))
-	reportPending = false
+	// Repo-existence validation for --repo happens inside SetupCommand.Run(), so every return
+	// path from here is covered by the single usage-report call site in ExecWithPackageManager.
+	setupCmd.SetServerDetails(artDetails).SetRepoName(c.String("repo")).SetProjectKey(cliutils.GetProject(c))
 	return commands.ExecWithPackageManager(setupCmd, packageManager.String())
-}
-
-// validateRepoExists checks if the specified repository exists in Artifactory.
-func validateRepoExists(repoName string, artDetails *coreConfig.ServerDetails) error {
-	serviceDetails, err := artDetails.CreateArtAuthConfig()
-	if err != nil {
-		return err
-	}
-	return utils.ValidateRepoExists(repoName, serviceDetails)
 }
 
 func selectPackageManagerInteractively() (selectedPackageManager project.ProjectType, err error) {

--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jfrog/jfrog-cli/docs/buildtools/helmcommand"
 	"github.com/jfrog/jfrog-cli/docs/buildtools/rubyconfig"
 	setupdocs "github.com/jfrog/jfrog-cli/docs/buildtools/setup"
+	"github.com/jfrog/jfrog-cli/utils/usage"
 
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/container"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/dotnet"
@@ -1825,6 +1826,18 @@ func setupCmd(c *cli.Context) (err error) {
 	if repoName != "" {
 		// If a repository was provided, validate it exists in Artifactory.
 		if err = validateRepoExists(repoName, artDetails); err != nil {
+			// The server and package manager are already known at this point, so report usage
+			// here too - otherwise every setup attempt against a mistyped or inaccessible repo
+			// silently disappears from usage telemetry instead of being counted as an attempt.
+			commandName := setupCmd.CommandName()
+			var flagsUsed []string
+			for _, f := range c.Command.Flags {
+				if name := f.GetName(); c.IsSet(name) {
+					flagsUsed = append(flagsUsed, name)
+				}
+			}
+			waitUsageReport := usage.StartReport(commandName, flagsUsed, artDetails)
+			usage.WaitForReport(commandName, waitUsageReport, usage.DefaultReportTimeout)
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- `jf setup <package-manager> --repo <name>` returned early when the target repo didn't exist, before ever reaching `commands.ExecWithPackageManager` - the only call in this path that triggers a usage report. Found while investigating why `jf setup npm/mvn/docker/pypi/yarn/twine/uv` runs against a shared test server were largely missing from usage BI data despite 50+ manual runs.
- The correct fix moves the `--repo` existence check into `SetupCommand.Run()` itself (in `jfrog-cli-artifactory`), so it's covered by the same single usage-report call site as every other command. That's implemented and open here: **jfrog/jfrog-cli-artifactory#512** (branch [`RTECO-0000-setup-usage-report-on-invalid-repo`](https://github.com/bhanurp/jfrog-cli-artifactory/tree/RTECO-0000-setup-usage-report-on-invalid-repo)).
- This PR is now just the `jfrog-cli` side of that fix: `buildtools/cli.go`'s `setupCmd` no longer validates the repo itself - that responsibility moved to `SetupCommand.Run()`. **Once jfrog-cli-artifactory#512 merges and is released, the only remaining step is bumping this repo's `go.mod`/`go.sum` to the new `jfrog-cli-artifactory` version** - no further code change is needed in `jfrog-cli`.
- Also unhides the `setup` command from the help menu (`Hidden: false`) - the GA-gating comment no longer applies now that this reporting gap is fixed.

## Test plan
- [x] `go build ./buildtools/...`
- [x] `go vet ./buildtools/...`
- [x] Verified end-to-end locally against the jfrog-cli-artifactory#512 branch (via a temporary `replace` directive, not committed): `jf setup` builds, runs, and shows in `jf --help`.
- [ ] Once jfrog-cli-artifactory#512 merges: bump the dependency here and confirm `jf setup npm --repo <nonexistent-repo>` fires a usage report even though the command errors out.
