### PR TITLE
Fix jf api rejecting flags placed after the endpoint path

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -143,3 +143,18 @@ func TestApiWithInputFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "200", strings.TrimSpace(string(stderr)))
 }
+
+// TestApiFlagsAfterPath is the JGC-539 regression test: flags placed after the
+// endpoint path must work exactly like flags placed before it, matching the
+// documented 'jf api --help' examples.
+func TestApiFlagsAfterPath(t *testing.T) {
+	initApiTest(t)
+	payloadFile := tests.CreateTempFile(t, "items.find({})")
+	stdout, stderr, err := tests.GetCmdOutput(t, apiCli, "api", "artifactory/api/search/aql", "--method=POST", "--input="+payloadFile, "--header=X-Jfrog-Test: integration-test")
+	require.NoError(t, err)
+	assert.Equal(t, "200", strings.TrimSpace(string(stderr)))
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(stdout, &result))
+	_, hasResults := result["results"]
+	assert.True(t, hasResults)
+}

--- a/main.go
+++ b/main.go
@@ -133,6 +133,10 @@ func execMain() error {
 		},
 	}
 	args := os.Args
+	// jf api has a "docs" subcommand, which makes urfave/cli skip its usual flag
+	// reordering and fail on flags placed after the endpoint path. Work around it
+	// here rather than in the command itself. See NormalizeApiTrailingFlags.
+	args = cliutils.NormalizeApiTrailingFlags(args)
 	cliutils.SetCliExecutableName(args[0])
 	// Auto-promote --format=json (already supported by many commands and by
 	// commands.Exec subcommands) to JFROG_CLI_ERROR_OUTPUT_FORMAT=json so that

--- a/utils/cliutils/api_argv_reorder.go
+++ b/utils/cliutils/api_argv_reorder.go
@@ -1,0 +1,92 @@
+package cliutils
+
+import (
+	"strings"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/urfave/cli"
+)
+
+// NormalizeApiTrailingFlags works around a quirk of urfave/cli v1: a command with
+// Subcommands (like "api", which has "docs") skips the library's own flag
+// reordering and hands args straight to the stdlib flag package, which stops
+// parsing at the first non-flag token. That makes "jf api <path> --flag" fail
+// with a bogus argument-count error, even though it's the documented usage.
+// "jf api docs search/describe" are unaffected (they're leaf commands, so
+// urfave/cli reorders their flags on its own) and must be left untouched here.
+func NormalizeApiTrailingFlags(argv []string) []string {
+	if len(argv) < 3 || argv[1] != "api" {
+		return argv
+	}
+	if len(argv) >= 3 && argv[2] == "docs" {
+		return argv
+	}
+
+	prefix := argv[:2]
+	tail := append([]string(nil), argv[2:]...)
+	flagTokens, positionals := extractKnownFlags(GetCommandFlags(Api), tail)
+
+	reordered := make([]string, 0, len(argv)-2)
+	reordered = append(reordered, flagTokens...)
+	reordered = append(reordered, positionals...)
+	return append(prefix, reordered...)
+}
+
+// extractKnownFlags pulls every occurrence of the given flags out of args, wherever
+// they appear, and returns them separately from the remaining positional arguments.
+// Relative order is preserved within each group.
+func extractKnownFlags(flags []cli.Flag, args []string) (flagTokens, positionals []string) {
+	remaining := append([]string(nil), args...)
+	for _, f := range flags {
+		aliases := flagAliases(f)
+		if _, isBool := f.(cli.BoolFlag); isBool {
+			for {
+				flagIndex, _, err := findFirstBooleanFlag(aliases, remaining)
+				if err != nil || flagIndex == -1 {
+					break
+				}
+				flagTokens = append(flagTokens, remaining[flagIndex])
+				coreutils.RemoveFlagFromCommand(&remaining, flagIndex, flagIndex)
+			}
+			continue
+		}
+		for {
+			flagIndex, flagValueIndex, _, err := coreutils.FindFlagFirstMatch(aliases, remaining)
+			if err != nil || flagIndex == -1 {
+				break
+			}
+			flagTokens = append(flagTokens, remaining[flagIndex:flagValueIndex+1]...)
+			coreutils.RemoveFlagFromCommand(&remaining, flagIndex, flagValueIndex)
+		}
+	}
+	return flagTokens, remaining
+}
+
+func findFirstBooleanFlag(aliases, args []string) (flagIndex int, flagValue bool, err error) {
+	for _, alias := range aliases {
+		flagIndex, flagValue, err = coreutils.FindBooleanFlag(alias, args)
+		if err != nil || flagIndex != -1 {
+			return
+		}
+	}
+	return -1, false, nil
+}
+
+// flagAliases returns every spelling of a flag, dash-prefixed as urfave/cli expects
+// it on the command line, e.g. "header, H" -> ["--header", "-H"].
+func flagAliases(f cli.Flag) []string {
+	names := strings.Split(f.GetName(), ",")
+	aliases := make([]string, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if len(name) == 1 {
+			aliases = append(aliases, "-"+name)
+		} else {
+			aliases = append(aliases, "--"+name)
+		}
+	}
+	return aliases
+}

