### PR TITLE
Add QA section to AI descriptions for permission-target, users, groups, transfer, and config commands

### DIFF
--- a/docs/artifactory/groupaddusers/help.go
+++ b/docs/artifactory/groupaddusers/help.go
@@ -35,5 +35,16 @@ Gotchas:
 - Users not already created on the server are not added; the command may succeed with a partial set.
 - Existing memberships are preserved; this is additive, not a full replacement.
 
-Related: jf rt gc, jf rt gdel, jf rt user-create, jf rt uc`
+Related: jf rt gc, jf rt gdel, jf rt user-create, jf rt uc
+
+QA:
+Q: Could you guide me through the process of adding users to a group in JFrog Artifactory considering that the group name is 'group1' and the users are 'user1,user2,user3'?
+A: jf rt gau group1 'user1,user2,user3'
+
+Q: Could you elucidate the approach for inserting users into a group in JFrog Artifactory provided the group name is 'group3' and the users are 'user7,user8,user9'?
+A: jf rt gau group3 'user7,user8,user9'
+
+Q: Could you outline the procedure for adding users to a group in JFrog Artifactory with the group name being 'group5' and the users are 'user13,user14,user15'?
+A: jf rt gau group5 'user13,user14,user15'
+`
 }

--- a/docs/artifactory/groupcreate/help.go
+++ b/docs/artifactory/groupcreate/help.go
@@ -29,5 +29,16 @@ Gotchas:
 - Group names must be unique on the server.
 - The group is created empty; member assignment is a separate 'jf rt gau' call.
 
-Related: jf rt gau, jf rt gdel, jf rt ptc`
+Related: jf rt gau, jf rt gdel, jf rt ptc
+
+QA:
+Q: Could you guide me through the process of creating a group in JFrog Artifactory considering that the group name is 'group1'?
+A: jf rt gc group1
+
+Q: Could you elucidate the approach for forming a group in JFrog Artifactory provided the group name is 'group3'?
+A: jf rt gc group3
+
+Q: Could you outline the procedure for constructing a group in JFrog Artifactory with the group name being 'group5'?
+A: jf rt gc group5
+`
 }

--- a/docs/artifactory/groupdelete/help.go
+++ b/docs/artifactory/groupdelete/help.go
@@ -28,5 +28,16 @@ Gotchas:
 - No undo; recreate via 'jf rt gc' and re-add users with 'jf rt gau' if needed.
 - Deleting a group does not delete permission targets that reference it; those will lose the group as a principal silently.
 
-Related: jf rt gc, jf rt gau, jf rt ptu`
+Related: jf rt gc, jf rt gau, jf rt ptu
+
+QA:
+Q: Could you guide me through the process of deleting a group in JFrog Artifactory considering that the group name is 'group1'?
+A: jf rt gdel group1
+
+Q: Could you elucidate the approach for eradicating a group in JFrog Artifactory provided the group name is 'group3'?
+A: jf rt gdel group3
+
+Q: Could you outline the procedure for discarding a group in JFrog Artifactory with the group name being 'group5'?
+A: jf rt gdel group5
+`
 }

--- a/docs/artifactory/groupdelete/help.go
+++ b/docs/artifactory/groupdelete/help.go
@@ -34,7 +34,7 @@ QA:
 Q: Could you guide me through the process of deleting a group in JFrog Artifactory considering that the group name is 'group1'?
 A: jf rt gdel group1
 
-Q: Could you elucidate the approach for eradicating a group in JFrog Artifactory provided the group name is 'group3'?
+Q: Could you elucidate the approach for removing a group in JFrog Artifactory provided the group name is 'group3'?
 A: jf rt gdel group3
 
 Q: Could you outline the procedure for discarding a group in JFrog Artifactory with the group name being 'group5'?

--- a/docs/artifactory/permissiontargetcreate/help.go
+++ b/docs/artifactory/permissiontargetcreate/help.go
@@ -34,5 +34,16 @@ Gotchas:
 - The JSON schema is strict; missing required fields produce a 400 from the server.
 - --vars allows templated variable substitution (key=value pairs).
 
-Related: jf rt ptt, jf rt ptu, jf rt ptdel`
+Related: jf rt ptt, jf rt ptu, jf rt ptdel
+
+QA:
+Q: Could you guide me through the process of creating a permission target in JFrog Artifactory considering that the template path is 'template1.json'?
+A: jf rt ptc template1.json
+
+Q: Could you elucidate the approach for forming a permission target in JFrog Artifactory provided the template path is 'template3.json'?
+A: jf rt ptc template3.json
+
+Q: Could you outline the procedure for constructing a permission target in JFrog Artifactory with the template path being 'template5.json'?
+A: jf rt ptc template5.json
+`
 }

