### PR TITLE
Fix apispec parser crashing on OpenAPI 3.1 nullable type unions

### DIFF
--- a/docs/api-spec/parser.go
+++ b/docs/api-spec/parser.go
@@ -6,10 +6,12 @@ package apispec
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"sort"
 	"strings"
 	"sync"
 
+	"github.com/jfrog/jfrog-client-go/utils/log"
 	"gopkg.in/yaml.v3"
 )
 
@@ -115,7 +117,7 @@ type rawMediaTypeItem struct {
 // and sidestep any $ref cycles in the full (non-stub) bundle.
 type rawSchema struct {
 	Ref         string               `yaml:"$ref"`
-	Type        string               `yaml:"type"`
+	Type        flexType             `yaml:"type"`
 	Description string               `yaml:"description"`
 	Default     any                  `yaml:"default"`
 	Required    []string             `yaml:"required"`
@@ -123,19 +125,79 @@ type rawSchema struct {
 	Items       *rawSchema           `yaml:"items"`
 }
 
+// flexType decodes an OpenAPI "type" keyword, which JSON Schema 2020-12 (used
+// by OpenAPI 3.1) allows to be either a single string ("string") or a
+// nullable union sequence (e.g. [string, "null"]) in place of the older
+// "nullable: true" sibling keyword. For a sequence, the first non-"null"
+// entry is used -- enough to keep propertyType's type hint accurate without
+// modeling nullability itself.
+type flexType string
+
+func (t *flexType) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.SequenceNode:
+		var types []string
+		if err := node.Decode(&types); err != nil {
+			return err
+		}
+		for _, s := range types {
+			if s != "null" {
+				*t = flexType(s)
+				return nil
+			}
+		}
+		*t = ""
+		return nil
+	default:
+		var s string
+		if err := node.Decode(&s); err != nil {
+			return err
+		}
+		*t = flexType(s)
+		return nil
+	}
+}
+
+// FileError describes a single embedded spec file that failed to parse and
+// was skipped -- see Failures.
+type FileError struct {
+	File string
+	Err  error
+}
+
+func (e FileError) Error() string {
+	return fmt.Sprintf("%s: %s", e.File, e.Err)
+}
+
 var (
 	once       sync.Once
 	operations []Operation
 	parseErr   error
+	fileErrors []FileError
 )
 
 // Operations returns every operation across the embedded OpenAPI spec bundle.
-// Parsing happens once per process and the result is cached.
+// Parsing happens once per process and the result is cached. A spec file that
+// fails to parse is skipped (logged as a warning, see Failures) rather than
+// failing every other file's operations along with it; parseErr is non-nil
+// only for a bundle-level failure (e.g. the embedded directory itself can't
+// be read).
 func Operations() ([]Operation, error) {
 	once.Do(func() {
-		operations, parseErr = parseAll()
+		operations, fileErrors, parseErr = parseAll()
 	})
 	return operations, parseErr
+}
+
+// Failures reports which embedded spec files failed to parse and were
+// skipped, if any. Parsing tolerates a bad file at runtime so that most of
+// the catalog stays searchable, but a non-empty Failures() means the catalog
+// is incomplete -- the full-build release gate (parser_full_test.go) fails
+// on any entry here rather than shipping a release with a silently gappy
+// catalog.
+func Failures() []FileError {
+	_, _ = Operations()
+	return fileErrors
 }
 
 // Info reports which spec bundle is embedded and, for full builds, the
@@ -154,20 +216,34 @@ func isSpecFile(name string) bool {
 	return strings.HasSuffix(name, ".yaml") && !strings.HasPrefix(name, ".") && !strings.HasPrefix(name, "_")
 }
 
