### PR TITLE
Add --legacy flag to jf login and jf c add

### DIFF
--- a/config/cli.go
+++ b/config/cli.go
@@ -153,7 +153,8 @@ func addOrEdit(c *cli.Context, operation configOperation) error {
 		SetInteractive(configCommandConfiguration.Interactive).
 		SetEncPassword(configCommandConfiguration.EncPassword).
 		SetUseBasicAuthOnly(configCommandConfiguration.BasicAuthOnly).
-		SetOIDCParams(configCommandConfiguration.OidcParams)
+		SetOIDCParams(configCommandConfiguration.OidcParams).
+		SetLegacy(configCommandConfiguration.Legacy)
 
 	return configCmd.Run()
 }
@@ -360,6 +361,7 @@ func CreateConfigCommandConfiguration(c *cli.Context) (configCommandConfiguratio
 	configCommandConfiguration.EncPassword = c.BoolT(cliutils.EncPassword)
 	configCommandConfiguration.Interactive = cliutils.GetInteractiveValue(c)
 	configCommandConfiguration.BasicAuthOnly = c.Bool(cliutils.BasicAuthOnly)
+	configCommandConfiguration.Legacy = c.Bool(cliutils.Legacy)
 	return
 }
 

--- a/docs/config/add/help.go
+++ b/docs/config/add/help.go
@@ -23,12 +23,14 @@ Common patterns:
   $ jf c add my-server --url=https://mycorp.jfrog.io --user=admin --password=secret --interactive=false
   $ jf c add my-server --url=https://mycorp.jfrog.io --access-token=eyJ... --interactive=false
   $ jf c add my-server --overwrite
+  $ jf c add my-server --legacy
 
 Gotchas:
 - The command is interactive by default. Pass --interactive=false in scripts and CI.
 - Re-adding an existing server ID fails unless --overwrite is set; use 'jf c edit' to modify in place.
 - Server IDs cannot be "delete", "use", "show", or "clear" (reserved names).
 - --basic-auth-only is incompatible with --access-token.
+- By default the interactive flow only asks for the platform URL. --legacy restores prompts for each service's own URL (Artifactory, Distribution, Xray, Mission Control, Pipelines), for Artifactory v6.x self-hosted setups where these don't share a single platform URL.
 
 Related: jf c edit, jf c show, jf c use, jf login
 