--- a/docs/artifactory/permissiontargetdelete/help.go
+++ b/docs/artifactory/permissiontargetdelete/help.go
@@ -31,5 +31,16 @@ Gotchas:
 - Removing a permission target does NOT delete the repos, users, or groups it referenced.
 - --quiet skips the confirmation prompt; useful in CI.
 
-Related: jf rt ptc, jf rt ptu`
+Related: jf rt ptc, jf rt ptu
+
+QA:
+Q: Could you guide me through the process of deleting a permission target in JFrog Artifactory considering that the permission target name is 'target1'?
+A: jf rt ptdel target1
+
+Q: Could you elucidate the approach for eradicating a permission target in JFrog Artifactory provided the permission target name is 'target3'?
+A: jf rt ptdel target3
+
+Q: Could you outline the procedure for discarding a permission target in JFrog Artifactory with the permission target name being 'target5'?
+A: jf rt ptdel target5
+`
 }

--- a/docs/artifactory/permissiontargetdelete/help.go
+++ b/docs/artifactory/permissiontargetdelete/help.go
@@ -37,7 +37,7 @@ QA:
 Q: Could you guide me through the process of deleting a permission target in JFrog Artifactory considering that the permission target name is 'target1'?
 A: jf rt ptdel target1
 
-Q: Could you elucidate the approach for eradicating a permission target in JFrog Artifactory provided the permission target name is 'target3'?
+Q: Could you elucidate the approach for removing a permission target in JFrog Artifactory provided the permission target name is 'target3'?
 A: jf rt ptdel target3
 
 Q: Could you outline the procedure for discarding a permission target in JFrog Artifactory with the permission target name being 'target5'?

--- a/docs/artifactory/permissiontargettemplate/help.go
+++ b/docs/artifactory/permissiontargettemplate/help.go
@@ -28,5 +28,16 @@ Gotchas:
 - This is an interactive command; does not work in non-TTY environments.
 - The generated file is plain JSON; edit it before passing to ptc/ptu for production use.
 
-Related: jf rt ptc, jf rt ptu, jf rt ptdel`
+Related: jf rt ptc, jf rt ptu, jf rt ptdel
+
+QA:
+Q: Could you guide me through the process of creating a permission target template in Artifactory considering that the template path is 'template1.json'?
+A: jf rt ptt template1.json
+
+Q: Could you elucidate the approach for establishing a permission target template in Artifactory provided the template path is 'template3.json'?
+A: jf rt ptt template3.json
+
+Q: Could you outline the procedure for forming a permission target template in Artifactory with the template path being 'template5.json'?
+A: jf rt ptt template5.json
+`
 }

--- a/docs/artifactory/permissiontargetupdate/help.go
+++ b/docs/artifactory/permissiontargetupdate/help.go
@@ -33,5 +33,16 @@ Gotchas:
 - The update is a full replacement; missing fields revert to defaults.
 - After updating, verify the result with 'jf api /artifactory/api/v2/security/permissions/<name>'.
 
-Related: jf rt ptt, jf rt ptc, jf rt ptdel`
+Related: jf rt ptt, jf rt ptc, jf rt ptdel
+
+QA:
+Q: Could you guide me through the process of updating a permission target in Artifactory considering that the template path is 'template1.json'?
+A: jf rt ptu template1.json
+
+Q: Could you elucidate the approach for altering a permission target in Artifactory provided the template path is 'template3.json'?
+A: jf rt ptu template3.json
+
+Q: Could you outline the procedure for adjusting a permission target in Artifactory with the template path being 'template5.json'?
+A: jf rt ptu template5.json
+`
 }

--- a/docs/artifactory/transferconfigmerge/help.go
+++ b/docs/artifactory/transferconfigmerge/help.go
@@ -34,5 +34,10 @@ Gotchas:
 - Only repos and projects are merged; permission targets, users, and other config are NOT.
 - Run during low-traffic windows on the source to avoid mid-export drift.
 
-Related: jf rt transfer-config, jf rt transfer-files`
+Related: jf rt transfer-config, jf rt transfer-files
+
+QA:
+Q: How can I merge the configurations from the source server to the target server in JFrog Artifactory?
+A: jf rt transfer-config-merge source-server target-server
+`
 }