-func parseAll() ([]Operation, error) {
-	entries, err := specFS.ReadDir(rootDir)
+func parseAll() ([]Operation, []FileError, error) {
+	return parseDir(specFS, rootDir)
+}
+
+// parseDir parses every spec file directly under dir in fsys, skipping (and
+// recording in the returned []FileError) any file that fails to parse rather
+// than letting one bad file take down every other file's operations. fsys is
+// a parameter rather than the package-level specFS so this loop's
+// skip-and-continue behavior can be verified with a synthetic in-memory
+// filesystem in tests, without needing a deliberately-broken fixture in the
+// real embedded stub/full bundle.
+func parseDir(fsys fs.FS, dir string) ([]Operation, []FileError, error) {
+	entries, err := fs.ReadDir(fsys, dir)
 	if err != nil {
-		return nil, fmt.Errorf("apispec: reading %s: %w", rootDir, err)
+		return nil, nil, fmt.Errorf("apispec: reading %s: %w", dir, err)
 	}
 
 	var ops []Operation
+	var failures []FileError
 	for _, entry := range entries {
 		if entry.IsDir() || !isSpecFile(entry.Name()) {
 			continue
 		}
-		fileOps, err := parseFile(rootDir + "/" + entry.Name())
+		fileOps, err := parseFile(fsys, dir+"/"+entry.Name())
 		if err != nil {
-			return nil, fmt.Errorf("apispec: parsing %s: %w", entry.Name(), err)
+			log.Warn(fmt.Sprintf("apispec: skipping %s: parsing failed: %s", entry.Name(), err))
+			failures = append(failures, FileError{File: entry.Name(), Err: err})
+			continue
 		}
 		ops = append(ops, fileOps...)
 	}
@@ -178,11 +254,11 @@ func parseAll() ([]Operation, error) {
 		}
 		return ops[i].Method < ops[j].Method
 	})
-	return ops, nil
+	return ops, failures, nil
 }
 
