### PR TITLE
RTECO-1884 - Inconsistent inputs from github workflows for packages e2e tests

### DIFF
--- a/.github/workflows/accessTests.yml
+++ b/.github/workflows/accessTests.yml
@@ -2,17 +2,6 @@ name: Access Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 permissions:
   id-token: write
@@ -76,8 +65,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Get ID Token and Exchange Token

--- a/.github/workflows/agentApmTests.yml
+++ b/.github/workflows/agentApmTests.yml
@@ -3,17 +3,6 @@ name: Agent APM Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   Agent-APM-Tests:
@@ -91,8 +80,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run agent apm tests

--- a/.github/workflows/apkTests.yml
+++ b/.github/workflows/apkTests.yml
@@ -1,49 +1,7 @@
 name: Alpine APK Tests
 on:
   workflow_call:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
-      jfrog_user:
-        description: "Username for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
-      jfrog_password:
-        description: "Password for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
-      jfrog_user:
-        description: "Username for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
-      jfrog_password:
-        description: "Password for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   Apk-Tests:
@@ -80,7 +38,6 @@ jobs:
         uses: jfrog/.github/actions/install-go-with-cache@main
 
       - name: Install local Artifactory
-        if: inputs.jfrog_url == ''
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
@@ -100,23 +57,11 @@ jobs:
       - name: Run Alpine APK tests (alpine:${{ matrix.alpine-version }})
         env:
           ALPINE_VER: ${{ matrix.alpine-version }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
-          JFROG_USER: ${{ inputs.jfrog_user }}
-          JFROG_PASSWORD: ${{ inputs.jfrog_password }}
           MAX_ATTEMPTS: "3"
           RETRY_DELAY: "10"
         run: |
           set +e
           set -uo pipefail
-
-          # Build credential flags: external JPD (url + token) or empty for local Artifactory.
-          creds=""
-          if [ -n "$JFROG_URL" ]; then
-            creds="-jfrog.url=$JFROG_URL -jfrog.adminToken=$JFROG_ADMIN_TOKEN"
-          fi
-          [ -n "$JFROG_USER" ]     && creds="$creds -jfrog.user=$JFROG_USER"
-          [ -n "$JFROG_PASSWORD" ] && creds="$creds -jfrog.password=$JFROG_PASSWORD"
 
           run_regex="TestApk|TestSetupApk"
           fails=""
@@ -130,8 +75,7 @@ jobs:
               ./apk.test \
                 -test.v -test.timeout 0 \
                 -test.run "$run_regex" \
-                -test.alpine \
-                $creds 2>&1 | tee /tmp/apk-out.log
+                -test.alpine 2>&1 | tee /tmp/apk-out.log
             docker_exit=${PIPESTATUS[0]}
 
             # Collect the top-level names of tests that failed this attempt.

--- a/.github/workflows/artifactoryTests.yml
+++ b/.github/workflows/artifactoryTests.yml
@@ -2,17 +2,6 @@ name: Artifactory Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   Artifactory-Tests:
@@ -76,8 +65,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run Artifactory tests

--- a/.github/workflows/cargoTests.yml
+++ b/.github/workflows/cargoTests.yml
@@ -2,17 +2,6 @@ name: Cargo Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   Cargo-Tests:
@@ -61,8 +50,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
 
       - name: Run Cargo tests

--- a/.github/workflows/conanTests.yml
+++ b/.github/workflows/conanTests.yml
@@ -2,17 +2,6 @@ name: Conan Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   Conan-Tests:
@@ -65,8 +54,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
 
       - name: Run Conan tests

--- a/.github/workflows/gradleTests.yml
+++ b/.github/workflows/gradleTests.yml
@@ -2,17 +2,6 @@ name: Gradle Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   Gradle-Tests:
@@ -89,8 +78,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run Gradle tests

--- a/.github/workflows/helmTests.yml
+++ b/.github/workflows/helmTests.yml
@@ -2,17 +2,6 @@ name: Helm Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 permissions:
   id-token: write
@@ -82,8 +71,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Get ID Token and Exchange Token

--- a/.github/workflows/huggingfaceTests.yml
+++ b/.github/workflows/huggingfaceTests.yml
@@ -2,17 +2,6 @@ name: HuggingFace Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 permissions:
   id-token: write
@@ -90,8 +79,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Get ID Token and Exchange Token

--- a/.github/workflows/lifecycleTests.yml
+++ b/.github/workflows/lifecycleTests.yml
@@ -4,17 +4,6 @@ env:
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   Lifecycle-Tests:
@@ -75,8 +64,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run Lifecycle tests

--- a/.github/workflows/mavenTests.yml
+++ b/.github/workflows/mavenTests.yml
@@ -2,17 +2,6 @@ name: Maven Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   Maven-Tests:
@@ -80,8 +69,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run Maven tests

--- a/.github/workflows/nixTests.yml
+++ b/.github/workflows/nixTests.yml
@@ -2,17 +2,6 @@ name: Nix Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   Nix-Tests:
@@ -65,8 +54,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
 
       - name: Run Nix tests

--- a/.github/workflows/npmTests.yml
+++ b/.github/workflows/npmTests.yml
@@ -2,17 +2,6 @@ name: npm Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   npm-Tests:
@@ -84,8 +73,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run npm tests

--- a/.github/workflows/nugetTests.yml
+++ b/.github/workflows/nugetTests.yml
@@ -3,17 +3,6 @@ name: NuGet Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   NuGet-Tests:
@@ -102,8 +91,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run NuGet tests

--- a/.github/workflows/pluginsTests.yml
+++ b/.github/workflows/pluginsTests.yml
@@ -2,17 +2,6 @@ name: Plugins Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   Plugins-Tests:
@@ -73,8 +62,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run plugins tests

--- a/.github/workflows/pnpmTests.yml
+++ b/.github/workflows/pnpmTests.yml
@@ -2,17 +2,6 @@ name: pnpm Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   pnpm-Tests:
@@ -84,8 +73,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run pnpm tests

--- a/.github/workflows/poetryTests.yml
+++ b/.github/workflows/poetryTests.yml
@@ -3,16 +3,6 @@ on:
   workflow_call:
   workflow_dispatch:
     inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
       poetry_version:
         description: "Poetry version to install."
         type: string
@@ -91,8 +81,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run Poetry tests

--- a/.github/workflows/pythonTests.yml
+++ b/.github/workflows/pythonTests.yml
@@ -2,17 +2,6 @@ name: Python Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   Python-Tests:
@@ -89,8 +78,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
       - name: Run Python tests

--- a/.github/workflows/rubyTests.yml
+++ b/.github/workflows/rubyTests.yml
@@ -2,17 +2,6 @@ name: Ruby Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   Ruby-Tests:
@@ -62,8 +51,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           RT_CONNECTION_TIMEOUT_SECONDS: '1200'
 
       - name: Run Ruby tests

--- a/.github/workflows/transferTests.yml
+++ b/.github/workflows/transferTests.yml
@@ -2,17 +2,6 @@ name: Transfer Tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      jfrog_url:
-        description: "External JFrog Platform URL. Leave empty for local Artifactory."
-        type: string
-        required: false
-        default: ""
-      jfrog_admin_token:
-        description: "Admin token for external JFrog Platform."
-        type: string
-        required: false
-        default: ""
 
 jobs:
   Transfer-Artifactory-7-Tests:
@@ -73,8 +62,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           JFROG_HOME: ${{ runner.temp }}
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}
 