--- a/docs/artifactory/transferfiles/help.go
+++ b/docs/artifactory/transferfiles/help.go
@@ -38,5 +38,16 @@ Gotchas:
 - Throughput is governed by 'jf rt transfer-settings'; defaults are conservative.
 - Idempotent on file content but not on repo property changes; re-running after a target-side delete causes redelivery.
 
-Related: jf rt transfer-config, jf rt transfer-settings, jf rt transfer-plugin-install`
+Related: jf rt transfer-config, jf rt transfer-settings, jf rt transfer-plugin-install
+
+QA:
+Q: What's the JFrog CLI command to transfer the configuration from my artifactory to the target artifactory?
+A: jf rt transfer-config source-server target-server
+
+Q: What is the command to stop the ongoing file transfer process in JFrog Artifactory?
+A: jf rt transfer-files --stop
+
+Q: What is the command to manually copy the filestore to reduce the transfer time in JFrog Artifactory?
+A: jf rt transfer-files source-server target-server --filestore
+`
 }

--- a/docs/artifactory/transferplugininstall/help.go
+++ b/docs/artifactory/transferplugininstall/help.go
@@ -31,5 +31,10 @@ Gotchas:
 - The plugin requires a Groovy plugins admin restart (or wait for the scheduled reload).
 - This command only targets self-hosted instances; cloud-hosted sources need a different transfer mechanism.
 
-Related: jf rt transfer-files, jf rt transfer-settings`
+Related: jf rt transfer-files, jf rt transfer-settings
+
+QA:
+Q: What's the JFrog CLI command to install the data-transfer user plugin in the primary node of the source instance?
+A: jf rt transfer-plugin-install source-server
+`
 }

--- a/docs/artifactory/transfersettings/help.go
+++ b/docs/artifactory/transfersettings/help.go
@@ -23,5 +23,10 @@ Gotchas:
 - Interactive only; cannot be scripted directly. For automation, edit ~/.jfrog/transfer-settings.json directly.
 - Settings apply across all subsequent transfer-files invocations.
 
-Related: jf rt transfer-files, jf rt transfer-config`
+Related: jf rt transfer-files, jf rt transfer-config
+
+QA:
+Q: How can I adjust the file transfer speed in JFrog Artifactory?
+A: jf rt transfer-settings
+`
 }

--- a/docs/artifactory/userscreate/help.go
+++ b/docs/artifactory/userscreate/help.go
@@ -26,5 +26,16 @@ Gotchas:
 - --replace=true overwrites existing users with the same username (destructive).
 - Passwords sit in plaintext in the CSV; protect the file and delete after use.
 
-Related: jf rt user-create, jf rt udel, jf rt gau`
+Related: jf rt user-create, jf rt udel, jf rt gau
+
+QA:
+Q: Could you guide me through the process of creating users in JFrog Artifactory considering that the details for the users are in the present CSV file named 'users.csv'?
+A: jf rt uc --csv users.csv
+
+Q: Could you elucidate the approach for creating users in JFrog Artifactory provided the user details exist within a CSV file named 'team.csv'?
+A: jf rt uc --csv team.csv
+
+Q: Could you outline the procedure for creating users in JFrog Artifactory with the user details situated within a CSV file labeled 'employees.csv'?
+A: jf rt uc --csv employees.csv
+`
 }

--- a/docs/artifactory/usersdelete/help.go
+++ b/docs/artifactory/usersdelete/help.go
@@ -30,5 +30,16 @@ Gotchas:
 - No undo. Audit beforehand with 'jf api /artifactory/api/security/users'.
 - Deleting a user does NOT revoke long-lived access tokens issued to that user; rotate or revoke those separately.
 
-Related: jf rt user-create, jf rt uc, jf rt gdel`
+Related: jf rt user-create, jf rt uc, jf rt gdel
+
+QA:
+Q: Could you guide me through the process of deleting users in JFrog Artifactory considering that the usernames are 'user1,user2,user3'?
+A: jf rt udel 'user1,user2,user3'
+
+Q: Could you elucidate the approach for eradicating users in JFrog Artifactory provided the usernames are 'user7,user8,user9'?
+A: jf rt udel 'user7,user8,user9'
+
+Q: Could you outline the procedure for discarding users in JFrog Artifactory with the usernames being 'user13,user14,user15'?
+A: jf rt udel 'user13,user14,user15'
+`
 }

--- a/docs/artifactory/usersdelete/help.go
+++ b/docs/artifactory/usersdelete/help.go
@@ -36,7 +36,7 @@ QA:
 Q: Could you guide me through the process of deleting users in JFrog Artifactory considering that the usernames are 'user1,user2,user3'?
 A: jf rt udel 'user1,user2,user3'
 
