### PR TITLE
Run Alpine APK tests inside real Alpine Docker containers

### DIFF
--- a/.github/workflows/apkTests.yml
+++ b/.github/workflows/apkTests.yml
@@ -47,16 +47,20 @@ on:
 
 jobs:
   Apk-Tests:
-    name: Alpine APK tests (${{ matrix.alpine-version }})
+    name: Alpine APK tests (${{ matrix.alpine-version }}, apk-tools ${{ matrix.apk-tools }})
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        alpine-version:
-          - v3.18
-          - v3.19
-          - v3.20
-          - v3.21
+        # Cover both apk-tools major versions:
+        #   - v2.x: Alpine 3.18–3.21 (apk-tools 2.14.x)
+        #   - v3.x: Alpine 3.23 is the first stable release shipping apk-tools 3.x.
+        include:
+          - { alpine-version: v3.18, apk-tools: v2 }
+          - { alpine-version: v3.19, apk-tools: v2 }
+          - { alpine-version: v3.20, apk-tools: v2 }
+          - { alpine-version: v3.21, apk-tools: v2 }
+          - { alpine-version: v3.23, apk-tools: v3 }
 
     steps:
       - name: Checkout code
@@ -82,16 +86,73 @@ jobs:
           RTLIC: ${{ secrets.RTLIC }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
 
-      # Run on the host runner with the host Go toolchain (1.26+).
-      # Tests that require the native `apk` binary skip themselves via
-      # apkAvailable() when apk is not on PATH (Ubuntu runner).
-      # The Alpine chroot approach will be re-enabled once the Go version
-      # constraint in go.mod aligns with Alpine's packaged Go release.
-      - name: Run Alpine APK tests
-        run: |
-          go test -v github.com/jfrog/jfrog-cli --timeout 0 --test.alpine \
-            ${{ inputs.jfrog_url != '' && format('--jfrog.url={0} --jfrog.adminToken={1}', inputs.jfrog_url, inputs.jfrog_admin_token) || '' }} \
-            ${{ inputs.jfrog_user != '' && format('--jfrog.user={0}', inputs.jfrog_user) || '' }} \
-            ${{ inputs.jfrog_password != '' && format('--jfrog.password={0}', inputs.jfrog_password) || '' }}
+      # Step 1: Compile the test binary on the host runner using Go 1.26+.
+      # Alpine's packaged Go does not yet reach 1.26, so we cross-compile a
+      # static Linux/amd64 binary here and run it inside the Alpine container.
+      - name: Build test binary
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -c -o apk.test .
+
+      # Step 2: Run the pre-built binary inside the target Alpine container, retrying
+      # ONLY the tests that fail (up to MAX_ATTEMPTS). The shared JFrog platform's WAF
+      # occasionally returns a transient 403 on config-add/build-publish; a selective
+      # rerun absorbs those blips without masking a genuinely broken test.
+      # --network host lets the test binary reach Artifactory on localhost.
+      - name: Run Alpine APK tests (alpine:${{ matrix.alpine-version }})
         env:
-          CGO_ENABLED: "0"
+          ALPINE_VER: ${{ matrix.alpine-version }}
+          JFROG_URL: ${{ inputs.jfrog_url }}
+          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
+          JFROG_USER: ${{ inputs.jfrog_user }}
+          JFROG_PASSWORD: ${{ inputs.jfrog_password }}
+          MAX_ATTEMPTS: "3"
+          RETRY_DELAY: "10"
+        run: |
+          set +e
+          set -uo pipefail
+
+          # Build credential flags: external JPD (url + token) or empty for local Artifactory.
+          creds=""
+          if [ -n "$JFROG_URL" ]; then
+            creds="-jfrog.url=$JFROG_URL -jfrog.adminToken=$JFROG_ADMIN_TOKEN"
+          fi
+          [ -n "$JFROG_USER" ]     && creds="$creds -jfrog.user=$JFROG_USER"
+          [ -n "$JFROG_PASSWORD" ] && creds="$creds -jfrog.password=$JFROG_PASSWORD"
+
+          run_regex="TestApk|TestSetupApk"
+          fails=""
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            echo ">> Attempt $attempt/$MAX_ATTEMPTS: -test.run=$run_regex"
+            docker run --rm \
+              --network host \
+              -v "${{ github.workspace }}":/workspace \
+              -w /workspace \
+              "alpine:${ALPINE_VER#v}" \
+              ./apk.test \
+                -test.v -test.timeout 0 \
+                -test.run "$run_regex" \
+                -test.alpine \
+                $creds 2>&1 | tee /tmp/apk-out.log
+            docker_exit=${PIPESTATUS[0]}
+
+            # Collect the top-level names of tests that failed this attempt.
+            fails=$(grep -Eo '^--- FAIL: [A-Za-z0-9_]+' /tmp/apk-out.log | awk '{print $3}' | sort -u | tr '\n' '|' | sed 's/|$//')
+            if [ -z "$fails" ] && [ "$docker_exit" -eq 0 ]; then
+              echo ">> All Alpine tests passed on attempt $attempt."
+              exit 0
+            fi
+            if [ -z "$fails" ]; then
+              echo ">> Container exited with status $docker_exit and no '--- FAIL:' lines — treating as failure."
+              next_regex="TestApk|TestSetupApk"
+              fails="<docker exit $docker_exit, no test-level failures reported>"
+            else
+              echo ">> Failed on attempt $attempt: $fails"
+              next_regex="^($fails)$"
+            fi
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo ">> Retrying failed tests in ${RETRY_DELAY}s..."
+              sleep "$RETRY_DELAY"
+              run_regex="$next_regex"
+            fi
+          done
+          echo ">> STILL FAILING after $MAX_ATTEMPTS attempts: $fails" >&2
+          exit 1


### PR DESCRIPTION
## Summary

Updates `.github/workflows/apkTests.yml` to actually exercise the native `apk`
binary, instead of running the Alpine test suite directly on the ubuntu-24.04
host runner (where `apk` is not on PATH and every `TestApk*` self-skips via
`apkAvailable()`).

## What changed

- Compile a static Linux/amd64 test binary on the host (`go test -c`), since
  Alpine's packaged Go does not yet reach the 1.26 toolchain this repo requires.
- Run that binary inside the actual `alpine:<version>` Docker image via
  `docker run --network host`, so `apk` is genuinely present and the real
  code paths run.
- Expand the matrix to cover both `apk-tools` major versions: v3.18-v3.21
  (apk-tools 2.14.x) and v3.23 (first stable release shipping apk-tools 3.x).
- Add selective retry (up to 3 attempts) scoped to only the tests that failed
  each attempt, to absorb transient 403s from the shared JPD's WAF on
  config-add/build-publish without masking a genuinely broken test.

## Why a standalone PR

This is being split out from #3561 (`jf apk` command support) because
`build-gate.yml` triggers on `pull_request_target`, which resolves reusable
workflow calls like `apkTests.yml` against the base branch's copy of the
file, not the PR branch's. Landing this workflow change on master first is a
prerequisite for #3561's own Alpine CI job to actually run inside Docker
instead of silently skipping.

## Test plan
- [ ] Manually trigger via `workflow_dispatch` on this branch and confirm
      `apk` tests execute inside the alpine:v3.18/v3.19/v3.20/v3.21/v3.23
      containers (rather than skipping with "apk binary not found").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
