### PR TITLE
RTECO-0000 - Enable setup comand

### DIFF
--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -106,7 +106,7 @@ func GetCommands() []cli.Command {
 	cmds := cliutils.GetSortedCommands(cli.CommandsByName{
 		{
 			// Currently, the setup command is hidden from the help menu, till it will be released as GA.
-			Hidden:       true,
+			Hidden:       false,
 			Name:         "setup",
 			Flags:        cliutils.GetCommandFlags(cliutils.Setup),
 			Usage:        setupdocs.GetDescription(),

--- a/buildtools/cli.go
+++ b/buildtools/cli.go
@@ -3,8 +3,6 @@ package buildtools
 import (
 	"errors"
 	"fmt"
-	conancommand "github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/conan"
-	nixcommand "github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/nix"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -12,6 +10,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	conancommand "github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/conan"
+	nixcommand "github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/nix"
 
 	"github.com/BurntSushi/toml"
 	"github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/container/strategies"
@@ -105,12 +106,11 @@ const (
 func GetCommands() []cli.Command {
 	cmds := cliutils.GetSortedCommands(cli.CommandsByName{
 		{
-			// Currently, the setup command is hidden from the help menu, till it will be released as GA.
 			Hidden:       false,
 			Name:         "setup",
 			Flags:        cliutils.GetCommandFlags(cliutils.Setup),
-			Usage:        setupdocs.GetDescription(),
-			HelpName:     corecommon.CreateUsage("setup", setupdocs.GetDescription(), setupdocs.Usage),
+			Usage:        corecommon.ResolveDescription(setupdocs.GetDescription(), setupdocs.GetAIDescription()),
+			HelpName:     corecommon.CreateUsage("setup", corecommon.ResolveDescription(setupdocs.GetDescription(), setupdocs.GetAIDescription()), setupdocs.Usage),
 			ArgsUsage:    common.CreateEnvVars(),
 			UsageText:    setupdocs.GetArguments(),
 			BashComplete: corecommon.CreateBashCompletionFunc(setup.GetSupportedPackageManagersList()...),

--- a/docs/buildtools/setup/help.go
+++ b/docs/buildtools/setup/help.go
@@ -16,3 +16,27 @@ func GetArguments() string {
 	return `	package manager
 		The package manager to configure. Supported package managers are: ` + strings.Join(setup.GetSupportedPackageManagersList(), ", ") + "."
 }
+
+func GetAIDescription() string {
+	return `Interactively (or non-interactively, via flags) configure a local package manager (` + strings.Join(setup.GetSupportedPackageManagersList(), ", ") + `) to resolve and/or publish through JFrog Artifactory. This is the fastest way to point an existing project at Artifactory without hand-editing the tool's native config files.
+
+When to use:
+- One-time setup of a package manager on a developer machine or CI runner to work against Artifactory.
+- Switching an already-configured package manager to a different repository or server.
+
+Prerequisites:
+- A configured server (jf c add or jf login), or pass --url/--user/--password/--access-token directly.
+- The Artifactory repository name for the package manager (a virtual repo where supported).
+
+Common patterns:
+  $ jf setup npm
+  $ jf setup go --repo=go-remote
+  $ jf setup docker --server-id=my-server
+
+Gotchas:
+- Without --repo, the command prompts for repository selection, so it is interactive by default; pass --repo for non-interactive/CI use.
+- Configuration is applied globally to the package manager's native config (e.g., ~/.npmrc, NuGet.Config), affecting all projects on the machine, not just the current one.
+- docker/podman authenticate directly against the registry and skip the repository prompt entirely (no --repo needed); helm still goes through repository selection like the other package managers even though its login step doesn't end up using the repo name.
+
+Related: jf npm-config, jf go-config, jf pip-config, jf c add`
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
## Description
- Enabled setup command