-func parseFile(name string) ([]Operation, error) {
-	data, err := specFS.ReadFile(name)
+func parseFile(fsys fs.FS, name string) ([]Operation, error) {
+	data, err := fs.ReadFile(fsys, name)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +407,7 @@ func propertyType(p rawSchema) string {
 			case p.Items.Ref != "":
 				itemType = schemaRefName(p.Items.Ref)
 			case p.Items.Type != "":
-				itemType = p.Items.Type
+				itemType = string(p.Items.Type)
 			}
 		}
 		return "array<" + itemType + ">"
@@ -339,7 +415,7 @@ func propertyType(p rawSchema) string {
 	if p.Type == "" {
 		return "object"
 	}
-	return p.Type
+	return string(p.Type)
 }
 
 func stringifyDefault(v any) string {

--- a/docs/api-spec/parser_full_test.go
+++ b/docs/api-spec/parser_full_test.go
@@ -1,0 +1,42 @@
+//go:build full
+
+// This test only runs when built with -tags full, i.e. against the real
+// rdme-admin-sourced bundle populated into docs/api-spec/full/ at release
+// time (see embed_full.go). It exists as a release gate for JGC-537: a
+// spec change upstream that this package's narrow parser can't handle
+// (e.g. an OpenAPI construct decoded into the wrong Go type) must fail this
+// test and block the release, rather than surface for the first time as a
+// runtime error from `jf api docs search`/`describe`.
+//
+// The release pipeline that builds the "full" binary must run
+// `go test -tags full ./docs/api-spec/...` (or equivalent) after fetching
+// the rdme-admin bundle and fail the build on any failure here.
+
+package apispec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperations_Full(t *testing.T) {
+	ops, err := Operations()
+	require.NoError(t, err, "the embedded full OpenAPI spec bundle directory must be readable")
+	assert.NotEmpty(t, ops, "the full bundle should declare at least one operation")
+
+	// Operations() tolerates a bad spec file by skipping it (see parseDir) so
+	// that most of the catalog stays searchable at runtime. A release build
+	// must not tolerate that silently, though: any skipped file means part of
+	// the catalog didn't make it in, which should block the release rather
+	// than ship a gap that only surfaces when a user searches for the
+	// missing operation.
+	assert.Empty(t, Failures(), "every embedded full spec file must parse cleanly for a release build")
+}
+
+func TestInfo_Full(t *testing.T) {
+	info := Info()
+	assert.Equal(t, "full", info.SpecBundle)
+	assert.NotEmpty(t, info.SpecVersion, "full builds should report the rdme-admin version they were fetched from")
+}

--- a/docs/api-spec/parser_test.go
+++ b/docs/api-spec/parser_test.go
@@ -72,6 +72,10 @@ func TestOperations_Stub(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "array<string>", groups.Type)
 
+	middleName, ok := propsByName["middle_name"]
+	require.True(t, ok, "middle_name should be a flattened property of UserCreateRequest")
+	assert.Equal(t, "string", middleName.Type, "type: [string, \"null\"] should resolve to its non-null member (JGC-537)")
+
 	deleteWorker, ok := byOperationId["deleteWorker"]
 	require.True(t, ok, "deleteWorker should be present")
 	assert.Equal(t, "DELETE", deleteWorker.Method)

--- a/docs/api-spec/resilience_test.go
+++ b/docs/api-spec/resilience_test.go
@@ -1,0 +1,72 @@
+package apispec
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseDir_SkipsBadFileAndContinues is a regression test for JGC-537: a
+// single spec file that fails to parse must not take down every other
+// file's operations. It uses a synthetic in-memory filesystem rather than a
+// real embedded bundle so the failure case doesn't need to live as a
+// deliberately-broken fixture in the shipped stub/full bundle.
+func TestParseDir_SkipsBadFileAndContinues(t *testing.T) {
+	fsys := fstest.MapFS{
+		"spec/good.yaml": &fstest.MapFile{Data: []byte(`
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      responses:
+        '200':
+          description: OK
+`)},
+		// type as a mapping is invalid under any interpretation (unlike
+		// flexType's string-or-sequence), so this always fails to parse
+		// regardless of what other leniency this package grows over time.
+		"spec/bad.yaml": &fstest.MapFile{Data: []byte(`
+paths:
+  /broken:
+    post:
+      operationId: broken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: {not: a-valid-type}
+      responses:
+        '200':
+          description: OK
+`)},
+	}
+
+	ops, failures, err := parseDir(fsys, "spec")
+	require.NoError(t, err, "one bad file should not fail the whole bundle")
+
+	require.Len(t, ops, 1, "the good file's operation should still be present")
+	assert.Equal(t, "listWidgets", ops[0].OperationId)
+
+	require.Len(t, failures, 1)
+	assert.Equal(t, "bad.yaml", failures[0].File)
+}
+
+func TestParseDir_NoFailuresWhenAllFilesParse(t *testing.T) {
+	fsys := fstest.MapFS{
+		"spec/good.yaml": &fstest.MapFile{Data: []byte(`
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      responses:
+        '200':
+          description: OK
+`)},
+	}
+
+	_, failures, err := parseDir(fsys, "spec")
+	require.NoError(t, err)
+	assert.Empty(t, failures)
+}

--- a/docs/api-spec/stub/users-api.yaml
+++ b/docs/api-spec/stub/users-api.yaml
@@ -247,6 +247,15 @@ components:
           type: boolean
           default: false
           description: Whether UI access is disabled
+        middle_name:
+          # OpenAPI 3.1 / JSON Schema 2020-12 nullable-union form of "type"
+          # (a sequence rather than a scalar). Regression fixture for JGC-537:
+          # apispec must decode this rather than failing to unmarshal a YAML
+          # sequence into a Go string.
+          type:
+            - string
+            - "null"
+          description: The user's middle name, if any
     UserListResponse:
       type: object
       properties:

--- a/general/api/docs_describe_test.go
+++ b/general/api/docs_describe_test.go
@@ -1,3 +1,10 @@
+//go:build !full
+
+// These tests assert exact values from the stub fixtures (bundle name
+// "stub", specific stub operations) and don't apply to a full build (whose
+// docs/api-spec/full/ content is populated at release time) -- same
+// rationale as docs/api-spec/parser_test.go.
+
 package api
 
 import (

--- a/general/api/docs_search_test.go
+++ b/general/api/docs_search_test.go
@@ -1,3 +1,10 @@
+//go:build !full
+
+// These tests assert exact values from the stub fixtures (bundle name
+// "stub", exact operation count, specific stub operations) and don't apply
+// to a full build (whose docs/api-spec/full/ content is populated at
+// release time) -- same rationale as docs/api-spec/parser_test.go.
+
 package api
 
 import (


### PR DESCRIPTION
## Summary
- `rawSchema.Type` now tolerates OpenAPI 3.1's type-as-sequence form (e.g. `type: [string, "null"]`), which yaml.v3 previously refused to unmarshal into a plain string, breaking `jf api docs search`/`describe` (JGC-537).
- Parsing no longer aborts the whole bundle on the first bad file: a file that fails to parse is now skipped (logged as a warning) instead of taking every other file's operations down with it. Added `Failures()` to report skipped files.
- Added a `full`-tagged regression test that fails if any embedded spec file can't be parsed, intended as a release gate for the internal release pipeline that builds with `-tags full` against the real rdme-admin-sourced bundle.
- Excluded `general/api`'s stub-only docs command tests from full builds (they hardcoded the stub bundle's name/count), matching `docs/api-spec/parser_test.go`'s existing convention -- otherwise the new full-build test run fails regardless of the real spec.

- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
