### PR TITLE
[PM Fixer] Add pnpm 12 to CI test matrix

### DIFF
--- a/.github/workflows/pnpmTests.yml
+++ b/.github/workflows/pnpmTests.yml
@@ -27,7 +27,7 @@ jobs:
             version: 2022
           - name: macos
             version: 14
-        pnpm-version: [10, 11]
+        pnpm-version: [10, 11, 12]
     runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
     steps:
       - name: Skip macOS - JGC-413
@@ -55,7 +55,8 @@ jobs:
         if: matrix.os.name != 'macos'
         uses: actions/setup-node@v7
         with:
-          # pnpm 11 requires Node >=22.13 (pnpm 10 only requires >=18.12, so 22 covers both legs).
+          # pnpm 11+ requires Node >=22.13 (pnpm 10 only requires >=18.12, so 22.13 covers all
+          # three tested legs - no evidence pnpm 12 raised this floor further).
           node-version: "22.13"
 
       - name: Install pnpm ${{ matrix.pnpm-version }}


### PR DESCRIPTION
## Summary
This repo's own CI (`pnpmTests.yml`, gates every PR merge here) is hardcoded to `pnpm-version: [10, 11]`. pnpm 12 is the actual current latest release — #3692 fixed a real pnpm 12 compatibility bug found by the external PM-compat-monitor pipeline — but this matrix never tested it, meaning a pnpm-12 regression could land through normal PR review here and only get caught later, externally, off-cycle.

## Fix
Added `12` to the `pnpm-version` matrix. Node 22.13 (already used for the 10/11 legs) covers pnpm 12 too — nothing in the compat-monitor's investigation found evidence pnpm 12 raised that floor further, so no other change was needed. Updated the accompanying comment for accuracy.

## Compatibility impact
CI config only. No production or test code touched.

## Test plan
- YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- Verified the "Validate pnpm version" step's bash comparison logic against a real pnpm 12.3.4 install — correctly passes for matrix value 12
- The actual matrix job itself needs a real CI run (live Artifactory + OS runners) to fully confirm, but the code path this fix touches (`npm install -g pnpm@${{ matrix.pnpm-version }}` + the version-validation step) is identical to what already works for the 10/11 legs
- Depends on #3692 being merged first — before that fix, this matrix entry would fail immediately on the `-store-dir` test-helper bug

---
_Opened by PM Compat Fixer follow-up, prompted by review of [#3692](https://github.com/jfrog/jfrog-cli/pull/3692)._
