### PR TITLE
JFMIG-46 - Add new flags to support migration by created time and dow…

### DIFF
--- a/artifactory/cli.go
+++ b/artifactory/cli.go
@@ -1321,6 +1321,8 @@ func transferFilesCmd(c *cli.Context) error {
 	newTransferFilesCmd.SetIncludeReposPatterns(includeReposPatterns)
 	newTransferFilesCmd.SetExcludeReposPatterns(excludeReposPatterns)
 	newTransferFilesCmd.SetIncludeFilesPatterns(getIncludeFilesPatterns(c))
+	newTransferFilesCmd.SetCreatedAfter(c.String(cliutils.CreatedAfter))
+	newTransferFilesCmd.SetDownloadedAfter(c.String(cliutils.DownloadedAfter))
 	newTransferFilesCmd.SetIgnoreState(c.Bool(cliutils.IgnoreState))
 	newTransferFilesCmd.SetProxyKey(c.String(cliutils.ProxyKey))
 	runErr := newTransferFilesCmd.Run()

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-application v1.0.2-0.20260713081138-6df6041db819
 	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260722060859-50ee96befe5c
-	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260624085155-5ba797de2616
+	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260724083402-361ba4a2ecdb
 	github.com/jfrog/jfrog-cli-evidence v0.9.5-0.20260618135203-4d2bdd4ee35f
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260618062042-6053ab368cab
 	github.com/jfrog/jfrog-cli-security v1.31.3

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,8 @@ github.com/jfrog/jfrog-cli-application v1.0.2-0.20260713081138-6df6041db819 h1:n
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260713081138-6df6041db819/go.mod h1:p8yLtbmCxxQucIbLZKnWu0F+EDtj6NLXbRQCEK/nb6o=
 github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260722060859-50ee96befe5c h1:eFpR1Wz6py0OrCn53cLwbYgGEKa2qKOOyAXaIdDq3/k=
 github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260722060859-50ee96befe5c/go.mod h1:1vxzqW7jHBSuTNqO2vxEnhbniwq4dj5wveDuCMJX7Yo=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260624085155-5ba797de2616 h1:bioFXGzf3pF2qnC3LZD1S1saWiHSekL4vdsDSWksj/4=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260624085155-5ba797de2616/go.mod h1:9R90mhbczGXwW5EGlDs7F08ejQU/xdoDhYHMvzBiqgE=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260724083402-361ba4a2ecdb h1:OW2W8ryV0FiCq1DKfRXPLwuB8OB+1wWebVG/sQPaF3Y=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260724083402-361ba4a2ecdb/go.mod h1:9R90mhbczGXwW5EGlDs7F08ejQU/xdoDhYHMvzBiqgE=
 github.com/jfrog/jfrog-cli-evidence v0.9.5-0.20260618135203-4d2bdd4ee35f h1:MV4BATdkEoUYJmdPDvaB9EBb8JQZg28n/K4X7dcmyAY=
 github.com/jfrog/jfrog-cli-evidence v0.9.5-0.20260618135203-4d2bdd4ee35f/go.mod h1:t2luv7YHtrKe/Yf1xLZgLOkkiPtk1DsKj0OLXL2GwYo=
 github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260618062042-6053ab368cab h1:Zn/qB8LYhSu82YDtbqXwErN1RPHTHe/a3gQY6Ti/OBE=

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -617,6 +617,8 @@ const (
 	IncludeProjects = "include-projects"
 	ExcludeProjects = "exclude-projects"
 	IncludeFiles    = "include-files"
+	CreatedAfter    = "created-after"
+	DownloadedAfter = "downloaded-after"
 
 	// *** JFrog Pipelines Commands' flags ***
 	// Base flags
@@ -1849,6 +1851,14 @@ var flagsMap = map[string]cli.Flag{
 		Name:  IncludeFiles,
 		Usage: "[Optional] List of semicolon-separated(;) path patterns to include in the transfer. Files will be filtered based on their directory path. Pattern examples: 'folder/subfolder/*', 'org/company/*'.` `",
 	},
+	CreatedAfter: cli.StringFlag{
+		Name:  CreatedAfter,
+		Usage: "[Optional] Transfer only files created at or after this exact UTC timestamp. Format: YYYY-MM-DDTHH:mm:ss.sssZ. When both --created-after and --downloaded-after are set, --created-after takes precedence.` `",
+	},
+	DownloadedAfter: cli.StringFlag{
+		Name:  DownloadedAfter,
+		Usage: "[Optional] Transfer only files last downloaded at or after this exact UTC timestamp. Format: YYYY-MM-DDTHH:mm:ss.sssZ. Files that were never downloaded are excluded. Ignored when --created-after is also set.` `",
+	},
 	IgnoreState: cli.BoolFlag{
 		Name:  IgnoreState,
 		Usage: "[Default: false] Set to true to ignore the saved state from previous transfer-files operations.` `",
@@ -2352,7 +2362,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, sshPassphrase, sshKeyPath, serverId, deleteQuiet,
 	},
 	TransferFiles: {
-		Filestore, IncludeRepos, ExcludeRepos, IncludeFiles, IgnoreState, ProxyKey, transferFilesStatus, Stop, PreChecks, transferFilesFormat,
+		Filestore, IncludeRepos, ExcludeRepos, IncludeFiles, CreatedAfter, DownloadedAfter, IgnoreState, ProxyKey, transferFilesStatus, Stop, PreChecks, transferFilesFormat,
 	},
 	TransferInstall: {
 		installPluginVersion, InstallPluginSrcDir, InstallPluginHomeDir,

--- a/utils/cliutils/utils_test.go
+++ b/utils/cliutils/utils_test.go
@@ -477,3 +477,20 @@ func TestLoginCommandFlagsIncludeServerId(t *testing.T) {
 	}
 	assert.Contains(t, flagNames, "server-id", "Expected login command flags to include 'server-id'")
 }
+
+func TestTransferFilesTimestampFilterFlags(t *testing.T) {
+	flags := GetCommandFlags(TransferFiles)
+	assert.NotEmpty(t, flags)
+
+	var flagNames []string
+	usageByName := map[string]string{}
+	for _, f := range flags {
+		flagNames = append(flagNames, f.GetName())
+		usageByName[f.GetName()] = f.String()
+	}
+
+	assert.Contains(t, flagNames, CreatedAfter)
+	assert.Contains(t, flagNames, DownloadedAfter)
+	assert.Contains(t, usageByName[CreatedAfter], "YYYY-MM-DDTHH:mm:ss.sssZ")
+	assert.Contains(t, usageByName[DownloadedAfter], "YYYY-MM-DDTHH:mm:ss.sssZ")
+}


### PR DESCRIPTION
…nloaded time

- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
