### PR TITLE
Verify checksum in official CLI install scripts

### DIFF
--- a/.github/workflows/scriptTests.yml
+++ b/.github/workflows/scriptTests.yml
@@ -70,6 +70,22 @@ jobs:
           sh build/getcli/jfrog.sh
           ./jfrog --version
 
+      - name: Test setup CLI - jf (download, verify, and PATH install only)
+        run: |
+          # jf setup with no package-manager arg drops into an interactive
+          # picker; with stdin from /dev/null it fails fast (non-zero exit)
+          # rather than hanging. That's fine here - this step only checks
+          # that the download + checksum verification + PATH-install steps
+          # before it succeeded, not that the interactive wizard completed.
+          # build/setupcli/jf.sh moves the binary onto PATH (into
+          # /usr/local/bin or similar), it does not leave it in this step's
+          # working directory - and on Windows it's named jf.exe, not jf -
+          # so invoke it via PATH resolution rather than a cwd-relative path.
+          out=$(sh build/setupcli/jf.sh </dev/null 2>&1 || true)
+          printf '%s\n' "$out"
+          echo "$out" | grep -q "Checksum verified" || exit 1
+          echo "$out" | grep -q "was installed in" || exit 1
+
       - name: Check Windows Certificate Expiration Date
         shell: pwsh
         run: |
@@ -85,7 +101,7 @@ jobs:
 
       - name: Test Build CLI - sh
         run: |
-          rm ./jf
+          rm -f ./jf
           sh build/build.sh
           ./jf --version
         if: matrix.os.name == 'macos' || matrix.os.name == 'ubuntu'
@@ -118,3 +134,21 @@ jobs:
           npm version $latest_version --allow-same-version
           npm install --no-audit
           ./bin/jf${{ matrix.os.osSuffix }} --version
+
+  checksum-verification-unit-tests:
+    name: Install script checksum verification (unit tests)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      - name: Setup FastCI
+        uses: jfrog-fastci/fastci@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          fastci_otel_token: ${{ secrets.FASTCI_TOKEN }}
+
+      - name: Run install script checksum verification tests
+        run: sh build/scripts_test/run_tests.sh

--- a/build/getcli/jf.sh
+++ b/build/getcli/jf.sh
@@ -58,7 +58,55 @@ else
     esac
 fi
 
-URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
+BASE_URL="${JFROG_CLI_RELEASES_BASE_URL:-https://releases.jfrog.io/artifactory/jfrog-cli}"
+URL="${BASE_URL}/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
-curl -XGET "$URL" -L -k -g > $FILE_NAME
-chmod +x $FILE_NAME
+curl -XGET "$URL" -L -g -o "$FILE_NAME"
+
+# Verify the download against the SHA256 checksum sidecar published for this
+# binary (JGC-542) before it is ever chmod +x'd or moved onto PATH. The
+# checksum lives at the exact same path as the binary, with .sha256 appended
+# (a per-binary sidecar, not a shared manifest - see JGC-542's corrected design).
+CHECKSUM_URL="${URL}.sha256"
+CHECKSUM_TMP="${FILE_NAME}.sha256.tmp"
+
+echo "Verifying checksum against: $CHECKSUM_URL"
+if ! curl -sS --fail -L -g "$CHECKSUM_URL" -o "$CHECKSUM_TMP"; then
+    echo "ERROR: could not download the checksum from $CHECKSUM_URL" >&2
+    echo "  (downloaded binary: $URL)" >&2
+    echo "Refusing to install an unverified $FILE_NAME binary." >&2
+    rm -f "$FILE_NAME" "$CHECKSUM_TMP"
+    exit 1
+fi
+
+EXPECTED_SHA256=$(awk 'NR==1 { print $1 }' "$CHECKSUM_TMP")
+rm -f "$CHECKSUM_TMP"
+
+if [ -z "$EXPECTED_SHA256" ]; then
+    echo "ERROR: empty or malformed checksum at $CHECKSUM_URL" >&2
+    echo "  (downloaded binary: $URL)" >&2
+    echo "Refusing to install an unverified $FILE_NAME binary." >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL_SHA256=$(sha256sum "$FILE_NAME" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL_SHA256=$(shasum -a 256 "$FILE_NAME" | awk '{print $1}')
+else
+    echo "ERROR: neither sha256sum nor shasum is available to verify the download." >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+    echo "ERROR: checksum mismatch for $FILE_NAME downloaded from $URL" >&2
+    echo "  expected (from $CHECKSUM_URL): $EXPECTED_SHA256" >&2
+    echo "  actual:                        $ACTUAL_SHA256" >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+echo "Checksum verified ($ACTUAL_SHA256)."
+chmod +x "$FILE_NAME"

--- a/build/getcli/jf.sh
+++ b/build/getcli/jf.sh
@@ -58,7 +58,7 @@ else
     esac
 fi
 
-BASE_URL="${JFROG_CLI_RELEASES_BASE_URL:-https://releases.jfrog.io/artifactory/jfrog-cli}"
+BASE_URL="https://releases.jfrog.io/artifactory/jfrog-cli"
 URL="${BASE_URL}/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
 curl -XGET "$URL" -L -g -o "$FILE_NAME"

--- a/build/getcli/jfrog.sh
+++ b/build/getcli/jfrog.sh
@@ -58,7 +58,55 @@ else
     esac
 fi
 
-URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
+BASE_URL="${JFROG_CLI_RELEASES_BASE_URL:-https://releases.jfrog.io/artifactory/jfrog-cli}"
+URL="${BASE_URL}/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
-curl -XGET "$URL" -L -k -g > $FILE_NAME
-chmod +x $FILE_NAME
+curl -XGET "$URL" -L -g -o "$FILE_NAME"
+
+# Verify the download against the SHA256 checksum sidecar published for this
+# binary (JGC-542) before it is ever chmod +x'd or moved onto PATH. The
+# checksum lives at the exact same path as the binary, with .sha256 appended
+# (a per-binary sidecar, not a shared manifest - see JGC-542's corrected design).
+CHECKSUM_URL="${URL}.sha256"
+CHECKSUM_TMP="${FILE_NAME}.sha256.tmp"
+
+echo "Verifying checksum against: $CHECKSUM_URL"
+if ! curl -sS --fail -L -g "$CHECKSUM_URL" -o "$CHECKSUM_TMP"; then
+    echo "ERROR: could not download the checksum from $CHECKSUM_URL" >&2
+    echo "  (downloaded binary: $URL)" >&2
+    echo "Refusing to install an unverified $FILE_NAME binary." >&2
+    rm -f "$FILE_NAME" "$CHECKSUM_TMP"
+    exit 1
+fi
+
+EXPECTED_SHA256=$(awk 'NR==1 { print $1 }' "$CHECKSUM_TMP")
+rm -f "$CHECKSUM_TMP"
+
+if [ -z "$EXPECTED_SHA256" ]; then
+    echo "ERROR: empty or malformed checksum at $CHECKSUM_URL" >&2
+    echo "  (downloaded binary: $URL)" >&2
+    echo "Refusing to install an unverified $FILE_NAME binary." >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL_SHA256=$(sha256sum "$FILE_NAME" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL_SHA256=$(shasum -a 256 "$FILE_NAME" | awk '{print $1}')
+else
+    echo "ERROR: neither sha256sum nor shasum is available to verify the download." >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+    echo "ERROR: checksum mismatch for $FILE_NAME downloaded from $URL" >&2
+    echo "  expected (from $CHECKSUM_URL): $EXPECTED_SHA256" >&2
+    echo "  actual:                        $ACTUAL_SHA256" >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+echo "Checksum verified ($ACTUAL_SHA256)."
+chmod +x "$FILE_NAME"

--- a/build/getcli/jfrog.sh
+++ b/build/getcli/jfrog.sh
@@ -58,7 +58,7 @@ else
     esac
 fi
 
-BASE_URL="${JFROG_CLI_RELEASES_BASE_URL:-https://releases.jfrog.io/artifactory/jfrog-cli}"
+BASE_URL="https://releases.jfrog.io/artifactory/jfrog-cli"
 URL="${BASE_URL}/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
 curl -XGET "$URL" -L -g -o "$FILE_NAME"

--- a/build/installcli/jf.sh
+++ b/build/installcli/jf.sh
@@ -59,10 +59,58 @@ else
     esac
 fi
 
-URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
+BASE_URL="${JFROG_CLI_RELEASES_BASE_URL:-https://releases.jfrog.io/artifactory/jfrog-cli}"
+URL="${BASE_URL}/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
-curl -XGET "$URL" -L -k -g > $FILE_NAME
-chmod +x $FILE_NAME
+curl -XGET "$URL" -L -g -o "$FILE_NAME"
+
+# Verify the download against the SHA256 checksum sidecar published for this
+# binary (JGC-542) before it is ever chmod +x'd or moved onto PATH. The
+# checksum lives at the exact same path as the binary, with .sha256 appended
+# (a per-binary sidecar, not a shared manifest - see JGC-542's corrected design).
+CHECKSUM_URL="${URL}.sha256"
+CHECKSUM_TMP="${FILE_NAME}.sha256.tmp"
+
+echo "Verifying checksum against: $CHECKSUM_URL"
+if ! curl -sS --fail -L -g "$CHECKSUM_URL" -o "$CHECKSUM_TMP"; then
+    echo "ERROR: could not download the checksum from $CHECKSUM_URL" >&2
+    echo "  (downloaded binary: $URL)" >&2
+    echo "Refusing to install an unverified $FILE_NAME binary." >&2
+    rm -f "$FILE_NAME" "$CHECKSUM_TMP"
+    exit 1
+fi
+
+EXPECTED_SHA256=$(awk 'NR==1 { print $1 }' "$CHECKSUM_TMP")
+rm -f "$CHECKSUM_TMP"
+
+if [ -z "$EXPECTED_SHA256" ]; then
+    echo "ERROR: empty or malformed checksum at $CHECKSUM_URL" >&2
+    echo "  (downloaded binary: $URL)" >&2
+    echo "Refusing to install an unverified $FILE_NAME binary." >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL_SHA256=$(sha256sum "$FILE_NAME" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL_SHA256=$(shasum -a 256 "$FILE_NAME" | awk '{print $1}')
+else
+    echo "ERROR: neither sha256sum nor shasum is available to verify the download." >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+    echo "ERROR: checksum mismatch for $FILE_NAME downloaded from $URL" >&2
+    echo "  expected (from $CHECKSUM_URL): $EXPECTED_SHA256" >&2
+    echo "  actual:                        $ACTUAL_SHA256" >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+echo "Checksum verified ($ACTUAL_SHA256)."
+chmod +x "$FILE_NAME"
 
 # Move executable to a destination in path.
 # Order is by destination priority.

--- a/build/installcli/jf.sh
+++ b/build/installcli/jf.sh
@@ -59,7 +59,7 @@ else
     esac
 fi
 
-BASE_URL="${JFROG_CLI_RELEASES_BASE_URL:-https://releases.jfrog.io/artifactory/jfrog-cli}"
+BASE_URL="https://releases.jfrog.io/artifactory/jfrog-cli"
 URL="${BASE_URL}/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
 curl -XGET "$URL" -L -g -o "$FILE_NAME"

--- a/build/installcli/jfrog.sh
+++ b/build/installcli/jfrog.sh
@@ -59,10 +59,58 @@ else
     esac
 fi
 
-URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
+BASE_URL="${JFROG_CLI_RELEASES_BASE_URL:-https://releases.jfrog.io/artifactory/jfrog-cli}"
+URL="${BASE_URL}/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
-curl -XGET "$URL" -L -k -g > $FILE_NAME
-chmod +x $FILE_NAME
+curl -XGET "$URL" -L -g -o "$FILE_NAME"
+
+# Verify the download against the SHA256 checksum sidecar published for this
+# binary (JGC-542) before it is ever chmod +x'd or moved onto PATH. The
+# checksum lives at the exact same path as the binary, with .sha256 appended
+# (a per-binary sidecar, not a shared manifest - see JGC-542's corrected design).
+CHECKSUM_URL="${URL}.sha256"
+CHECKSUM_TMP="${FILE_NAME}.sha256.tmp"
+
+echo "Verifying checksum against: $CHECKSUM_URL"
+if ! curl -sS --fail -L -g "$CHECKSUM_URL" -o "$CHECKSUM_TMP"; then
+    echo "ERROR: could not download the checksum from $CHECKSUM_URL" >&2
+    echo "  (downloaded binary: $URL)" >&2
+    echo "Refusing to install an unverified $FILE_NAME binary." >&2
+    rm -f "$FILE_NAME" "$CHECKSUM_TMP"
+    exit 1
+fi
+
+EXPECTED_SHA256=$(awk 'NR==1 { print $1 }' "$CHECKSUM_TMP")
+rm -f "$CHECKSUM_TMP"
+
+if [ -z "$EXPECTED_SHA256" ]; then
+    echo "ERROR: empty or malformed checksum at $CHECKSUM_URL" >&2
+    echo "  (downloaded binary: $URL)" >&2
+    echo "Refusing to install an unverified $FILE_NAME binary." >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL_SHA256=$(sha256sum "$FILE_NAME" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL_SHA256=$(shasum -a 256 "$FILE_NAME" | awk '{print $1}')
+else
+    echo "ERROR: neither sha256sum nor shasum is available to verify the download." >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+    echo "ERROR: checksum mismatch for $FILE_NAME downloaded from $URL" >&2
+    echo "  expected (from $CHECKSUM_URL): $EXPECTED_SHA256" >&2
+    echo "  actual:                        $ACTUAL_SHA256" >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+echo "Checksum verified ($ACTUAL_SHA256)."
+chmod +x "$FILE_NAME"
 
 # Move executable to a destination in path.
 # Order is by destination priority.

--- a/build/installcli/jfrog.sh
+++ b/build/installcli/jfrog.sh
@@ -59,7 +59,7 @@ else
     esac
 fi
 
-BASE_URL="${JFROG_CLI_RELEASES_BASE_URL:-https://releases.jfrog.io/artifactory/jfrog-cli}"
+BASE_URL="https://releases.jfrog.io/artifactory/jfrog-cli"
 URL="${BASE_URL}/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
 curl -XGET "$URL" -L -g -o "$FILE_NAME"

--- a/build/scripts_test/run_tests.sh
+++ b/build/scripts_test/run_tests.sh
@@ -1,0 +1,215 @@
+#!/bin/sh
+set -eu
+
+# Dependency-free unit tests for the install-script checksum verification
+# added in JGC-543. Drives each script against local file:// fixtures built
+# on the fly, in a scratch directory, for whatever OS/ARCH this machine
+# actually is (mirroring each script's own uname-based detection) — so these
+# tests produce real pass/fail evidence on any dev machine and in CI alike,
+# without network access and without depending on JGC-542's checksums being
+# published yet.
+
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+VERSION="1.2.3"
+FAILURES=0
+
+# Mirror the CLI_OS/ARCH detection every install script performs via uname,
+# so generated fixtures match whatever this test actually runs on.
+if uname -s | grep -q -E -i "(cygwin|mingw|msys|windows)"; then
+    CLI_OS="windows"
+    ARCH="amd64"
+elif uname -s | grep -q -i "darwin"; then
+    CLI_OS="mac"
+    if [ "$(uname -m)" = "arm64" ]; then
+      ARCH="arm64"
+    else
+      ARCH="386"
+    fi
+else
+    CLI_OS="linux"
+    MACHINE_TYPE="$(uname -m)"
+    case $MACHINE_TYPE in
+        i386 | i486 | i586 | i686 | i786 | x86)
+            ARCH="386"
+            ;;
+        amd64 | x86_64 | x64)
+            ARCH="amd64"
+            ;;
+        arm | armv7l)
+            ARCH="arm"
+            ;;
+        aarch64)
+            ARCH="arm64"
+            ;;
+        s390x)
+            ARCH="s390x"
+            ;;
+        ppc64)
+           ARCH="ppc64"
+           ;;
+        ppc64le)
+           ARCH="ppc64le"
+           ;;
+        *)
+            echo "Unknown machine type: $MACHINE_TYPE" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    sha256_of() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+    sha256_of() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+    echo "Neither sha256sum nor shasum is available; cannot run these tests." >&2
+    exit 1
+fi
+
+# make_fixture_tree FIXTURE_ROOT CLI_MAJOR_VER FILE_NAME CASE FIXTURE_VERSION
+#   Builds one release-tree fixture under $FIXTURE_ROOT for the given case:
+#     good              - correct checksum, as a bare 64-char hex digest (no
+#                         filename column, no trailing newline) in a
+#                         per-binary .sha256 sidecar, matching the real
+#                         releases.jfrog.io response
+#     mismatch          - well-formed but wrong checksum (same bare-digest
+#                         shape as "good")
+#     missing-manifest  - no .sha256 sidecar at all
+#     missing-entry     - sidecar exists but is empty (empty/malformed checksum)
+#   FIXTURE_VERSION is the literal directory name to build the release tree
+#   under (normally $VERSION, but build/setupcli/jf.sh never reads $1 into
+#   VERSION - it always looks under the literal "[RELEASE]" - so callers for
+#   that script must pass "[RELEASE]" here instead).
+make_fixture_tree() {
+    fixture_root=$1
+    cli_major_ver=$2
+    file_name=$3
+    case_name=$4
+    fixture_version=$5
+
+    rel_dir="jfrog-cli-${CLI_OS}-${ARCH}"
+    version_dir="$fixture_root/$cli_major_ver/$fixture_version"
+    mkdir -p "$version_dir/$rel_dir"
+    printf 'dummy-%s-binary\n' "$file_name" > "$version_dir/$rel_dir/$file_name"
+
+    sidecar="$version_dir/$rel_dir/$file_name.sha256"
+
+    case "$case_name" in
+        good)
+            hash=$(sha256_of "$version_dir/$rel_dir/$file_name")
+            printf '%s' "$hash" > "$sidecar"
+            ;;
+        mismatch)
+            printf '%s' "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" > "$sidecar"
+            ;;
+        missing-manifest)
+            : # no .sha256 sidecar written - simulates a 404
+            ;;
+        missing-entry)
+            : > "$sidecar" # sidecar exists but is empty - simulates empty/malformed checksum
+            ;;
+        *)
+            echo "unknown fixture case: $case_name" >&2
+            exit 1
+            ;;
+    esac
+}
+
+# run_case SCRIPT CLI_MAJOR_VER FILE_NAME CASE EXPECT
+#   SCRIPT         path to the install script, relative to repo root
+#   CLI_MAJOR_VER  "v2-jf" or "v2" (matches the script's own CLI_MAJOR_VER)
+#   FILE_NAME      "jf" or "jfrog" (matches the script's own FILE_NAME)
+#   CASE           good | mismatch | missing-manifest | missing-entry
+#   EXPECT         "pass" or "fail" - on "fail", also asserts the script's
+#                  scratch run directory was left empty (verification always
+#                  rm -f's the partial binary before exiting, for every
+#                  script, so this holds regardless of the binary's name)
+run_case() {
+    script=$1
+    cli_major_ver=$2
+    file_name=$3
+    case_name=$4
+    expect=$5
+
+    # build/setupcli/jf.sh never assigns $1 to VERSION - it always builds its
+    # URLs under the literal "[RELEASE]" path segment, and only uses $1 (if
+    # given) to build the interactive `jf setup` command it execs on success.
+    # So its fixture must be built under "[RELEASE]", and the script must be
+    # invoked with no positional argument at all.
+    case "$script" in
+        */setupcli/*)
+            fixture_version="[RELEASE]"
+            script_arg=""
+            ;;
+        *)
+            fixture_version="$VERSION"
+            script_arg="$VERSION"
+            ;;
+    esac
+
+    work_dir=$(mktemp -d)
+    fixture_root="$work_dir/fixture"
+    mkdir -p "$fixture_root"
+    make_fixture_tree "$fixture_root" "$cli_major_ver" "$file_name" "$case_name" "$fixture_version"
+
+    run_dir="$work_dir/run"
+    mkdir -p "$run_dir"
+
+    status=0
+    (
+        cd "$run_dir"
+        # shellcheck disable=SC2086 # intentionally unquoted: empty means "no
+        # positional arg at all" for setupcli, not an empty-string arg.
+        JFROG_CLI_RELEASES_BASE_URL="file://$fixture_root" \
+            sh "$REPO_ROOT/$script" $script_arg </dev/null
+    ) || status=$?
+
+    label="$script [$case_name]"
+    if [ "$expect" = "pass" ] && [ "$status" -ne 0 ]; then
+        echo "FAIL: $label expected exit 0, got $status"
+        FAILURES=$((FAILURES + 1))
+    elif [ "$expect" = "fail" ] && [ "$status" -eq 0 ]; then
+        echo "FAIL: $label expected non-zero exit, got 0"
+        FAILURES=$((FAILURES + 1))
+    elif [ "$expect" = "fail" ] && [ -n "$(ls -A "$run_dir" 2>/dev/null)" ]; then
+        echo "FAIL: $label left files behind after a failed verification: $(ls -A "$run_dir")"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $label"
+    fi
+
+    rm -rf "$work_dir"
+}
+
+# --- build/getcli/jf.sh (added in this task) ---
+run_case build/getcli/jf.sh v2-jf jf good pass
+run_case build/getcli/jf.sh v2-jf jf mismatch fail
+run_case build/getcli/jf.sh v2-jf jf missing-manifest fail
+run_case build/getcli/jf.sh v2-jf jf missing-entry fail
+
+# --- build/getcli/jfrog.sh ---
+run_case build/getcli/jfrog.sh v2 jfrog good pass
+run_case build/getcli/jfrog.sh v2 jfrog mismatch fail
+run_case build/getcli/jfrog.sh v2 jfrog missing-manifest fail
+run_case build/getcli/jfrog.sh v2 jfrog missing-entry fail
+
+# --- build/installcli/jf.sh (negative paths only - see task notes) ---
+run_case build/installcli/jf.sh v2-jf jf mismatch fail
+run_case build/installcli/jf.sh v2-jf jf missing-manifest fail
+run_case build/installcli/jf.sh v2-jf jf missing-entry fail
+
+# --- build/installcli/jfrog.sh (negative paths only) ---
+run_case build/installcli/jfrog.sh v2 jfrog mismatch fail
+run_case build/installcli/jfrog.sh v2 jfrog missing-manifest fail
+run_case build/installcli/jfrog.sh v2 jfrog missing-entry fail
+
+# --- build/setupcli/jf.sh (negative paths only) ---
+run_case build/setupcli/jf.sh v2-jf jf mismatch fail
+run_case build/setupcli/jf.sh v2-jf jf missing-manifest fail
+run_case build/setupcli/jf.sh v2-jf jf missing-entry fail
+
+if [ "$FAILURES" -ne 0 ]; then
+    echo "$FAILURES case(s) failed."
+    exit 1
+fi
+echo "All cases passed."

--- a/build/scripts_test/run_tests.sh
+++ b/build/scripts_test/run_tests.sh
@@ -152,6 +152,15 @@ run_case() {
     mkdir -p "$fixture_root"
     make_fixture_tree "$fixture_root" "$cli_major_ver" "$file_name" "$case_name" "$fixture_version"
 
+    # The shipped script has no runtime override for its download URL (an
+    # env var hook there would itself be an attack surface in production -
+    # see the PR review comment this responds to). To point a script at our
+    # local file:// fixtures for testing, patch a throwaway copy's hardcoded
+    # BASE_URL instead of the real script.
+    script_under_test="$work_dir/$(basename "$script")"
+    sed "s#^BASE_URL=.*#BASE_URL=\"file://$fixture_root\"#" "$REPO_ROOT/$script" > "$script_under_test"
+    chmod +x "$script_under_test"
+
     run_dir="$work_dir/run"
     mkdir -p "$run_dir"
 
@@ -160,8 +169,7 @@ run_case() {
         cd "$run_dir"
         # shellcheck disable=SC2086 # intentionally unquoted: empty means "no
         # positional arg at all" for setupcli, not an empty-string arg.
-        JFROG_CLI_RELEASES_BASE_URL="file://$fixture_root" \
-            sh "$REPO_ROOT/$script" $script_arg </dev/null
+        sh "$script_under_test" $script_arg </dev/null
     ) || status=$?
 
     label="$script [$case_name]"

--- a/build/setupcli/jf.sh
+++ b/build/setupcli/jf.sh
@@ -63,10 +63,58 @@ else
     esac
 fi
 
-URL="https://releases.jfrog.io/artifactory/jfrog-cli/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
+BASE_URL="${JFROG_CLI_RELEASES_BASE_URL:-https://releases.jfrog.io/artifactory/jfrog-cli}"
+URL="${BASE_URL}/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
-curl -XGET "$URL" -L -k -g > $FILE_NAME
-chmod +x $FILE_NAME
+curl -XGET "$URL" -L -g -o "$FILE_NAME"
+
+# Verify the download against the SHA256 checksum sidecar published for this
+# binary (JGC-542) before it is ever chmod +x'd or moved onto PATH. The
+# checksum lives at the exact same path as the binary, with .sha256 appended
+# (a per-binary sidecar, not a shared manifest - see JGC-542's corrected design).
+CHECKSUM_URL="${URL}.sha256"
+CHECKSUM_TMP="${FILE_NAME}.sha256.tmp"
+
+echo "Verifying checksum against: $CHECKSUM_URL"
+if ! curl -sS --fail -L -g "$CHECKSUM_URL" -o "$CHECKSUM_TMP"; then
+    echo "ERROR: could not download the checksum from $CHECKSUM_URL" >&2
+    echo "  (downloaded binary: $URL)" >&2
+    echo "Refusing to install an unverified $FILE_NAME binary." >&2
+    rm -f "$FILE_NAME" "$CHECKSUM_TMP"
+    exit 1
+fi
+
+EXPECTED_SHA256=$(awk 'NR==1 { print $1 }' "$CHECKSUM_TMP")
+rm -f "$CHECKSUM_TMP"
+
+if [ -z "$EXPECTED_SHA256" ]; then
+    echo "ERROR: empty or malformed checksum at $CHECKSUM_URL" >&2
+    echo "  (downloaded binary: $URL)" >&2
+    echo "Refusing to install an unverified $FILE_NAME binary." >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL_SHA256=$(sha256sum "$FILE_NAME" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL_SHA256=$(shasum -a 256 "$FILE_NAME" | awk '{print $1}')
+else
+    echo "ERROR: neither sha256sum nor shasum is available to verify the download." >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+    echo "ERROR: checksum mismatch for $FILE_NAME downloaded from $URL" >&2
+    echo "  expected (from $CHECKSUM_URL): $EXPECTED_SHA256" >&2
+    echo "  actual:                        $ACTUAL_SHA256" >&2
+    rm -f "$FILE_NAME"
+    exit 1
+fi
+
+echo "Checksum verified ($ACTUAL_SHA256)."
+chmod +x "$FILE_NAME"
 
 # Move executable to a destination in path.
 # Order is by destination priority.

--- a/build/setupcli/jf.sh
+++ b/build/setupcli/jf.sh
@@ -63,7 +63,7 @@ else
     esac
 fi
 
-BASE_URL="${JFROG_CLI_RELEASES_BASE_URL:-https://releases.jfrog.io/artifactory/jfrog-cli}"
+BASE_URL="https://releases.jfrog.io/artifactory/jfrog-cli"
 URL="${BASE_URL}/${CLI_MAJOR_VER}/${VERSION}/jfrog-cli-${CLI_OS}-${ARCH}/${FILE_NAME}"
 echo "Downloading from: $URL"
 curl -XGET "$URL" -L -g -o "$FILE_NAME"


### PR DESCRIPTION
The five official install scripts (`build/getcli/jf.sh`, `build/getcli/jfrog.sh`, `build/installcli/jf.sh`, `build/installcli/jfrog.sh`, `build/setupcli/jf.sh`) now verify the downloaded `jf`/`jfrog` binary's SHA256 before ever `chmod +x`-ing or installing it onto PATH, and no longer skip TLS verification (`curl -k` removed).

The checksum is fetched from the per-binary `.sha256` sidecar JGC-542 publishes at the exact same path as the binary (e.g. `jfrog-cli-linux-amd64/jf.sha256`) — verified end-to-end against the real, published `releases.jfrog.io` endpoint. The install aborts (deleting the partial binary) on a checksum mismatch, an unreachable/missing sidecar, or an empty/malformed one, with failure messages naming both the binary and checksum URLs and both hashes where relevant.

Adds a dependency-free test driver (`build/scripts_test/run_tests.sh`, 17 cases) that builds fixtures on the fly matching whatever OS/arch the machine actually is — real subprocess execution against `file://` URLs, no mocks, no network dependency — and wires it into CI alongside a new smoke test for `build/setupcli/jf.sh`, which previously had no coverage at all.

---

- [x] All [tests](https://github.com/jfrog/jfrog-cli/blob/master/CONTRIBUTING.md#tests) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] The pull request is targeting the `master` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.

---
