### PR TITLE
JGC-541 - Bump Go to 1.26.6 for CVE-2026-39821

### DIFF
--- a/build/docker/full/Dockerfile
+++ b/build/docker/full/Dockerfile
@@ -1,6 +1,6 @@
 ARG repo_name_21
 # Remove ${repo_name_21} to pull from Docker Hub.
-FROM ${repo_name_21}/jfrog-docker/golang:1.26.5 as builder
+FROM ${repo_name_21}/jfrog-docker/golang:1.26.6 as builder
 ARG image_name=jfrog-cli-full
 ARG cli_executable_name
 WORKDIR /${image_name}

--- a/build/docker/slim/Dockerfile
+++ b/build/docker/slim/Dockerfile
@@ -1,6 +1,6 @@
 ARG repo_name_21
 # Remove ${repo_name_21} to pull from Docker Hub.
-FROM ${repo_name_21}/jfrog-docker/golang:1.26.5-alpine as builder
+FROM ${repo_name_21}/jfrog-docker/golang:1.26.6-alpine as builder
 ARG image_name=jfrog-cli
 ARG cli_executable_name
 WORKDIR /${image_name}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jfrog/jfrog-cli
 
-go 1.26.5
+go 1.26.6
 
 replace (
 	// Should not be updated to 0.11.0+ due to default spec version change (1.6 -> 1.7, https://github.com/CycloneDX/cyclonedx-go/pull/257)


### PR DESCRIPTION
## Summary
- Bump Go toolchain from 1.26.5 to **1.26.6** to remediate **CVE-2026-39821** (XRAY-988717), which blocked distribution of `ecosystem-cli-docker-images-rb-v2-jf` / 2.121.0.
- Updates `go.mod` and both Docker builder images (full + slim).

## Context
JGC-541 tracks the Critical Xray violation on `go://github.com/golang/go:1.26.3`, `1.26.5`, and `1.25.9`. Go **1.26.6** is the patched release for the 1.26.x line.

## Test plan
- [ ] CI build-gate passes
- [ ] Docker images build successfully with `golang:1.26.6` base
- [ ] Next release RB scan clears CVE-2026-39821 on golang/go components


Made with [Cursor](https://cursor.com)