### PR TITLE
remove -k (--insecure) flag from curl

### DIFF
--- a/build/getcli/jf.sh
+++ b/build/getcli/jf.sh
@@ -60,5 +60,5 @@ fi
 
 URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
-curl -XGET "$URL" -L -k -g > $FILE_NAME
+curl -XGET "$URL" -L -g > $FILE_NAME
 chmod +x $FILE_NAME

--- a/build/getcli/jfrog.sh
+++ b/build/getcli/jfrog.sh
@@ -60,5 +60,5 @@ fi
 
 URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
-curl -XGET "$URL" -L -k -g > $FILE_NAME
+curl -XGET "$URL" -L -g > $FILE_NAME
 chmod +x $FILE_NAME

--- a/build/gitlab/v2/.setup-jfrog-unix.yml
+++ b/build/gitlab/v2/.setup-jfrog-unix.yml
@@ -82,7 +82,7 @@
     fi
 
   # Download with curl and verify exit code and status code.
-  - status_code=$(curl -XGET "$URL" -L -k -g -w "%{http_code}" -f -O -H "${AUTH_HEADER}")
+  - status_code=$(curl -XGET "$URL" -L -g -w "%{http_code}" -f -O -H "${AUTH_HEADER}")
   - exit_code=$?
   - |
     if [ $exit_code -ne 0 ]; then

--- a/build/installcli/jf.sh
+++ b/build/installcli/jf.sh
@@ -61,7 +61,7 @@ fi
 
 URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
-curl -XGET "$URL" -L -k -g > $FILE_NAME
+curl -XGET "$URL" -L -g > $FILE_NAME
 chmod +x $FILE_NAME
 
 # Move executable to a destination in path.

--- a/build/installcli/jfrog.sh
+++ b/build/installcli/jfrog.sh
@@ -61,7 +61,7 @@ fi
 
 URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
-curl -XGET "$URL" -L -k -g > $FILE_NAME
+curl -XGET "$URL" -L -g > $FILE_NAME
 chmod +x $FILE_NAME
 
 # Move executable to a destination in path.

--- a/build/setupcli/jf.sh
+++ b/build/setupcli/jf.sh
@@ -65,7 +65,7 @@ fi
 
 URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
-curl -XGET "$URL" -L -k -g > $FILE_NAME
+curl -XGET "$URL" -L -g > $FILE_NAME
 chmod +x $FILE_NAME
 
 # Move executable to a destination in path.


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [X] The pull request is targeting the `master` branch.
- [X] The code has been validated to compile successfully by running `go vet ./...`.
- [X] The code has been formatted properly using `go fmt ./...
**(no go code in commit)**
---

the -k (--insecure) flags skips the verification of whether or not the transfer is actually secure 

see https://daniel.haxx.se/blog/2020/01/27/curl-ootw-k-insecure/ on why --insecure really means insecure

since the files are served from jfrogs domain it is in the users interest to know that the certificate is actually validated