@@ -128,8 +115,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC_V6 }}
-          JFROG_URL: ${{ inputs.jfrog_url }}
-          JFROG_ADMIN_TOKEN: ${{ inputs.jfrog_admin_token }}
           JFROG_HOME: ${{ runner.temp }}
           VERSION: 6.23.21
           RT_CONNECTION_TIMEOUT_SECONDS: ${{ env.RT_CONNECTION_TIMEOUT_SECONDS || '1200' }}


### PR DESCRIPTION
## Summary

The `jfrog_url` / `jfrog_admin_token` `workflow_dispatch` inputs (plus `jfrog_user`/`jfrog_password` in `apkTests.yml`) exist in every package/Artifactory e2e workflow to let a manual run skip the local Artifactory install and point at an external JPD instead.

Investigation into the reported "unused inputs" showed the wiring itself was correct in every workflow (passed through to `install-local-artifactory` and referenced in the `go test` invocation) - but checking actual `workflow_dispatch` run history shows these inputs have never actually been supplied by anyone: `jfrog_admin_token` was blank on every inspected run, and every run always took the local-install branch. In practice this is dead capability across the whole package/Artifactory suite set.

This PR removes it:
- Deletes the `jfrog_url`/`jfrog_admin_token` (`jfrog_user`/`jfrog_password` for apk) `workflow_dispatch` inputs from all 18 affected workflows.
- Removes the `JFROG_URL`/`JFROG_ADMIN_TOKEN` passthrough to `install-local-artifactory` - every suite now always installs Artifactory locally, matching actual usage.
- Removes the now-always-empty `env.JFROG_TESTS_IS_EXTERNAL == 'true' && format(...) || ''` conditional from the affected `go test` commands (`conanTests`, `gradleTests`, `mavenTests`, `nixTests`, `npmTests`, `nugetTests`, `pluginsTests`, `pnpmTests`, `poetryTests`, `pythonTests`, `rubyTests`, `artifactoryTests`'s project-suite step, `transferTests`'s Artifactory-6 job).
- `apkTests.yml`: also removes the redundant duplicate inputs block (it declared the same inputs under both `workflow_call` and `workflow_dispatch`, unlike every other suite which only declares under `workflow_dispatch`), makes "Install local Artifactory" unconditional (was gated on `inputs.jfrog_url == ''`), and drops the dead `creds` shell logic in the test-run step.
- `poetryTests.yml` keeps its unrelated `poetry_version` input untouched.
- `accessTests.yml`, `helmTests.yml`, `huggingfaceTests.yml`, `lifecycleTests.yml`, and `transferTests.yml`'s first job read `env.JFROG_TESTS_URL`/`env.JFROG_TESTS_LOCAL_ACCESS_TOKEN` (set by the action regardless of local/external mode), not `inputs.*` directly, so their `go test` lines are unchanged.

No behavioral change for the actual CI path: every suite already always installed Artifactory locally in every observed run; this just removes the unused override capability and the resulting dead conditionals.

## Test plan
- [x] Validated all 18 changed workflow files parse as valid YAML
- [x] Confirmed no remaining references to `jfrog_url`/`jfrog_admin_token`/`jfrog_user`/`jfrog_password`/`JFROG_TESTS_IS_EXTERNAL` in the changed files
- [ ] CI (build-gate suites) runs green on this PR