-Q: Could you elucidate the approach for eradicating users in JFrog Artifactory provided the usernames are 'user7,user8,user9'?
+Q: Could you elucidate the approach for removing users in JFrog Artifactory provided the usernames are 'user7,user8,user9'?
 A: jf rt udel 'user7,user8,user9'
 
 Q: Could you outline the procedure for discarding users in JFrog Artifactory with the usernames being 'user13,user14,user15'?

--- a/docs/config/add/help.go
+++ b/docs/config/add/help.go
@@ -33,13 +33,13 @@ Gotchas:
 Related: jf c edit, jf c show, jf c use, jf login
 
 QA:
-Q: What's the JFrog CLI command to add a new server configuration to the JFrog Platform?
+Q: What's the JFrog CLI command to configure a new JFrog Platform server?
 A: jf c add
 
 Q: I want to add a new server configuration with the URL 'https://my-jfrog-platform.com' and the username 'my-username'. What's the command for that?
 A: jf c add --url=https://my-jfrog-platform.com --user=my-username
 
-Q: What's the command to add a new server configuration with the URL 'https://my-jfrog-platform.com' the username 'my-username' the password 'my-password' and the Artifactory URL 'https://my-artifactory.com'?
-A: jf c add --url='https://my-jfrog-platform.com' --user=my-username --password='my-password' --artifactory-url='https://my-artifactory.com'
+Q: What's the command to add a new server configuration with the URL 'https://my-jfrog-platform.com' the username 'my-username' and the password 'my-password'?
+A: jf c add --url='https://my-jfrog-platform.com' --user=my-username --password='my-password'
 `
 }

--- a/docs/config/add/help.go
+++ b/docs/config/add/help.go
@@ -30,5 +30,16 @@ Gotchas:
 - Server IDs cannot be "delete", "use", "show", or "clear" (reserved names).
 - --basic-auth-only is incompatible with --access-token.
 
-Related: jf c edit, jf c show, jf c use, jf login`
+Related: jf c edit, jf c show, jf c use, jf login
+
+QA:
+Q: What's the JFrog CLI command to add a new server configuration to the JFrog Platform?
+A: jf c add
+
+Q: I want to add a new server configuration with the URL 'https://my-jfrog-platform.com' and the username 'my-username'. What's the command for that?
+A: jf c add --url=https://my-jfrog-platform.com --user=my-username
+
+Q: What's the command to add a new server configuration with the URL 'https://my-jfrog-platform.com' the username 'my-username' the password 'my-password' and the Artifactory URL 'https://my-artifactory.com'?
+A: jf c add --url='https://my-jfrog-platform.com' --user=my-username --password='my-password' --artifactory-url='https://my-artifactory.com'
+`
 }

--- a/docs/config/edit/help.go
+++ b/docs/config/edit/help.go
@@ -26,5 +26,16 @@ Gotchas:
 - Interactive mode is on by default. Use --interactive=false for scripts.
 - Only the fields you pass are updated; omitted fields keep their previous values.
 
-Related: jf c add, jf c show, jf c use, jf c rm`
+Related: jf c add, jf c show, jf c use, jf c rm
+
+QA:
+Q: What's the JFrog CLI command to adjust a server configuration with the ID 'my-server'?
+A: jf c edit my-server
+
+Q: I want to modify the server configuration with the ID 'my-server' change the URL to 'https://new-jfrog-platform.com' and change the username to 'new-username'. What's the command for that?
+A: jf c edit my-server --url='https://new-jfrog-platform.com' --user='new-username'
+
+Q: What's the command to update the server configuration with the ID 'my-server' change the URL to 'https://new-jfrog-platform.com' change the username to 'new-username' change the password to 'new-password' and change the Artifactory URL to 'https://new-artifactory.com'?
+A: jf c edit my-server --url='https://new-jfrog-platform.com' --user='new-username' --password='new-password' --artifactory-url='https://new-artifactory.com'
+`
 }

--- a/docs/config/exportcmd/help.go
+++ b/docs/config/exportcmd/help.go
@@ -26,5 +26,10 @@ Gotchas:
 - The token embeds credentials; redact or treat as secret. Do not paste into logs or commit to version control.
 - The token is not human-readable but is reversible; security is "obfuscated", not encrypted.
 
-Related: jf c import, jf c show`
+Related: jf c import, jf c show
+
+QA:
+Q: What's the JFrog CLI command to generate a token that stores the server configuration for the server with the ID 'my-server'?
+A: jf c export my-server
+`
 }

--- a/docs/config/importcmd/help.go
+++ b/docs/config/importcmd/help.go
@@ -25,5 +25,10 @@ Gotchas:
 - The token contains credentials; treat it like a password and never commit it.
 - The imported server ID inherits from the original; if it collides with an existing one, the import fails.
 
-Related: jf c export, jf c add, jf c show`
+Related: jf c export, jf c add, jf c show
+
+QA:
+Q: What's the JFrog CLI command to import a server configuration from a token?
+A: jf c import <token>
+`
 }

--- a/docs/config/remove/help.go
+++ b/docs/config/remove/help.go
@@ -36,7 +36,7 @@ Gotchas:
 Related: jf c add, jf c show, jf c use
 
 QA:
-Q: What's the JFrog CLI command to eliminate a server configuration with the ID 'my-server'?
+Q: What's the JFrog CLI command to remove a server configuration with the ID 'my-server'?
 A: jf c rm my-server
 `
 }