--- a/utils/cliutils/api_argv_reorder_test.go
+++ b/utils/cliutils/api_argv_reorder_test.go
@@ -1,0 +1,128 @@
+package cliutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli"
+)
+
+func TestNormalizeApiTrailingFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+		want []string
+	}{
+		{
+			name: "JGC-539 repro: single flag after path",
+			argv: []string{"jf", "api", "/xray/api/v1/system/version", "--server-id=repo21"},
+			want: []string{"jf", "api", "--server-id=repo21", "/xray/api/v1/system/version"},
+		},
+		{
+			// Flags are extracted in the command's own flag-definition order (alphabetical
+			// by flag name, see buildAndSortFlags), not their original relative order in
+			// argv -- that's fine, since flag.Parse doesn't care about order between
+			// distinct flags, only that each flag stays adjacent to its own value.
+			name: "JGC-539 repro: multiple flags after path",
+			argv: []string{"jf", "api", "/xray/api/v1/ignore_rules", "-X", "POST", "-H", "Content-Type: application/json", "--input", "./body.json"},
+			want: []string{"jf", "api", "-H", "Content-Type: application/json", "--input", "./body.json", "-X", "POST", "/xray/api/v1/ignore_rules"},
+		},
+		{
+			name: "flags already before path: no-op",
+			argv: []string{"jf", "api", "--server-id=repo21", "/xray/api/v1/system/version"},
+			want: []string{"jf", "api", "--server-id=repo21", "/xray/api/v1/system/version"},
+		},
+		{
+			name: "boolean flag after path",
+			argv: []string{"jf", "api", "/artifactory/api/repositories", "--verbose"},
+			want: []string{"jf", "api", "--verbose", "/artifactory/api/repositories"},
+		},
+		{
+			name: "repeated header flag after path",
+			argv: []string{"jf", "api", "/artifactory/api/repositories", "-H", "A: 1", "-H", "B: 2"},
+			want: []string{"jf", "api", "-H", "A: 1", "-H", "B: 2", "/artifactory/api/repositories"},
+		},
+		{
+			name: "too many positionals: order preserved, arity error left for the real parser",
+			argv: []string{"jf", "api", "/a", "/b", "-X", "GET"},
+			want: []string{"jf", "api", "-X", "GET", "/a", "/b"},
+		},
+		{
+			name: "unrecognized flag after path is left untouched",
+			argv: []string{"jf", "api", "/artifactory/api/repositories", "--bogus", "x"},
+			want: []string{"jf", "api", "/artifactory/api/repositories", "--bogus", "x"},
+		},
+		{
+			name: "docs search: untouched",
+			argv: []string{"jf", "api", "docs", "search", "user", "--tag=access"},
+			want: []string{"jf", "api", "docs", "search", "user", "--tag=access"},
+		},
+		{
+			name: "docs describe: untouched",
+			argv: []string{"jf", "api", "docs", "describe", "GET", "/access/api/v2/users", "--format=json"},
+			want: []string{"jf", "api", "docs", "describe", "GET", "/access/api/v2/users", "--format=json"},
+		},
+		{
+			name: "bare docs: untouched",
+			argv: []string{"jf", "api", "docs"},
+			want: []string{"jf", "api", "docs"},
+		},
+		{
+			name: "unrelated command: untouched",
+			argv: []string{"jf", "rt", "upload", "a", "b", "--flat=true"},
+			want: []string{"jf", "rt", "upload", "a", "b", "--flat=true"},
+		},
+		{
+			name: "argv too short: untouched",
+			argv: []string{"jf", "api"},
+			want: []string{"jf", "api"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, NormalizeApiTrailingFlags(tt.argv))
+		})
+	}
+}
+
+// TestNormalizeApiTrailingFlags_FixesRealParsing proves the reordering actually
+// resolves urfave/cli's arity/flag-parsing failure for "api", using the same
+// Flags + Subcommands shape production registers in main.go.
+func TestNormalizeApiTrailingFlags_FixesRealParsing(t *testing.T) {
+	var gotArgs cli.Args
+	var gotMethod string
+	var gotHeaders []string
+	var gotInput string
+
+	app := cli.NewApp()
+	app.Commands = []cli.Command{
+		{
+			Name:  "api",
+			Flags: GetCommandFlags(Api),
+			Action: func(c *cli.Context) error {
+				gotArgs = c.Args()
+				gotMethod = c.String("method")
+				gotHeaders = c.StringSlice("header")
+				gotInput = c.String("input")
+				return nil
+			},
+			Subcommands: []cli.Command{{Name: "docs"}},
+		},
+	}
+
+	rawArgs := []string{"jf", "api", "/xray/api/v1/ignore_rules", "-X", "POST", "-H", "Content-Type: application/json", "--input", "./body.json"}
+
+	// Sanity check: without the fix, urfave/cli's flag parsing breaks on this
+	// exact input (path before flags), matching the ticket's reported bug.
+	require.NoError(t, app.Run(rawArgs))
+	assert.NotEqual(t, 1, len(gotArgs), "expected the unfixed argv to already be broken (more than 1 positional arg)")
+
+	gotArgs, gotMethod, gotHeaders, gotInput = nil, "", nil, ""
+	require.NoError(t, app.Run(NormalizeApiTrailingFlags(rawArgs)))
+	require.Equal(t, 1, len(gotArgs))
+	assert.Equal(t, "/xray/api/v1/ignore_rules", gotArgs.First())
+	assert.Equal(t, "POST", gotMethod)
+	assert.Equal(t, []string{"Content-Type: application/json"}, gotHeaders)
+	assert.Equal(t, "./body.json", gotInput)
+}


### PR DESCRIPTION
## Summary
- jf api has a docs subcommand, which makes urfave/cli v1 skip its own flag-reordering, so flags typed after the endpoint path failed with "Wrong number of arguments" (JGC-539). docs search/describe are unaffected and untouched.
- Reorders argv before urfave/cli parses it, reusing jfrog-cli-core's existing flag-scanning helpers.

- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the master branch.
- [x] The code has been validated to compile successfully by running go vet ./....
- [x] The code has been formatted properly using go fmt ./....