--- a/docs/general/login/help.go
+++ b/docs/general/login/help.go
@@ -7,7 +7,7 @@ func GetDescription() string {
 }
 
 func GetAIDescription() string {
-	return `Authenticate to a JFrog Platform interactively via your default web browser. Returns an access token and persists a server configuration under ~/.jfrog/. Works for Artifactory 7.64.0+. Headless environments (CI, agents) should prefer 'jf c add' with --access-token instead.
+	return `Authenticate to a JFrog Platform interactively via your default web browser. Returns an access token and persists a server configuration under ~/.jfrog/. Always uses a single JFrog Platform URL (no per-service paths). Works for Artifactory 7.64.0+. Headless environments (CI, agents) should prefer 'jf c add' with --access-token instead.
 
 When to use:
 - First-time setup on a developer workstation where a browser is available.
@@ -20,9 +20,11 @@ Prerequisites:
 Common patterns:
   $ jf login
   $ jf login --disable-token-refresh
+  $ jf login --legacy
 
 Gotchas:
-- Requires Artifactory 7.64.0 or newer; older targets must use 'jf c add'.
+- Requires Artifactory 7.64.0 or newer; older targets must use 'jf c add', or 'jf login --legacy'.
+- --legacy is for Artifactory v6.x self-hosted, where Artifactory/Distribution/Xray/Mission Control/Pipelines don't share a single platform URL. It skips the browser-based web login and prompts for each service's URL and standard credentials instead.
 - Does not work in CI/headless environments — no browser to open.
 - The flow stores credentials locally under ~/.jfrog/.
 - --disable-token-refresh persists in the saved server config; omitting the flag on a later 'jf login' re-run leaves the previously saved value untouched.

--- a/general/login/cli.go
+++ b/general/login/cli.go
@@ -12,7 +12,7 @@ func LoginCmd(c *cli.Context) error {
 	if c.NArg() > 0 {
 		return cliutils.WrongNumberOfArgumentsHandler(c)
 	}
-	loginCmd := coreLogin.NewLoginCommand().SetServerId(c.String("server-id"))
+	loginCmd := coreLogin.NewLoginCommand().SetServerId(c.String("server-id")).SetLegacy(c.Bool(cliutils.Legacy))
 	if c.IsSet(disableTokenRefreshFlag) {
 		disableTokenRefresh := c.Bool(disableTokenRefreshFlag)
 		loginCmd.SetDisableTokenRefresh(&disableTokenRefresh)

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847
 	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260812053557-d311dd344da9
-	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260813123937-e7fa28b75506
+	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260814071425-102723197072
 	github.com/jfrog/jfrog-cli-evidence v0.10.0
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260618062042-6053ab368cab
 	github.com/jfrog/jfrog-cli-security v1.33.1

--- a/go.sum
+++ b/go.sum
@@ -404,8 +404,8 @@ github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847 h1:w
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847/go.mod h1:p8yLtbmCxxQucIbLZKnWu0F+EDtj6NLXbRQCEK/nb6o=
 github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260812053557-d311dd344da9 h1:6N87yf7y1Zce1DvqZ1zX1sWirdJ7lh04mFvjr1JhVL0=
 github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260812053557-d311dd344da9/go.mod h1:eYyYY+GMdddy75/rCWiKg8EydGp/jRY+9+30QkGpbGw=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260813123937-e7fa28b75506 h1:LgAoLyXkXzQ3AaJ10YVq1HAl38vVy75kFElDb6nEgEM=
-github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260813123937-e7fa28b75506/go.mod h1:gf7aUg/G9JyltCNhwMD5RVEsFzUCKPWKXRcTXSqMYBk=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260814071425-102723197072 h1:lWQd4C+sXVQW3xvFhQkkLivwx5//bQnjbd+P5Cr3FLY=
+github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260814071425-102723197072/go.mod h1:gf7aUg/G9JyltCNhwMD5RVEsFzUCKPWKXRcTXSqMYBk=
 github.com/jfrog/jfrog-cli-evidence v0.10.0 h1:9wbdHOl+wcN3crNw5qtQtQ0N28NX+9QH/Yo3Ia+iYhc=
 github.com/jfrog/jfrog-cli-evidence v0.10.0/go.mod h1:xTtHBeiVg3gbJ7jcx48sMlcWlCsRnvqlPKpbGJt22k0=
 github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260618062042-6053ab368cab h1:Zn/qB8LYhSu82YDtbqXwErN1RPHTHe/a3gQY6Ti/OBE=

--- a/utils/cliutils/commandsflags.go
+++ b/utils/cliutils/commandsflags.go
@@ -237,6 +237,7 @@ const (
 	EncPassword   = "enc-password"
 	BasicAuthOnly = "basic-auth-only"
 	Overwrite     = "overwrite"
+	Legacy        = "legacy"
 
 	// Unique upload flags
 	uploadPrefix      = "upload-"
@@ -1022,6 +1023,10 @@ var flagsMap = map[string]cli.Flag{
 	interactive: cli.BoolTFlag{
 		Name:  interactive,
 		Usage: "[Default: true, unless $CI is true] Set to false if you don't want the config command to be interactive. If true, the --url option becomes optional.` `",
+	},
+	Legacy: cli.BoolFlag{
+		Name:  Legacy,
+		Usage: "[Default: false] Set to true to configure or log in to a JFrog Platform where products don't share a single unified URL, such as Artifactory 6.x self-hosted. When set, you'll be prompted to review or override each service's URL (Artifactory, Distribution, Xray, Mission Control, Pipelines), and 'jf login' will use standard authentication instead of the browser-based web login.` `",
 	},
 	EncPassword: cli.BoolTFlag{
 		Name:  EncPassword,
@@ -2079,11 +2084,11 @@ var commandFlags = map[string][]string{
 	AddConfig: {
 		interactive, EncPassword, configPlatformUrl, configRtUrl, configDistUrl, configXrUrl, configMcUrl, configPlUrl, configUser, configPassword, configAccessToken, sshKeyPath, sshPassphrase, ClientCertPath,
 		ClientCertKeyPath, BasicAuthOnly, configInsecureTls, Overwrite, passwordStdin, accessTokenStdin, OidcTokenID,
-		OidcProviderName, OidcAudience, OidcProviderType, ApplicationKey, configDisableRefreshAccessToken,
+		OidcProviderName, OidcAudience, OidcProviderType, ApplicationKey, configDisableRefreshAccessToken, Legacy,
 	},
 	EditConfig: {
 		interactive, EncPassword, configPlatformUrl, configRtUrl, configDistUrl, configXrUrl, configMcUrl, configPlUrl, configUser, configPassword, configAccessToken, sshKeyPath, sshPassphrase, ClientCertPath,
-		ClientCertKeyPath, BasicAuthOnly, configInsecureTls, passwordStdin, accessTokenStdin, configDisableRefreshAccessToken,
+		ClientCertKeyPath, BasicAuthOnly, configInsecureTls, passwordStdin, accessTokenStdin, configDisableRefreshAccessToken, Legacy,
 	},
 	DeleteConfig: {
 		deleteQuiet,
@@ -2497,7 +2502,7 @@ var commandFlags = map[string][]string{
 		aptDistribution, aptComponent, aptTrusted, aptImportKey, aptRemove,
 	},
 	Login: {
-		serverId, configDisableRefreshAccessToken,
+		serverId, configDisableRefreshAccessToken, Legacy,
 	},
 }
 


### PR DESCRIPTION
By default, `jf login` and `jf c add` now only use the main JFrog Platform URL. A new `--legacy` flag restores prompts for each service's own URL (Artifactory/Distribution/Xray/Mission Control/Pipelines) and, for `jf login`, skips the browser-based web login, for Artifactory v6.x self-hosted setups where these products don't share one platform URL.

**Depends on** https://github.com/jfrog/jfrog-cli-core/pull/1605 (not yet merged) — `go.mod` currently points directly at that branch (`feature/JGC-487`) and is marked with a `remove before merging` comment. This PR should not be merged until the core PR is merged/released and `go.mod` is updated to reference a real released version.

- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`. (Note: `config/cli.go` has one pre-existing, unrelated import-ordering diff from `gofmt`; left untouched to keep this PR scoped.)

---
