### PR TITLE
Allow unsafe PR checkout in build-gate-approved workflows

### DIFF
--- a/.github/workflows/accessTests.yml
+++ b/.github/workflows/accessTests.yml
@@ -43,6 +43,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/agentPluginsTests.yml
+++ b/.github/workflows/agentPluginsTests.yml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/apkTests.yml
+++ b/.github/workflows/apkTests.yml
@@ -63,6 +63,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         uses: jfrog-fastci/fastci@v1

--- a/.github/workflows/artifactoryTests.yml
+++ b/.github/workflows/artifactoryTests.yml
@@ -43,6 +43,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/conanTests.yml
+++ b/.github/workflows/conanTests.yml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/distributionTests.yml
+++ b/.github/workflows/distributionTests.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
           
       - name: Setup Go with cache
         uses: jfrog/.github/actions/install-go-with-cache@main

--- a/.github/workflows/dockerTests.yml
+++ b/.github/workflows/dockerTests.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Configure Docker with legacy snapshotter
         if: matrix.disable-containerd-snapshotter == true

--- a/.github/workflows/evidenceTests.yml
+++ b/.github/workflows/evidenceTests.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         uses: jfrog-fastci/fastci@v1

--- a/.github/workflows/frogbot-scan-pull-request.yml
+++ b/.github/workflows/frogbot-scan-pull-request.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
           
       - name: Setup Go with cache
         uses: jfrog/.github/actions/install-go-with-cache@main

--- a/.github/workflows/ghostFrogTests.yml
+++ b/.github/workflows/ghostFrogTests.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         uses: jfrog-fastci/fastci@v1

--- a/.github/workflows/goTests.yml
+++ b/.github/workflows/goTests.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         uses: jfrog-fastci/fastci@v1

--- a/.github/workflows/gradleTests.yml
+++ b/.github/workflows/gradleTests.yml
@@ -43,6 +43,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/helmTests.yml
+++ b/.github/workflows/helmTests.yml
@@ -43,6 +43,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/huggingfaceTests.yml
+++ b/.github/workflows/huggingfaceTests.yml
@@ -43,6 +43,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/lifecycleTests.yml
+++ b/.github/workflows/lifecycleTests.yml
@@ -42,6 +42,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/mavenTests.yml
+++ b/.github/workflows/mavenTests.yml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/nixTests.yml
+++ b/.github/workflows/nixTests.yml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/npmTests.yml
+++ b/.github/workflows/npmTests.yml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/nugetTests.yml
+++ b/.github/workflows/nugetTests.yml
@@ -41,6 +41,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/oidcTests.yml
+++ b/.github/workflows/oidcTests.yml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
           
       - name: Setup Go with cache
         uses: jfrog/.github/actions/install-go-with-cache@main

--- a/.github/workflows/pluginsTests.yml
+++ b/.github/workflows/pluginsTests.yml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/pnpmTests.yml
+++ b/.github/workflows/pnpmTests.yml
@@ -41,6 +41,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/podmanTests.yml
+++ b/.github/workflows/podmanTests.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Configure Docker 29 for Legacy Support
         run: |

--- a/.github/workflows/poetryTests.yml
+++ b/.github/workflows/poetryTests.yml
@@ -48,6 +48,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/pythonTests.yml
+++ b/.github/workflows/pythonTests.yml
@@ -41,6 +41,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'

--- a/.github/workflows/scriptTests.yml
+++ b/.github/workflows/scriptTests.yml
@@ -38,6 +38,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         uses: jfrog-fastci/fastci@v1

--- a/.github/workflows/transferTests.yml
+++ b/.github/workflows/transferTests.yml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         if: matrix.os.name != 'macos'
@@ -96,6 +98,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         uses: jfrog-fastci/fastci@v1

--- a/.github/workflows/uvTests.yml
+++ b/.github/workflows/uvTests.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # Safe: this workflow only runs after human approval via the build-gate environment.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup FastCI
         uses: jfrog-fastci/fastci@v1


### PR DESCRIPTION
`actions/checkout@v7` now refuses to check out a fork pull request's head ref under `pull_request_target` by default (the anti "pwn request" guard — see https://gh.io/securely-using-pull_request_target). That broke `frogbot-scan-pull-request.yml` and every `*Tests.yml` suite for externally-contributed PRs. All of them are only reachable through `build-gate.yml`'s single approval gate (`environment: build-gate`, required reviewers), so a maintainer already reviews the diff before any of them run. Opting in with `allow-unsafe-pr-checkout: true` on each checkout step restores that path without exposing any checkout outside the gate — `dependabot-auto-merge.yml`'s checkout stays untouched since it isn't behind the gate.

- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