--- a/docs/config/remove/help.go
+++ b/docs/config/remove/help.go
@@ -33,5 +33,10 @@ Gotchas:
 - No undo; re-add via 'jf c add' if removed by mistake.
 - Removing the active server leaves no default until you run 'jf c use'.
 
-Related: jf c add, jf c show, jf c use`
+Related: jf c add, jf c show, jf c use
+
+QA:
+Q: What's the JFrog CLI command to eliminate a server configuration with the ID 'my-server'?
+A: jf c rm my-server
+`
 }

--- a/docs/config/show/help.go
+++ b/docs/config/show/help.go
@@ -28,5 +28,10 @@ Gotchas:
 - Credentials are always masked; this command cannot dump real secrets.
 - Returns nothing silently if no servers are configured.
 
-Related: jf c add, jf c edit, jf c use, jf c export`
+Related: jf c add, jf c edit, jf c use, jf c export
+
+QA:
+Q: What's the JFrog CLI command to display the stored configuration for the server with the ID 'my-server'?
+A: jf c show my-server
+`
 }

--- a/docs/config/use/help.go
+++ b/docs/config/use/help.go
@@ -23,5 +23,10 @@ Gotchas:
 - Fails silently from the user's perspective if the server ID does not exist; check with 'jf c show' first.
 - Setting an active server is per-machine, not per-shell; affects all subsequent jf invocations.
 
-Related: jf c add, jf c show`
+Related: jf c add, jf c show
+
+QA:
+Q: What's the JFrog CLI command to designate a server configuration with the ID 'my-server' as default?
+A: jf c use my-server
+`
 }

--- a/docs/general/token/help.go
+++ b/docs/general/token/help.go
@@ -35,5 +35,16 @@ Gotchas:
 - --expiry is in seconds. Platform policy may cap the maximum lifetime.
 - The plaintext token is printed once; capture it immediately.
 
-Related: jf eot, jf c add, jf login`
+Related: jf eot, jf c add, jf login
+
+QA:
+Q: What's the JFrog CLI command to generate an access token for the current user in the default jfrog platform?
+A: jf atc
+
+Q: I want to create an access token for the user 'frog' with the audience 'my-audience'. What's the command for that?
+A: jf atc frog --audience=my-audience
+
+Q: What's the command to generate an access token for the user 'snake' that expires in 3600 seconds?
+A: jf atc snake --expiry=3600
+`
 }

--- a/docs/general/token/help.go
+++ b/docs/general/token/help.go
@@ -41,8 +41,8 @@ QA:
 Q: What's the JFrog CLI command to generate an access token for the current user in the default jfrog platform?
 A: jf atc
 
-Q: I want to create an access token for the user 'frog' with the audience 'my-audience'. What's the command for that?
-A: jf atc frog --audience=my-audience
+Q: I want to create an access token for the user 'frog' with the audience 'jfrt@*'. What's the command for that?
+A: jf atc frog --audience=jfrt@*
 
 Q: What's the command to generate an access token for the user 'snake' that expires in 3600 seconds?
 A: jf atc snake --expiry=3600


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---

Adds a `QA:` section to the AI-agent help text (`GetAIDescription`) of the permission-target, users, groups, transfer-*, config (`c`), and `atc` commands: a handful of curated, deduplicated real-world question → command examples per command, sourced from the JFrog CLI qna dataset. Purely additive text change appended after the existing `Related:` line — no behavior, schema, or struct changes.