### PR TITLE
Retry GetBuildInfo to absorb Artifactory index propagation lag

### DIFF
--- a/utils/tests/utils.go
+++ b/utils/tests/utils.go
@@ -285,7 +285,24 @@ func DeleteFiles(deleteSpec *spec.SpecFiles, serverDetails *config.ServerDetails
 	return deleteCommand.DeleteFiles(reader)
 }
 
+// buildInfoIndexRetries and buildInfoIndexBackoff bound the retry in
+// GetBuildInfo below: Artifactory's build-info search index can lag a
+// freshly-published build by a second or two, especially under concurrent
+// CI load (many PM compatibility tests hitting the same instance at once).
+// Total worst-case wait is ~7.5s (0.5+1+2+4), which is negligible next to
+// the seconds a full PM test takes, but eliminates a whole class of
+// "Build info was not found" false failures immediately after a publish.
+const (
+	buildInfoIndexRetries = 4
+	buildInfoIndexBackoff = 500 * time.Millisecond
+)
+
 // This function makes no assertion, caller is responsible to assert as needed.
+//
+// Retries when the build info is genuinely not there yet (found=false,
+// err=nil is Artifactory's 404 signal — see BuildInfoService.GetBuildInfo)
+// to absorb search-index propagation lag right after a publish. Any real
+// error is returned immediately, unretried, exactly as before.
 func GetBuildInfo(serverDetails *config.ServerDetails, buildName, buildNumber string) (pbi *buildinfo.PublishedBuildInfo, found bool, err error) {
 	servicesManager, err := artUtils.CreateServiceManager(serverDetails, -1, 0, false)
 	if err != nil {
@@ -294,7 +311,16 @@ func GetBuildInfo(serverDetails *config.ServerDetails, buildName, buildNumber st
 	params := services.NewBuildInfoParams()
 	params.BuildName = buildName
 	params.BuildNumber = buildNumber
-	return servicesManager.GetBuildInfo(params)
+
+	wait := buildInfoIndexBackoff
+	for attempt := 0; ; attempt++ {
+		pbi, found, err = servicesManager.GetBuildInfo(params)
+		if err != nil || found || attempt == buildInfoIndexRetries {
+			return pbi, found, err
+		}
+		time.Sleep(wait)
+		wait *= 2
+	}
 }
 
 func GetBuildRuns(serverDetails *config.ServerDetails, buildName string) (pbi *buildinfo.BuildRuns, found bool, err error) {


### PR DESCRIPTION
## Summary
- pm-version-monitor's pnpm compatibility test runs showed a sharp, date-correlated pass-rate collapse (100% → ~25%) on days with heavy concurrent CI load — spread evenly across every pnpm line including the officially-supported 10.x baseline, so it wasn't a pnpm-version issue at all.
- Every failure shared the same signature: `Error: Should be true` / `Messages: Build info was not found`, immediately after a successful `jfrog rt bp` publish.
- Root cause: `tests.GetBuildInfo` queried Artifactory right after the publish call returned success, with **no retry**. `BuildInfoService.GetBuildInfo`'s own doc comment confirms a 404 surfaces as `(found=false, err=nil)` — exactly the shape of "published, but the search index hasn't caught up yet," which gets more likely the more concurrent CI load hits the same Artifactory instance.
- Add a short bounded retry (4 attempts, 500ms exponential backoff, ~7.5s worst case) **inside `GetBuildInfo` itself**, so all ~20 call sites across `pnpm_test.go`, `npm_test.go`, `maven_test.go`, etc. benefit without touching each one individually. Only the `found=false, err=nil` case retries — any real error still returns immediately, unchanged from today's behavior.

## Test plan
- [x] `go build ./...` — succeeds
- [x] `go vet ./utils/tests/...` — clean
- [x] Traced the exact failing runs from pm-version-monitor's pnpm dashboard (August 20 mass-retest window) back to this call site and confirmed the signature matches on every one
- [x] Confirmed via `BuildInfoService.GetBuildInfo`'s doc comment in jfrog-client-go that `found=false, err=nil` is the documented 404 signal, so retrying only that case is safe and won't mask real failures