### PR TITLE
jf-ide-setup-support-user-auth-tokens-for-curated-ai-editor-extensions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jfrog/build-info-go v1.13.1-0.20260818195724-23e528d30b96
 	github.com/jfrog/gofrog v1.7.6
 	github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847
-	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260819055127-248d48a2d65c
+	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260819064118-94c434396433
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260814071425-102723197072
 	github.com/jfrog/jfrog-cli-evidence v0.10.0
 	github.com/jfrog/jfrog-cli-platform-services v1.10.1-0.20260618062042-6053ab368cab
@@ -248,4 +248,4 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.54.2-0.20251007084958-5eeaa42c31a6
 
-replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260818062137-18e36e626c63
+// replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260818062137-18e36e626c63

--- a/go.mod
+++ b/go.mod
@@ -248,4 +248,4 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.54.2-0.20251007084958-5eeaa42c31a6
 
-// replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260811155045-62401b3fa49b
+replace github.com/jfrog/jfrog-cli-artifactory => github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260818062137-18e36e626c63

--- a/go.sum
+++ b/go.sum
@@ -402,8 +402,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847 h1:wahxu7URLrhdHtI3CVH3aE1Y3eeubDin13t+QVJBeW8=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847/go.mod h1:p8yLtbmCxxQucIbLZKnWu0F+EDtj6NLXbRQCEK/nb6o=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260819055127-248d48a2d65c h1:c0Pso22Tw7vSxQBUUpt40FDA3Se5uCP5M7hzHdYh05c=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260819055127-248d48a2d65c/go.mod h1:1ACZmkzA38Si48i9f052M4BDLfti02lHUfL/f853Ny0=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260818062137-18e36e626c63 h1:w4ebEEzFBFkSUYwQZOo/+z+0R86xdd9dk2Su9ygc6G8=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260818062137-18e36e626c63/go.mod h1:eYyYY+GMdddy75/rCWiKg8EydGp/jRY+9+30QkGpbGw=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260814071425-102723197072 h1:lWQd4C+sXVQW3xvFhQkkLivwx5//bQnjbd+P5Cr3FLY=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260814071425-102723197072/go.mod h1:gf7aUg/G9JyltCNhwMD5RVEsFzUCKPWKXRcTXSqMYBk=
 github.com/jfrog/jfrog-cli-evidence v0.10.0 h1:9wbdHOl+wcN3crNw5qtQtQ0N28NX+9QH/Yo3Ia+iYhc=

--- a/go.sum
+++ b/go.sum
@@ -402,8 +402,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847 h1:wahxu7URLrhdHtI3CVH3aE1Y3eeubDin13t+QVJBeW8=
 github.com/jfrog/jfrog-cli-application v1.0.2-0.20260723152309-34eeb81e2847/go.mod h1:p8yLtbmCxxQucIbLZKnWu0F+EDtj6NLXbRQCEK/nb6o=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260818062137-18e36e626c63 h1:w4ebEEzFBFkSUYwQZOo/+z+0R86xdd9dk2Su9ygc6G8=
-github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260818062137-18e36e626c63/go.mod h1:eYyYY+GMdddy75/rCWiKg8EydGp/jRY+9+30QkGpbGw=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260819064118-94c434396433 h1:6W6P4WFO5OdAPCekbaLz93q8dH1hXlJZcxfugdlvW2A=
+github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260819064118-94c434396433/go.mod h1:1ACZmkzA38Si48i9f052M4BDLfti02lHUfL/f853Ny0=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260814071425-102723197072 h1:lWQd4C+sXVQW3xvFhQkkLivwx5//bQnjbd+P5Cr3FLY=
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260814071425-102723197072/go.mod h1:gf7aUg/G9JyltCNhwMD5RVEsFzUCKPWKXRcTXSqMYBk=
 github.com/jfrog/jfrog-cli-evidence v0.10.0 h1:9wbdHOl+wcN3crNw5qtQtQ0N28NX+9QH/Yo3Ia+iYhc=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] The pull request is targeting the `master` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.

---
  - When a user runs jf ide setup vscode <URL> and the URL points at an AI Editor Extensions repo in Artifactory, the CLI now automatically talks to Artifactory, gets a personal token that identifies who is downloading extensions, and stores that token inside VS Code's settings so every download from that URL is tagged with the user.
  - Without this change, downloads were anonymous  Artifactory couldn't tell which user was fetching which extension, and the "curation" feature (which controls what each user can download) had no way to work.
  
